### PR TITLE
mysql: group AUTO_INCREMENT column with its backing key in one ALTER

### DIFF
--- a/mysql/catalog/migration.go
+++ b/mysql/catalog/migration.go
@@ -107,6 +107,15 @@ type MigrationOp struct {
 	Phase    MigrationPhase
 	Priority int    // tie-breaker within a phase (lower = earlier)
 	sortName string // stable secondary key (table name, or table+column for column ops)
+
+	// AUTO_INCREMENT-hazard grouping metadata (mergeAutoIncrementKeyOps,
+	// migration_autoinc.go), set by the constructors of single-statement ALTER TABLE ops.
+	// alterClause is the clause rendered after "ALTER TABLE <ident> " (empty for ops that
+	// never participate in grouping); addsIndex/dropsIndex identify the index the op's own
+	// statement adds / drops ("primary" stands for the PRIMARY KEY, which has no user name).
+	alterClause string
+	addsIndex   *Index
+	dropsIndex  string
 }
 
 // Priority constants for tie-breaking within a phase. Lower runs earlier. For the
@@ -240,6 +249,11 @@ func GenerateMigrationWithNormalizer(from, to *Catalog, diff *SchemaDiff, n *Nor
 	ops = append(ops, generateTriggerDDL(from, to, diff, n)...)
 	ops = append(ops, generateEventDDL(from, to, diff, n)...)
 	ops = append(ops, generatePartitionDDL(from, to, diff, n)...)
+
+	// Group the clauses that MySQL requires to land in ONE statement: an AUTO_INCREMENT
+	// column and its backing key must never be separated by a statement boundary (errno 1075
+	// checks every ALTER's end state) — see migration_autoinc.go.
+	ops = mergeAutoIncrementKeyOps(ops, diff, n)
 
 	ops = sortMigrationOps(ops)
 

--- a/mysql/catalog/migration_autoinc.go
+++ b/mysql/catalog/migration_autoinc.go
@@ -46,6 +46,15 @@ import (
 // Ops participate only through the grouping metadata their constructors set (alterClause,
 // addsIndex, dropsIndex on MigrationOp); everything else — checks, views, options, FK
 // constraint adds — is invisible to the pass and never regrouped.
+//
+// FLAGGED LIMITATION (not handled): a storage-ENGINE conversion in the same plan. The
+// table-option ALTER (ENGINE=...) runs at PhaseMain/priorityTable, before every column/index
+// statement, and carries no grouping metadata — so converting a MyISAM table whose auto column
+// is covered only in a NON-first key position to InnoDB fails errno 1075 on the ENGINE
+// statement itself, even when the plan adds a first-position key later. Fixing it would mean
+// grouping table-option clauses (a different op family) or hoisting index adds above
+// priorityTable; both are out of this pass's contract. Such a plan also failed before the pass
+// existed — nothing regresses.
 
 // primaryIndexKey is the dropsIndex marker for the PRIMARY KEY, which has no user-facing name.
 // MySQL reserves the name PRIMARY for it, so the lower-cased form cannot collide with a
@@ -72,21 +81,42 @@ func mergeAutoIncrementKeyOps(ops []MigrationOp, diff *SchemaDiff, n *Normalizer
 }
 
 // aiMerger tracks the clause lists of the ops while hazards are resolved. clauses[i] is nil
-// until op i is touched; consumed[i] marks an op whose clauses moved into another statement.
+// until op i is touched; consumed[i] marks an op whose clauses moved into another statement,
+// and mergedInto[i] records which statement (so later analysis knows WHEN the clauses now run).
+// byTable groups the op indices by owning table once, so the per-table role collection does not
+// rescan the whole plan for every AUTO_INCREMENT-bearing table.
 type aiMerger struct {
-	ops      []MigrationOp
-	clauses  [][]string
-	consumed []bool
-	touched  []bool
+	ops        []MigrationOp
+	clauses    [][]string
+	consumed   []bool
+	touched    []bool
+	mergedInto []int
+	byTable    map[string][]int
 }
 
 func newAIMerger(ops []MigrationOp) *aiMerger {
-	return &aiMerger{
-		ops:      ops,
-		clauses:  make([][]string, len(ops)),
-		consumed: make([]bool, len(ops)),
-		touched:  make([]bool, len(ops)),
+	m := &aiMerger{
+		ops:        ops,
+		clauses:    make([][]string, len(ops)),
+		consumed:   make([]bool, len(ops)),
+		touched:    make([]bool, len(ops)),
+		mergedInto: make([]int, len(ops)),
+		byTable:    make(map[string][]int),
 	}
+	for i := range m.mergedInto {
+		m.mergedInto[i] = -1
+	}
+	for i, op := range ops {
+		key := aiTableKey(op.Database, op.ObjectName)
+		m.byTable[key] = append(m.byTable[key], i)
+	}
+	return m
+}
+
+// aiTableKey is the collision-free per-table grouping key (encodeKeyFields length-prefixes the
+// fields, so identifiers containing separator characters cannot alias another table).
+func aiTableKey(database, table string) string {
+	return encodeKeyFields("db", database, "table", table)
 }
 
 // clausesOf returns op i's current clause list, initializing it from alterClause.
@@ -114,6 +144,7 @@ func (m *aiMerger) mergeInto(target int, prepend bool, srcs ...int) {
 	var moved []string
 	for _, s := range srcs {
 		moved = append(moved, m.consume(s)...)
+		m.mergedInto[s] = target
 		if w := m.ops[s].Warning; w != "" && !strings.Contains(m.ops[target].Warning, w) {
 			if m.ops[target].Warning != "" {
 				m.ops[target].Warning += "; "
@@ -178,8 +209,9 @@ func (m *aiMerger) collectRoles(entry *TableDiffEntry) *tableOpRoles {
 	for _, ce := range entry.Columns {
 		colSort[columnSortName(entry.Database, entry.Name, ce.Name)] = toLower(ce.Name)
 	}
-	for i, op := range m.ops {
-		if m.consumed[i] || op.Database != entry.Database || op.ObjectName != entry.Name {
+	for _, i := range m.byTable[aiTableKey(entry.Database, entry.Name)] {
+		op := m.ops[i]
+		if m.consumed[i] {
 			continue
 		}
 		if op.alterClause == "" || !strings.HasSuffix(op.SQL, op.alterClause) {
@@ -279,8 +311,27 @@ func (m *aiMerger) mergeDropHazard(entry *TableDiffEntry, roles *tableOpRoles, f
 		// after it — the oracle-proven shape); a standalone ADD takes the drops in front.
 		prepend := m.ops[cand].dropsIndex == ""
 		m.mergeInto(cand, prepend, drops...)
+		// When the split-path PRIMARY KEY drop moved into this statement, the split's
+		// standalone ADD PRIMARY KEY (same priority, name-sorted) could otherwise run BEFORE
+		// it — while the old PK still exists (errno 1068). Pull the replacement PK add into
+		// the same statement (oracle-proven single-statement form).
+		if pkDropIn(m.ops, drops) {
+			if pa, ok := roles.idxAdd[primaryIndexKey]; ok && pa != cand && !m.consumed[pa] {
+				m.mergeInto(cand, false, pa)
+			}
+		}
 		m.pullDemotedPKMembers(entry, roles, cand, drops)
 	}
+}
+
+// pkDropIn reports whether any of the ops drops the PRIMARY KEY.
+func pkDropIn(ops []MigrationOp, indices []int) bool {
+	for _, i := range indices {
+		if ops[i].dropsIndex == primaryIndexKey {
+			return true
+		}
+	}
+	return false
 }
 
 // pullDemotedPKMembers completes a merged statement that carries the PRIMARY KEY drop: an old
@@ -289,14 +340,7 @@ func (m *aiMerger) mergeDropHazard(entry *TableDiffEntry, roles *tableOpRoles, f
 // once the PK drop moved into a PhaseMain statement. Folding the demoting MODIFYs into the same
 // statement satisfies both rules at once (oracle-probed on both versions).
 func (m *aiMerger) pullDemotedPKMembers(entry *TableDiffEntry, roles *tableOpRoles, target int, drops []int) {
-	pkDropped := false
-	for _, di := range drops {
-		if m.ops[di].dropsIndex == primaryIndexKey {
-			pkDropped = true
-			break
-		}
-	}
-	if !pkDropped || m.ops[target].Phase != PhaseMain {
+	if !pkDropIn(m.ops, drops) || m.ops[target].Phase != PhaseMain {
 		return
 	}
 	oldPK := primaryKeyIndex(entry.From)
@@ -305,6 +349,9 @@ func (m *aiMerger) pullDemotedPKMembers(entry *TableDiffEntry, roles *tableOpRol
 	}
 	var demotes []int
 	for _, ic := range oldPK.Columns {
+		if ic == nil {
+			continue
+		}
 		name := toLower(ic.Name)
 		mi, ok := roles.colModify[name]
 		if !ok || m.consumed[mi] || mi == target {
@@ -375,15 +422,20 @@ func (m *aiMerger) mergeAddHazard(entry *TableDiffEntry, roles *tableOpRoles, fr
 
 // addSideCovered reports whether a from-side key still covers the target auto column at its
 // column statement: the column must not be re-created in this plan (its own PhasePre DROP
-// strips it from every index) and the key's PhasePre drop, if any, must not have survived the
-// DROP-direction merges (a drop folded into a later statement keeps covering until then).
+// strips it from every index) and the key must still exist when the PhaseMain column statement
+// runs — either no statement drops it, or its drop was folded into a PhaseMain statement by the
+// DROP-direction merges (a drop folded into a PhasePre statement, e.g. another column's DROP,
+// still removes the key before PhaseMain).
 func (m *aiMerger) addSideCovered(entry *TableDiffEntry, roles *tableOpRoles, toAI string) bool {
 	if _, recreated := roles.colDrop[toAI]; recreated {
 		return false
 	}
 	for _, idx := range coveringIndexes(entry.From, toAI, entry.To.Engine) {
 		di, dropped := roles.idxDrop[coveredIndexKey(idx)]
-		if !dropped || m.consumed[di] {
+		if !dropped {
+			return true
+		}
+		if m.consumed[di] && m.mergedInto[di] >= 0 && m.ops[m.mergedInto[di]].Phase == PhaseMain {
 			return true
 		}
 	}
@@ -393,7 +445,11 @@ func (m *aiMerger) addSideCovered(entry *TableDiffEntry, roles *tableOpRoles, to
 // pullReferencedColumnAdds moves the ADD COLUMN statements of the backing key's OTHER new
 // columns into the grouped statement (the key clause must be able to reference them), plain
 // columns first, then generated ones, each name-ordered — matching the standalone emission
-// order of the column generator.
+// order of the column generator. When a GENERATED key part is pulled, ALL of the table's plain
+// column adds come along: the generated expression may reference a new plain column that is not
+// itself a key part, and leaving that column's ADD in its own name-sorted statement could run
+// it after this one (extra plain ADD clauses in the grouped statement are harmless,
+// oracle-proven).
 func (m *aiMerger) pullReferencedColumnAdds(roles *tableOpRoles, target int, idx *Index, toAI string, entry *TableDiffEntry) {
 	var plain, generated []string
 	for _, ic := range idx.Columns {
@@ -411,6 +467,17 @@ func (m *aiMerger) pullReferencedColumnAdds(roles *tableOpRoles, target int, idx
 			generated = append(generated, name)
 		} else {
 			plain = append(plain, name)
+		}
+	}
+	if len(generated) > 0 {
+		plain = plain[:0]
+		for name, ai := range roles.colAdd {
+			if name == toAI || m.consumed[ai] || ai == target {
+				continue
+			}
+			if col := entry.To.GetColumn(name); col != nil && col.Generated == nil {
+				plain = append(plain, name)
+			}
 		}
 	}
 	sort.Strings(plain)

--- a/mysql/catalog/migration_autoinc.go
+++ b/mysql/catalog/migration_autoinc.go
@@ -395,7 +395,7 @@ func (m *aiMerger) mergeAddHazard(entry *TableDiffEntry, roles *tableOpRoles, fr
 		}
 	}
 
-	if m.addSideCovered(entry, roles, toAI) {
+	if m.addSideCovered(entry, roles, toAI, target) {
 		return
 	}
 
@@ -420,13 +420,15 @@ func (m *aiMerger) mergeAddHazard(entry *TableDiffEntry, roles *tableOpRoles, fr
 	}
 }
 
-// addSideCovered reports whether a from-side key still covers the target auto column at its
-// column statement: the column must not be re-created in this plan (its own PhasePre DROP
-// strips it from every index) and the key must still exist when the PhaseMain column statement
-// runs — either no statement drops it, or its drop was folded into a PhaseMain statement by the
-// DROP-direction merges (a drop folded into a PhasePre statement, e.g. another column's DROP,
-// still removes the key before PhaseMain).
-func (m *aiMerger) addSideCovered(entry *TableDiffEntry, roles *tableOpRoles, toAI string) bool {
+// addSideCovered reports whether a from-side key still covers the target auto column at the
+// END of the target statement: the column must not be re-created in this plan (its own
+// PhasePre DROP strips it from every index) and the key must survive PAST the target. A
+// dropped key survives only when its DROP clause finally executes in a statement STRICTLY
+// AFTER the target — resolved transitively through the merge chain, because a drop first
+// folded into the old auto column's de-AUTO_INCREMENT MODIFY lands in the TARGET ITSELF once
+// that MODIFY is pulled in, and the key is then already gone at the target's own
+// end-of-statement (the exact errno-1075 window this pass closes; MyISAM shared-key probe).
+func (m *aiMerger) addSideCovered(entry *TableDiffEntry, roles *tableOpRoles, toAI string, target int) bool {
 	if _, recreated := roles.colDrop[toAI]; recreated {
 		return false
 	}
@@ -435,11 +437,38 @@ func (m *aiMerger) addSideCovered(entry *TableDiffEntry, roles *tableOpRoles, to
 		if !dropped {
 			return true
 		}
-		if m.consumed[di] && m.mergedInto[di] >= 0 && m.ops[m.mergedInto[di]].Phase == PhaseMain {
+		final := m.resolveMergedTarget(di)
+		if final != target && m.opExecutesBefore(target, final) {
 			return true
 		}
 	}
 	return false
+}
+
+// resolveMergedTarget follows the mergedInto chain to the statement that finally carries op
+// i's clauses (an op merged into an op that was itself merged onward moves with it).
+func (m *aiMerger) resolveMergedTarget(i int) int {
+	for m.consumed[i] && m.mergedInto[i] >= 0 && m.mergedInto[i] != i {
+		i = m.mergedInto[i]
+	}
+	return i
+}
+
+// opExecutesBefore reports whether op i's statement runs before op j's under
+// sortMigrationOps' total order (phase, priority, sortName, then original position — the
+// same stable tie-break the sort applies to equal keys).
+func (m *aiMerger) opExecutesBefore(i, j int) bool {
+	a, b := m.ops[i], m.ops[j]
+	if a.Phase != b.Phase {
+		return a.Phase < b.Phase
+	}
+	if a.Priority != b.Priority {
+		return a.Priority < b.Priority
+	}
+	if a.sortName != b.sortName {
+		return a.sortName < b.sortName
+	}
+	return i < j
 }
 
 // pullReferencedColumnAdds moves the ADD COLUMN statements of the backing key's OTHER new

--- a/mysql/catalog/migration_autoinc.go
+++ b/mysql/catalog/migration_autoinc.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"slices"
 	"sort"
 	"strings"
 )
@@ -404,7 +405,7 @@ func (m *aiMerger) mergeAddHazard(entry *TableDiffEntry, roles *tableOpRoles, fr
 	synthesized := ""
 	if cand >= 0 {
 		candIdx = m.ops[cand].addsIndex
-	} else if idx := fkImplicitBackingToSynthesize(entry, toAI); idx != nil {
+	} else if idx := m.fkImplicitBackingToSynthesize(entry, roles, toAI, target); idx != nil {
 		candIdx = idx
 		synthesized = "ADD " + formatIndexDefinition(idx, n)
 	}
@@ -412,7 +413,7 @@ func (m *aiMerger) mergeAddHazard(entry *TableDiffEntry, roles *tableOpRoles, fr
 		return // no in-plan backing — the target is invalid and MySQL reports it
 	}
 
-	m.pullReferencedColumnAdds(roles, target, candIdx, toAI, entry)
+	m.pullReferencedColumnOps(roles, target, candIdx, toAI, entry)
 	if synthesized != "" {
 		m.appendClause(target, synthesized)
 	} else {
@@ -471,46 +472,77 @@ func (m *aiMerger) opExecutesBefore(i, j int) bool {
 	return i < j
 }
 
-// pullReferencedColumnAdds moves the ADD COLUMN statements of the backing key's OTHER new
-// columns into the grouped statement (the key clause must be able to reference them), plain
-// columns first, then generated ones, each name-ordered — matching the standalone emission
-// order of the column generator. When a GENERATED key part is pulled, ALL of the table's plain
-// column adds come along: the generated expression may reference a new plain column that is not
-// itself a key part, and leaving that column's ADD in its own name-sorted statement could run
-// it after this one (extra plain ADD clauses in the grouped statement are harmless,
-// oracle-proven).
-func (m *aiMerger) pullReferencedColumnAdds(roles *tableOpRoles, target int, idx *Index, toAI string, entry *TableDiffEntry) {
-	var plain, generated []string
+// pullReferencedColumnOps moves the column statements the backing key depends on into the
+// grouped statement, so the key clause always references columns that exist in their final
+// shape at its end-of-statement:
+//
+//   - ADD COLUMN of every other NEW plain key-part column, then of generated ones (plain
+//     before generated, each name-ordered — matching the column generator's emission order);
+//   - MODIFY COLUMN of every EXISTING plain key-part column changed in this plan (a prefix
+//     part over a column widened in-plan would otherwise be validated against the old type —
+//     errno 1089 — because the grouped statement runs at the auto column's name slot, possibly
+//     before that MODIFY; in-statement, MySQL validates against the post-MODIFY shape,
+//     oracle-proven both clause orders);
+//   - when the key has GENERATED or FUNCTIONAL (expression) parts, ALL of the table's plain
+//     column adds: the expression may reference a new plain column that is not itself a key
+//     part (errno 1054 otherwise), and for functional parts additionally the generated adds.
+//     Conservative pulling is deterministic and harmless — extra clauses in the grouped
+//     statement are oracle-proven no-ops semantically.
+func (m *aiMerger) pullReferencedColumnOps(roles *tableOpRoles, target int, idx *Index, toAI string, entry *TableDiffEntry) {
+	var plain, generated, modifies []string
+	pullAllAdds, pullGeneratedAdds := false, false
 	for _, ic := range idx.Columns {
-		if ic == nil || ic.Expr != "" {
+		if ic == nil {
+			continue
+		}
+		if ic.Expr != "" {
+			// Functional part: its expression may reference any column added in this plan.
+			pullAllAdds, pullGeneratedAdds = true, true
 			continue
 		}
 		name := toLower(ic.Name)
 		if name == toAI {
 			continue
 		}
-		if _, ok := roles.colAdd[name]; !ok {
+		if _, ok := roles.colAdd[name]; ok {
+			if col := entry.To.GetColumn(ic.Name); col != nil && col.Generated != nil {
+				generated = append(generated, name)
+				pullAllAdds = true // its expression may reference a non-key-part new column
+			} else {
+				plain = append(plain, name)
+			}
 			continue
 		}
-		if col := entry.To.GetColumn(ic.Name); col != nil && col.Generated != nil {
-			generated = append(generated, name)
-		} else {
-			plain = append(plain, name)
+		if _, ok := roles.colModify[name]; ok {
+			modifies = append(modifies, name)
 		}
 	}
-	if len(generated) > 0 {
+	if pullAllAdds {
 		plain = plain[:0]
 		for name, ai := range roles.colAdd {
 			if name == toAI || m.consumed[ai] || ai == target {
 				continue
 			}
-			if col := entry.To.GetColumn(name); col != nil && col.Generated == nil {
+			col := entry.To.GetColumn(name)
+			if col == nil {
+				continue
+			}
+			if col.Generated == nil {
 				plain = append(plain, name)
+			} else if pullGeneratedAdds && !slices.Contains(generated, name) {
+				generated = append(generated, name)
 			}
 		}
 	}
+	sort.Strings(modifies)
 	sort.Strings(plain)
 	sort.Strings(generated)
+	for _, name := range modifies {
+		mi := roles.colModify[name]
+		if !m.consumed[mi] && mi != target {
+			m.mergeInto(target, false, mi)
+		}
+	}
 	for _, name := range append(plain, generated...) {
 		ai := roles.colAdd[name]
 		if !m.consumed[ai] && ai != target {
@@ -637,10 +669,14 @@ func columnEntry(entry *TableDiffEntry, col string) *ColumnDiffEntry {
 // into the grouped column statement when NO diffed key covers the new auto column — the ALTER
 // analog of formatCreateTable's last-resort inline. The index must cover the column, be
 // FK-implicit on the target (the index differ excludes it, so no ADD op exists), and its name
-// must be free on the from side (otherwise adding it would collide, errno 1061). The deferred
-// PhasePost FK ADD then reuses the pre-created index instead of auto-creating a duplicate
-// (oracle-probed). Candidates iterate in name order for determinism.
-func fkImplicitBackingToSynthesize(entry *TableDiffEntry, col string) *Index {
+// must be FREE when the grouped statement runs: either absent on the from side, or freed by an
+// in-plan DROP whose statement executes at or before the target (an FK re-pointed to the new
+// auto column keeps its constraint name, so the OLD implicit backing index of the SAME name is
+// dropped in PhasePre — the name is available again by the time the group runs; adding it
+// while the old one still existed would collide, errno 1061). The deferred PhasePost FK ADD
+// then reuses the pre-created index instead of auto-creating a duplicate (oracle-probed).
+// Candidates iterate in name order for determinism.
+func (m *aiMerger) fkImplicitBackingToSynthesize(entry *TableDiffEntry, roles *tableOpRoles, col string, target int) *Index {
 	implicit := fkImplicitIndexNames(entry.To)
 	if len(implicit) == 0 {
 		return nil
@@ -651,9 +687,20 @@ func fkImplicitBackingToSynthesize(entry *TableDiffEntry, col string) *Index {
 			fromNames[toLower(idx.Name)] = true
 		}
 	}
+	nameFree := func(name string) bool {
+		if !fromNames[name] {
+			return true
+		}
+		di, dropped := roles.idxDrop[name]
+		if !dropped {
+			return false
+		}
+		final := m.resolveMergedTarget(di)
+		return final == target || m.opExecutesBefore(final, target)
+	}
 	var best *Index
 	for _, idx := range entry.To.Indexes {
-		if idx == nil || idx.Primary || !implicit[toLower(idx.Name)] || fromNames[toLower(idx.Name)] {
+		if idx == nil || idx.Primary || !implicit[toLower(idx.Name)] || !nameFree(toLower(idx.Name)) {
 			continue
 		}
 		if !indexBacksAutoColumn(idx, col, entry.To.Engine) {

--- a/mysql/catalog/migration_autoinc.go
+++ b/mysql/catalog/migration_autoinc.go
@@ -1,0 +1,571 @@
+package catalog
+
+import (
+	"sort"
+	"strings"
+)
+
+// MySQL SDL generate — AUTO_INCREMENT / backing-key statement grouping.
+//
+// MySQL validates, at the END OF EVERY ALTER TABLE statement, that the table holds at most one
+// AUTO_INCREMENT column and that this column is keyed — the FIRST column of some index (errno
+// 1075, "there can be only one auto column and it must be defined as a key"). The plan generator
+// otherwise emits ONE clause per statement in a fixed phase/priority order (index drops →
+// column drops → column adds/modifies → index adds), so a change that is only valid when the
+// AUTO_INCREMENT column and its backing key move TOGETHER fails on whichever ungrouped
+// statement exposes the unkeyed (or doubled) auto column. formatCreateTable already inlines the
+// backing key for a NEW table (autoIncSupportingIndex); this pass is the ALTER-path analog for
+// MODIFIED tables: it detects the hazard statements and merges the involved clauses into one
+// ALTER TABLE.
+//
+// Oracle evidence (probed live on 5.7.25 and 8.0.32, identical behavior; each grouped form this
+// pass emits is proven by migration_autoinc_oracle_test.go):
+//   - `ADD COLUMN c ... AUTO_INCREMENT` alone → errno 1075; with `, ADD <any key with c first>`
+//     in the SAME statement → OK (UNIQUE, plain KEY, PRIMARY KEY; clause order is free).
+//   - InnoDB and MEMORY require c to be the FIRST column of the key (a non-first position fails
+//     even grouped); MyISAM alone also accepts a non-first position. A functional (expression)
+//     first part does NOT satisfy the rule; DESC and INVISIBLE keys DO.
+//   - `MODIFY COLUMN c ... AUTO_INCREMENT` (gaining the attribute) is subject to the same rule;
+//     it works ungrouped only when a surviving key already covers c.
+//   - Making one column AUTO_INCREMENT while another still holds the attribute fails ("only one
+//     auto column"); the de-AUTO_INCREMENT MODIFY and the gaining clause must share a statement.
+//   - Dropping the LAST key covering a still-AUTO_INCREMENT column → errno 1075 on the DROP
+//     statement; grouped with the column's DROP, its de-AUTO_INCREMENT MODIFY, or a replacement
+//     covering ADD (any of which restores validity at end of statement) → OK.
+//   - The combined `DROP PRIMARY KEY, ADD PRIMARY KEY` statement accepts extra clauses (a new
+//     AUTO_INCREMENT column's ADD, a stale covering key's DROP).
+//   - A demoted old-PK member's `MODIFY ... NULL` may share the statement that drops the PK.
+//
+// The pass is deliberately RULE-BASED (grouping exactly the hazard cases) rather than a general
+// per-table clause merger: every other statement keeps its own op, so op granularity, warnings,
+// and the global sort order stay untouched for non-hazard plans. When a hazard has no in-plan
+// resolution (the TARGET itself leaves an AUTO_INCREMENT column unkeyed — invalid in MySQL
+// regardless of statement grouping), the ops are left ungrouped and the apply surfaces MySQL's
+// own error, matching autoIncSupportingIndex's stance on unkeyable CREATEs.
+//
+// Ops participate only through the grouping metadata their constructors set (alterClause,
+// addsIndex, dropsIndex on MigrationOp); everything else — checks, views, options, FK
+// constraint adds — is invisible to the pass and never regrouped.
+
+// primaryIndexKey is the dropsIndex marker for the PRIMARY KEY, which has no user-facing name.
+// MySQL reserves the name PRIMARY for it, so the lower-cased form cannot collide with a
+// secondary index.
+const primaryIndexKey = "primary"
+
+// mergeAutoIncrementKeyOps rewrites the generated ops so that no statement boundary exposes an
+// unkeyed or doubled AUTO_INCREMENT column (see the file comment). It returns the ops slice to
+// use; ops merged into another statement are removed, the surviving statement carrying their
+// clauses (and warnings). Called by GenerateMigrationWithNormalizer before sortMigrationOps.
+func mergeAutoIncrementKeyOps(ops []MigrationOp, diff *SchemaDiff, n *Normalizer) []MigrationOp {
+	if diff == nil || len(ops) == 0 {
+		return ops
+	}
+	m := newAIMerger(ops)
+	for i := range diff.Tables {
+		entry := &diff.Tables[i]
+		if entry.Action != DiffModify || entry.From == nil || entry.To == nil {
+			continue
+		}
+		m.mergeTable(entry, n)
+	}
+	return m.result()
+}
+
+// aiMerger tracks the clause lists of the ops while hazards are resolved. clauses[i] is nil
+// until op i is touched; consumed[i] marks an op whose clauses moved into another statement.
+type aiMerger struct {
+	ops      []MigrationOp
+	clauses  [][]string
+	consumed []bool
+	touched  []bool
+}
+
+func newAIMerger(ops []MigrationOp) *aiMerger {
+	return &aiMerger{
+		ops:      ops,
+		clauses:  make([][]string, len(ops)),
+		consumed: make([]bool, len(ops)),
+		touched:  make([]bool, len(ops)),
+	}
+}
+
+// clausesOf returns op i's current clause list, initializing it from alterClause.
+func (m *aiMerger) clausesOf(i int) []string {
+	if m.clauses[i] == nil {
+		m.clauses[i] = []string{m.ops[i].alterClause}
+	}
+	return m.clauses[i]
+}
+
+// consume removes op i from the plan and returns its clauses for re-emission elsewhere.
+func (m *aiMerger) consume(i int) []string {
+	cl := m.clausesOf(i)
+	m.consumed[i] = true
+	return cl
+}
+
+// mergeInto moves the clauses of each src op into the target op, before (prepend) or after its
+// current clauses. Warnings on consumed ops move to the target so none are lost.
+func (m *aiMerger) mergeInto(target int, prepend bool, srcs ...int) {
+	if len(srcs) == 0 {
+		return
+	}
+	cur := m.clausesOf(target)
+	var moved []string
+	for _, s := range srcs {
+		moved = append(moved, m.consume(s)...)
+		if w := m.ops[s].Warning; w != "" && !strings.Contains(m.ops[target].Warning, w) {
+			if m.ops[target].Warning != "" {
+				m.ops[target].Warning += "; "
+			}
+			m.ops[target].Warning += w
+		}
+	}
+	if prepend {
+		m.clauses[target] = append(moved, cur...)
+	} else {
+		m.clauses[target] = append(cur, moved...)
+	}
+	m.touched[target] = true
+}
+
+// appendClause adds a synthesized clause (one not backed by an existing op) to the target.
+func (m *aiMerger) appendClause(target int, clause string) {
+	m.clauses[target] = append(m.clausesOf(target), clause)
+	m.touched[target] = true
+}
+
+// result rebuilds the op slice: consumed ops disappear; touched ops re-render their SQL from
+// the merged clause list (the original "ALTER TABLE <ident> " prefix is preserved byte-exactly
+// by trimming the op's own alterClause suffix).
+func (m *aiMerger) result() []MigrationOp {
+	out := make([]MigrationOp, 0, len(m.ops))
+	for i, op := range m.ops {
+		if m.consumed[i] {
+			continue
+		}
+		if m.touched[i] {
+			prefix := strings.TrimSuffix(op.SQL, op.alterClause)
+			op.SQL = prefix + strings.Join(m.clauses[i], ", ")
+		}
+		out = append(out, op)
+	}
+	return out
+}
+
+// tableOpRoles indexes one table's ops by their role in the hazard analysis. Only ops carrying
+// grouping metadata (a non-empty alterClause that suffix-matches their SQL) are eligible.
+type tableOpRoles struct {
+	colAdd    map[string]int // lower column name → op index (ADD COLUMN)
+	colModify map[string]int // lower column name → op index (MODIFY COLUMN)
+	colDrop   map[string]int // lower column name → op index (DROP COLUMN)
+	idxAdd    map[string]int // lower added-index name → op index (incl. combined PK change)
+	idxDrop   map[string]int // lower dropped-index name → op index, PhasePre statements only
+}
+
+// collectRoles gathers the table's ops. Column ops are matched through the diff's column
+// entries (recomputing the op's sortName — MySQL identifiers cannot contain '.', so the dotted
+// key is unambiguous); index ops carry their identity in addsIndex/dropsIndex.
+func (m *aiMerger) collectRoles(entry *TableDiffEntry) *tableOpRoles {
+	r := &tableOpRoles{
+		colAdd:    map[string]int{},
+		colModify: map[string]int{},
+		colDrop:   map[string]int{},
+		idxAdd:    map[string]int{},
+		idxDrop:   map[string]int{},
+	}
+	colSort := make(map[string]string, len(entry.Columns))
+	for _, ce := range entry.Columns {
+		colSort[columnSortName(entry.Database, entry.Name, ce.Name)] = toLower(ce.Name)
+	}
+	for i, op := range m.ops {
+		if m.consumed[i] || op.Database != entry.Database || op.ObjectName != entry.Name {
+			continue
+		}
+		if op.alterClause == "" || !strings.HasSuffix(op.SQL, op.alterClause) {
+			continue
+		}
+		switch op.Type {
+		case OpAddColumn, OpModifyColumn, OpDropColumn:
+			name, ok := colSort[op.sortName]
+			if !ok {
+				continue
+			}
+			switch op.Type {
+			case OpAddColumn:
+				r.colAdd[name] = i
+			case OpModifyColumn:
+				r.colModify[name] = i
+			default:
+				r.colDrop[name] = i
+			}
+		default:
+			if op.addsIndex != nil {
+				r.idxAdd[toLower(op.addsIndex.Name)] = i
+			}
+			if op.dropsIndex != "" && op.addsIndex == nil && op.Phase == PhasePre {
+				r.idxDrop[op.dropsIndex] = i
+			}
+		}
+	}
+	return r
+}
+
+// mergeTable runs the hazard analysis for one modified table: first the DROP direction (the
+// last covering key leaving while the column is still AUTO_INCREMENT), then the ADD direction
+// (the AUTO_INCREMENT attribute arriving without a surviving covering key, or migrating from
+// another column).
+func (m *aiMerger) mergeTable(entry *TableDiffEntry, n *Normalizer) {
+	fromAI := toLower(autoIncrementColumnName(entry.From))
+	toAI := toLower(autoIncrementColumnName(entry.To))
+	if fromAI == "" && toAI == "" {
+		return
+	}
+	roles := m.collectRoles(entry)
+
+	if fromAI != "" {
+		m.mergeDropHazard(entry, roles, fromAI, toAI)
+	}
+	if toAI != "" {
+		m.mergeAddHazard(entry, roles, fromAI, toAI, n)
+	}
+}
+
+// mergeDropHazard handles the DROP direction: every from-side key covering the AUTO_INCREMENT
+// column is dropped by a PhasePre statement, so the LAST such drop would end its statement with
+// an unkeyed auto column (errno 1075, oracle-probed). The covering drops are folded into
+// whichever statement restores validity:
+//
+//	(a) the column's own DROP COLUMN (PhasePre — the drops arrive with the column removal);
+//	(b) the column's de-AUTO_INCREMENT MODIFY (PhaseMain — the attribute leaves with the keys);
+//	(c) a covering key ADD when the column stays AUTO_INCREMENT (PhaseMain — the coverage swaps
+//	    atomically; the secondary-key analog of the combined PRIMARY KEY change).
+//
+// With no resolution the target itself is invalid (an unkeyed AUTO_INCREMENT column) and the
+// ops stay ungrouped — MySQL reports the error.
+func (m *aiMerger) mergeDropHazard(entry *TableDiffEntry, roles *tableOpRoles, fromAI, toAI string) {
+	covering := coveringIndexes(entry.From, fromAI, entry.From.Engine)
+	if len(covering) == 0 {
+		return
+	}
+	var drops []int
+	for _, idx := range covering {
+		di, ok := roles.idxDrop[coveredIndexKey(idx)]
+		if !ok {
+			return // a covering key survives PhasePre — every drop statement stays valid
+		}
+		drops = append(drops, di)
+	}
+	sort.Ints(drops)
+
+	if di, ok := roles.colDrop[fromAI]; ok {
+		// (a) `DROP INDEX k, DROP COLUMN c` — one PhasePre statement at the column drop's slot.
+		m.mergeInto(di, true, drops...)
+		return
+	}
+	if mi, ok := roles.colModify[fromAI]; ok && !columnToIsAutoIncrement(entry, fromAI) {
+		// (b) `MODIFY COLUMN c <no AUTO_INCREMENT>, DROP INDEX k` — one PhaseMain statement.
+		m.mergeInto(mi, false, drops...)
+		m.pullDemotedPKMembers(entry, roles, mi, drops)
+		return
+	}
+	if toAI == fromAI {
+		// (c) the column stays AUTO_INCREMENT: fold the drops into a covering ADD.
+		cand := m.chooseCoveringAddOp(entry.To, roles, fromAI)
+		if cand < 0 {
+			return
+		}
+		// The combined PK statement already ends in its ADD clause (append the stale drops
+		// after it — the oracle-proven shape); a standalone ADD takes the drops in front.
+		prepend := m.ops[cand].dropsIndex == ""
+		m.mergeInto(cand, prepend, drops...)
+		m.pullDemotedPKMembers(entry, roles, cand, drops)
+	}
+}
+
+// pullDemotedPKMembers completes a merged statement that carries the PRIMARY KEY drop: an old
+// PK member demoted to nullable in the same diff must not be MODIFYed while the PK still holds
+// it (errno 1171), and the split-PK ordering that normally guarantees this no longer applies
+// once the PK drop moved into a PhaseMain statement. Folding the demoting MODIFYs into the same
+// statement satisfies both rules at once (oracle-probed on both versions).
+func (m *aiMerger) pullDemotedPKMembers(entry *TableDiffEntry, roles *tableOpRoles, target int, drops []int) {
+	pkDropped := false
+	for _, di := range drops {
+		if m.ops[di].dropsIndex == primaryIndexKey {
+			pkDropped = true
+			break
+		}
+	}
+	if !pkDropped || m.ops[target].Phase != PhaseMain {
+		return
+	}
+	oldPK := primaryKeyIndex(entry.From)
+	if oldPK == nil {
+		return
+	}
+	var demotes []int
+	for _, ic := range oldPK.Columns {
+		name := toLower(ic.Name)
+		mi, ok := roles.colModify[name]
+		if !ok || m.consumed[mi] || mi == target {
+			continue
+		}
+		if ce := columnEntry(entry, name); ce != nil && ce.Action == DiffModify && ce.To != nil && ce.To.Nullable {
+			demotes = append(demotes, mi)
+		}
+	}
+	sort.Ints(demotes)
+	m.mergeInto(target, false, demotes...)
+}
+
+// mergeAddHazard handles the ADD direction: the table's target AUTO_INCREMENT column has an
+// ADD/MODIFY statement in the plan, and at that statement's boundary no surviving key covers it
+// (a brand-new column is never covered; a modified one only by from-keys that no PhasePre
+// statement dropped). The backing key's ADD is folded into the column statement, together with:
+//   - the previous AUTO_INCREMENT column's de-attribute MODIFY (two live auto columns are
+//     rejected even transiently, oracle-probed);
+//   - the ADDs of any other new columns the backing key references (plain before generated —
+//     a generated column cannot reference the auto column itself, so this order always works).
+//
+// When no diffed key covers the column, a FK-implicit backing index on the target table is
+// synthesized as a last resort — the ALTER analog of formatCreateTable's last-resort inline;
+// the deferred PhasePost FK then reuses it instead of auto-creating a duplicate.
+func (m *aiMerger) mergeAddHazard(entry *TableDiffEntry, roles *tableOpRoles, fromAI, toAI string, n *Normalizer) {
+	target, hasColOp := roles.colAdd[toAI]
+	if !hasColOp {
+		target, hasColOp = roles.colModify[toAI]
+	}
+	if !hasColOp || m.consumed[target] {
+		return
+	}
+
+	// The de-AUTO_INCREMENT of a different previous auto column must join this statement even
+	// when the new column is already covered (the "only one auto column" half of errno 1075).
+	if fromAI != "" && fromAI != toAI {
+		if mi, ok := roles.colModify[fromAI]; ok && !m.consumed[mi] && mi != target &&
+			!columnToIsAutoIncrement(entry, fromAI) {
+			m.mergeInto(target, true, mi)
+		}
+	}
+
+	if m.addSideCovered(entry, roles, toAI) {
+		return
+	}
+
+	cand := m.chooseCoveringAddOp(entry.To, roles, toAI)
+	var candIdx *Index
+	synthesized := ""
+	if cand >= 0 {
+		candIdx = m.ops[cand].addsIndex
+	} else if idx := fkImplicitBackingToSynthesize(entry, toAI); idx != nil {
+		candIdx = idx
+		synthesized = "ADD " + formatIndexDefinition(idx, n)
+	}
+	if candIdx == nil {
+		return // no in-plan backing — the target is invalid and MySQL reports it
+	}
+
+	m.pullReferencedColumnAdds(roles, target, candIdx, toAI, entry)
+	if synthesized != "" {
+		m.appendClause(target, synthesized)
+	} else {
+		m.mergeInto(target, false, cand)
+	}
+}
+
+// addSideCovered reports whether a from-side key still covers the target auto column at its
+// column statement: the column must not be re-created in this plan (its own PhasePre DROP
+// strips it from every index) and the key's PhasePre drop, if any, must not have survived the
+// DROP-direction merges (a drop folded into a later statement keeps covering until then).
+func (m *aiMerger) addSideCovered(entry *TableDiffEntry, roles *tableOpRoles, toAI string) bool {
+	if _, recreated := roles.colDrop[toAI]; recreated {
+		return false
+	}
+	for _, idx := range coveringIndexes(entry.From, toAI, entry.To.Engine) {
+		di, dropped := roles.idxDrop[coveredIndexKey(idx)]
+		if !dropped || m.consumed[di] {
+			return true
+		}
+	}
+	return false
+}
+
+// pullReferencedColumnAdds moves the ADD COLUMN statements of the backing key's OTHER new
+// columns into the grouped statement (the key clause must be able to reference them), plain
+// columns first, then generated ones, each name-ordered — matching the standalone emission
+// order of the column generator.
+func (m *aiMerger) pullReferencedColumnAdds(roles *tableOpRoles, target int, idx *Index, toAI string, entry *TableDiffEntry) {
+	var plain, generated []string
+	for _, ic := range idx.Columns {
+		if ic == nil || ic.Expr != "" {
+			continue
+		}
+		name := toLower(ic.Name)
+		if name == toAI {
+			continue
+		}
+		if _, ok := roles.colAdd[name]; !ok {
+			continue
+		}
+		if col := entry.To.GetColumn(ic.Name); col != nil && col.Generated != nil {
+			generated = append(generated, name)
+		} else {
+			plain = append(plain, name)
+		}
+	}
+	sort.Strings(plain)
+	sort.Strings(generated)
+	for _, name := range append(plain, generated...) {
+		ai := roles.colAdd[name]
+		if !m.consumed[ai] && ai != target {
+			m.mergeInto(target, false, ai)
+		}
+	}
+}
+
+// chooseCoveringAddOp picks the plan's best covering key ADD for the auto column: PRIMARY over
+// UNIQUE over plain, first-column coverage over MyISAM's any-position coverage, index name as
+// the deterministic tie-break. Returns -1 when no eligible ADD covers the column.
+func (m *aiMerger) chooseCoveringAddOp(to *Table, roles *tableOpRoles, col string) int {
+	names := make([]string, 0, len(roles.idxAdd))
+	for name := range roles.idxAdd {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	best := -1
+	var bestIdx *Index
+	bestLeftmost := false
+	for _, name := range names {
+		oi := roles.idxAdd[name]
+		if m.consumed[oi] {
+			continue
+		}
+		idx := m.ops[oi].addsIndex
+		if !indexBacksAutoColumn(idx, col, to.Engine) {
+			continue
+		}
+		leftmost := indexFirstColumnIs(idx, col)
+		if best < 0 || coveringAddPreferred(idx, leftmost, bestIdx, bestLeftmost) {
+			best, bestIdx, bestLeftmost = oi, idx, leftmost
+		}
+	}
+	return best
+}
+
+// coveringAddPreferred ranks candidate backing keys: first-column coverage beats any-position
+// coverage, then PRIMARY > UNIQUE > plain (names already iterate in sorted order, so the first
+// candidate of a rank wins the tie).
+func coveringAddPreferred(cand *Index, candLeftmost bool, cur *Index, curLeftmost bool) bool {
+	if candLeftmost != curLeftmost {
+		return candLeftmost
+	}
+	if cand.Primary != cur.Primary {
+		return cand.Primary
+	}
+	if cand.Unique != cur.Unique {
+		return cand.Unique
+	}
+	return false
+}
+
+// indexBacksAutoColumn reports whether the index satisfies errno 1075 for the named column
+// under the given storage engine: the column is the index's FIRST plain column, or — for MyISAM
+// only (oracle-probed; InnoDB and MEMORY reject it) — any plain column position.
+func indexBacksAutoColumn(idx *Index, col, engine string) bool {
+	return indexFirstColumnIs(idx, col) ||
+		(engineAllowsNonFirstAutoKey(engine) && indexHasPlainColumn(idx, col))
+}
+
+// coveringIndexes returns the table's indexes that back the named AUTO_INCREMENT column
+// (indexBacksAutoColumn) — the keys whose complete removal strands it (errno 1075).
+func coveringIndexes(tbl *Table, col, engine string) []*Index {
+	var out []*Index
+	for _, idx := range tbl.Indexes {
+		if idx == nil || isGeneratedInvisiblePrimaryKeyIndex(idx) {
+			continue
+		}
+		if indexBacksAutoColumn(idx, col, engine) {
+			out = append(out, idx)
+		}
+	}
+	return out
+}
+
+// coveredIndexKey is the dropsIndex-space key of an index (the PRIMARY KEY has no user name).
+func coveredIndexKey(idx *Index) string {
+	if idx.Primary {
+		return primaryIndexKey
+	}
+	return toLower(idx.Name)
+}
+
+// engineAllowsNonFirstAutoKey reports whether the storage engine accepts an AUTO_INCREMENT
+// column in a NON-first position of a multi-column key (MyISAM's grouped-sequence feature).
+// InnoDB and MEMORY require the first position (oracle-probed on 5.7.25 and 8.0.32).
+func engineAllowsNonFirstAutoKey(engine string) bool {
+	return strings.EqualFold(strings.TrimSpace(engine), "MyISAM")
+}
+
+// indexHasPlainColumn reports whether any plain (non-expression) key part is the named column.
+func indexHasPlainColumn(idx *Index, col string) bool {
+	for _, ic := range idx.Columns {
+		if ic != nil && ic.Expr == "" && strings.EqualFold(ic.Name, col) {
+			return true
+		}
+	}
+	return false
+}
+
+// columnToIsAutoIncrement reports whether the diff leaves the named column AUTO_INCREMENT on
+// the target side. A column without a diff entry is unchanged, so its target state is its
+// current state.
+func columnToIsAutoIncrement(entry *TableDiffEntry, col string) bool {
+	if ce := columnEntry(entry, col); ce != nil {
+		return ce.To != nil && ce.To.AutoIncrement
+	}
+	c := entry.To.GetColumn(col)
+	return c != nil && c.AutoIncrement
+}
+
+// columnEntry returns the diff's column entry for the lower-cased name, or nil.
+func columnEntry(entry *TableDiffEntry, col string) *ColumnDiffEntry {
+	for i := range entry.Columns {
+		if toLower(entry.Columns[i].Name) == col {
+			return &entry.Columns[i]
+		}
+	}
+	return nil
+}
+
+// fkImplicitBackingToSynthesize returns the target table's FK-implicit backing index to inline
+// into the grouped column statement when NO diffed key covers the new auto column — the ALTER
+// analog of formatCreateTable's last-resort inline. The index must cover the column, be
+// FK-implicit on the target (the index differ excludes it, so no ADD op exists), and its name
+// must be free on the from side (otherwise adding it would collide, errno 1061). The deferred
+// PhasePost FK ADD then reuses the pre-created index instead of auto-creating a duplicate
+// (oracle-probed). Candidates iterate in name order for determinism.
+func fkImplicitBackingToSynthesize(entry *TableDiffEntry, col string) *Index {
+	implicit := fkImplicitIndexNames(entry.To)
+	if len(implicit) == 0 {
+		return nil
+	}
+	fromNames := make(map[string]bool, len(entry.From.Indexes))
+	for _, idx := range entry.From.Indexes {
+		if idx != nil {
+			fromNames[toLower(idx.Name)] = true
+		}
+	}
+	var best *Index
+	for _, idx := range entry.To.Indexes {
+		if idx == nil || idx.Primary || !implicit[toLower(idx.Name)] || fromNames[toLower(idx.Name)] {
+			continue
+		}
+		if !indexBacksAutoColumn(idx, col, entry.To.Engine) {
+			continue
+		}
+		if best == nil || toLower(idx.Name) < toLower(best.Name) {
+			best = idx
+		}
+	}
+	return best
+}

--- a/mysql/catalog/migration_autoinc_oracle_test.go
+++ b/mysql/catalog/migration_autoinc_oracle_test.go
@@ -89,6 +89,12 @@ func autoIncMigrationProbes() []migrationProbe {
 		{"aig-myisam-gain-ai-existing-nonleftmost", "t",
 			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT NOT NULL, c INT NOT NULL, KEY k (a, c)) ENGINE=MyISAM",
 			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT NOT NULL, c INT NOT NULL AUTO_INCREMENT, KEY k (a, c)) ENGINE=MyISAM", both()},
+		// MyISAM shared composite key covering BOTH the old and the new auto column: the old
+		// column and the shared key leave in PhasePre, so the gaining MODIFY must still group
+		// with the NEW backing key (the consumed PhasePre drop does not cover PhaseMain).
+		{"aig-myisam-shared-key-ai-migrate", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c1 INT NOT NULL AUTO_INCREMENT, c2 INT NOT NULL, KEY k (c1, c2)) ENGINE=MyISAM",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c2 INT NOT NULL AUTO_INCREMENT, KEY k2 (c2)) ENGINE=MyISAM", both()},
 		// 8.0-only backing-key shapes that still satisfy errno 1075 (probed): DESC first column,
 		// INVISIBLE index, and a trailing functional part behind the plain first column.
 		{"aig-add-col-desc-key", "t",
@@ -153,6 +159,26 @@ func autoIncMigrationProbes() []migrationProbe {
 		{"aig-pk-swap-drop-secondary", "t",
 			"CREATE TABLE t (x INT NOT NULL, c INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_c (c), PRIMARY KEY (x))",
 			"CREATE TABLE t (x INT NOT NULL, c INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (c))", both()},
+		// The PK moves OFF the AUTO_INCREMENT column onto another column while a NEW secondary
+		// key takes over the coverage: the split DROP PRIMARY KEY, the covering ADD KEY, and the
+		// replacement ADD PRIMARY KEY must all share one statement (the key name `zz_c` sorts
+		// AFTER `primary`, pinning the ordering hazard where the PK re-add would otherwise run
+		// while the old PK still exists — errno 1068).
+		{"aig-pk-relocate-ai-to-secondary", "t",
+			"CREATE TABLE t (c INT NOT NULL AUTO_INCREMENT, b INT NOT NULL, x INT, PRIMARY KEY (c))",
+			"CREATE TABLE t (c INT NOT NULL AUTO_INCREMENT, b INT NOT NULL, x INT, PRIMARY KEY (b), KEY zz_c (c))", both()},
+		// The AUTO_INCREMENT column keeps the (shrinking) PK while a DIFFERENT old-PK member is
+		// demoted to nullable: the demoting MODIFY joins the DROP+ADD PRIMARY KEY statement
+		// (formerly a flagged known limitation of primaryKeyModifyOps).
+		{"aig-pk-keep-ai-demote-member", "t",
+			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, PRIMARY KEY (id, a))",
+			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT, a INT NULL, PRIMARY KEY (id))", both()},
+		// A GENERATED key part rides in the backing key: its ADD and the plain column its
+		// expression references (not itself a key part) are both pulled into the grouped
+		// statement, plain adds first.
+		{"aig-generated-keypart-pullin", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, seq INT NOT NULL AUTO_INCREMENT, d INT NOT NULL, g INT GENERATED ALWAYS AS (d+1) VIRTUAL, UNIQUE KEY uk_sg (seq, g))", both()},
 		// The AUTO_INCREMENT column keeps its attribute but is REDEFINED (type widen) while the
 		// backing key is reshaped in the same plan: the widen MODIFY stays its own statement
 		// (still covered by the old key) and the reshape is grouped.
@@ -230,21 +256,39 @@ func TestOracle_AutoIncGroupingFKImplicitBacking(t *testing.T) {
 	if testing.Short() {
 		t.Skip("oracle test skipped in short mode")
 	}
-	mc := fkMultiCase{
-		id: "aig-fk-implicit-backing",
-		fromSQL: "CREATE TABLE p (id INT NOT NULL PRIMARY KEY); " +
-			"CREATE TABLE c (id INT NOT NULL PRIMARY KEY, x INT)",
-		toSQL: "CREATE TABLE p (id INT NOT NULL PRIMARY KEY); " +
-			"CREATE TABLE c (id INT NOT NULL PRIMARY KEY, x INT, seq INT NOT NULL AUTO_INCREMENT, " +
-			"CONSTRAINT fk_seq FOREIGN KEY (seq) REFERENCES p (id))",
-		tables:   []string{"p", "c"},
-		versions: both(),
+	cases := []fkMultiCase{
+		{
+			id: "aig-fk-implicit-backing",
+			fromSQL: "CREATE TABLE p (id INT NOT NULL PRIMARY KEY); " +
+				"CREATE TABLE c (id INT NOT NULL PRIMARY KEY, x INT)",
+			toSQL: "CREATE TABLE p (id INT NOT NULL PRIMARY KEY); " +
+				"CREATE TABLE c (id INT NOT NULL PRIMARY KEY, x INT, seq INT NOT NULL AUTO_INCREMENT, " +
+				"CONSTRAINT fk_seq FOREIGN KEY (seq) REFERENCES p (id))",
+			tables:   []string{"p", "c"},
+			versions: both(),
+		},
+		// DROP direction of the FK-implicit form: the auto column's only covering key is the
+		// FK's backing index and both the FK and the column leave — the FK node's leftover
+		// DROP INDEX must join the DROP COLUMN statement (after the constraint drop released
+		// the index, errno 1553; ungrouped it fails errno 1075).
+		{
+			id: "aig-fk-implicit-backing-drop",
+			fromSQL: "CREATE TABLE p (id INT NOT NULL PRIMARY KEY); " +
+				"CREATE TABLE c (id INT NOT NULL PRIMARY KEY, x INT, seq INT NOT NULL AUTO_INCREMENT, " +
+				"CONSTRAINT fk_seq FOREIGN KEY (seq) REFERENCES p (id))",
+			toSQL: "CREATE TABLE p (id INT NOT NULL PRIMARY KEY); " +
+				"CREATE TABLE c (id INT NOT NULL PRIMARY KEY, x INT)",
+			tables:   []string{"p", "c"},
+			versions: both(),
+		},
 	}
 	for _, version := range both() {
 		o := connectOracle(t, version)
 		n := NormalizerFor(version)
-		t.Run(fmt.Sprintf("%s/%s", o.name, mc.id), func(t *testing.T) {
-			assertFKMultiApplyCorrect(t, o, n, mc)
-		})
+		for _, mc := range cases {
+			t.Run(fmt.Sprintf("%s/%s", o.name, mc.id), func(t *testing.T) {
+				assertFKMultiApplyCorrect(t, o, n, mc)
+			})
+		}
 	}
 }

--- a/mysql/catalog/migration_autoinc_oracle_test.go
+++ b/mysql/catalog/migration_autoinc_oracle_test.go
@@ -95,6 +95,13 @@ func autoIncMigrationProbes() []migrationProbe {
 		{"aig-myisam-shared-key-ai-migrate", "t",
 			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c1 INT NOT NULL AUTO_INCREMENT, c2 INT NOT NULL, KEY k (c1, c2)) ENGINE=MyISAM",
 			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c2 INT NOT NULL AUTO_INCREMENT, KEY k2 (c2)) ENGINE=MyISAM", both()},
+		// Same shared-key shape but the old auto column SURVIVES (de-AUTO_INCREMENTed): the
+		// shared key's drop folds into a's MODIFY, which is pulled into b's gaining statement —
+		// the drop then executes IN that statement, so the replacement key must join it too
+		// (4-clause statement; the 3-clause form without the new key fails errno 1075, probed).
+		{"aig-myisam-shared-key-ai-migrate-survive", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT NOT NULL AUTO_INCREMENT, b INT NOT NULL, KEY k (a, b)) ENGINE=MyISAM",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT NOT NULL, b INT NOT NULL AUTO_INCREMENT, KEY k2 (b)) ENGINE=MyISAM", both()},
 		// 8.0-only backing-key shapes that still satisfy errno 1075 (probed): DESC first column,
 		// INVISIBLE index, and a trailing functional part behind the plain first column.
 		{"aig-add-col-desc-key", "t",

--- a/mysql/catalog/migration_autoinc_oracle_test.go
+++ b/mysql/catalog/migration_autoinc_oracle_test.go
@@ -186,6 +186,33 @@ func autoIncMigrationProbes() []migrationProbe {
 		{"aig-generated-keypart-pullin", "t",
 			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
 			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, seq INT NOT NULL AUTO_INCREMENT, d INT NOT NULL, g INT GENERATED ALWAYS AS (d+1) VIRTUAL, UNIQUE KEY uk_sg (seq, g))", both()},
+		// PR-review scenarios (bot P2s on #364), each proven end-to-end on both engines:
+		// A FUNCTIONAL key part references a column added in the same plan that sorts after the
+		// auto column: its ADD must be pulled into the grouped statement (errno 1054 otherwise).
+		{"aig-funcpart-new-col", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, seq INT NOT NULL AUTO_INCREMENT, z INT, KEY k_sz (seq, (z + 1)))", only(MySQL80)},
+		// A PREFIX key part over an existing column widened in the same plan: the widening
+		// MODIFY must join the grouped statement (errno 1089 against the old length otherwise;
+		// in one statement MySQL validates against the post-MODIFY shape).
+		{"aig-prefix-over-widened", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v VARCHAR(100))",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v VARCHAR(500), seq INT NOT NULL AUTO_INCREMENT, KEY k_sv (seq, v(300)))", both()},
+		// REFUTED-claim pins (reviewer scenarios that pass without special handling):
+		// dropping a composite-PK member column SHRINKS the PK (it never auto-removes a PK the
+		// auto column remains a member of), so the grouped DROP PRIMARY KEY still finds a PK.
+		{"aig-pk-drop-member-drop-newkey", "t",
+			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, PRIMARY KEY (id, a))",
+			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT, KEY k_id (id))", both()},
+		{"aig-pk-shrink-member-drop", "t",
+			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, PRIMARY KEY (id, a))",
+			"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id))", both()},
+		// A pulled generated key part whose BASE column is widened in the same plan: MySQL
+		// permits adding the generated column against the old base type and widening it after
+		// (order-free, probed), so no base-MODIFY pull is required for convergence.
+		{"aig-genpart-base-widened", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, z INT)",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, z BIGINT, seq INT NOT NULL AUTO_INCREMENT, g INT GENERATED ALWAYS AS (z + 1) VIRTUAL, UNIQUE KEY uk_sg (seq, g))", both()},
 		// The AUTO_INCREMENT column keeps its attribute but is REDEFINED (type widen) while the
 		// backing key is reshaped in the same plan: the widen MODIFY stays its own statement
 		// (still covered by the old key) and the reshape is grouped.
@@ -285,6 +312,19 @@ func TestOracle_AutoIncGroupingFKImplicitBacking(t *testing.T) {
 				"CONSTRAINT fk_seq FOREIGN KEY (seq) REFERENCES p (id))",
 			toSQL: "CREATE TABLE p (id INT NOT NULL PRIMARY KEY); " +
 				"CREATE TABLE c (id INT NOT NULL PRIMARY KEY, x INT)",
+			tables:   []string{"p", "c"},
+			versions: both(),
+		},
+		// An FK re-pointed from an old column to a NEW auto column KEEPING its constraint name
+		// (PR-review scenario): the old implicit backing index of the SAME name is dropped in
+		// PhasePre, so the name is free again and the backing synthesis must not be blocked by
+		// its mere presence on the from side (errno 1075 ungrouped).
+		{
+			id: "aig-fk-rename-in-place-to-ai",
+			fromSQL: "CREATE TABLE p (id INT NOT NULL PRIMARY KEY); " +
+				"CREATE TABLE c (id INT NOT NULL PRIMARY KEY, old_id INT, CONSTRAINT fk FOREIGN KEY (old_id) REFERENCES p (id))",
+			toSQL: "CREATE TABLE p (id INT NOT NULL PRIMARY KEY); " +
+				"CREATE TABLE c (id INT NOT NULL PRIMARY KEY, old_id INT, seq INT NOT NULL AUTO_INCREMENT, CONSTRAINT fk FOREIGN KEY (seq) REFERENCES p (id))",
 			tables:   []string{"p", "c"},
 			versions: both(),
 		},

--- a/mysql/catalog/migration_autoinc_oracle_test.go
+++ b/mysql/catalog/migration_autoinc_oracle_test.go
@@ -1,0 +1,250 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle proof for the AUTO_INCREMENT / backing-key ALTER grouping (migration_autoinc.go),
+// against the LIVE MySQL engines (5.7.25 and 8.0.32 — identical errno-1075 behavior, probed
+// 2026-07). MySQL enforces, at the END OF EVERY STATEMENT, that a table has at most one
+// AUTO_INCREMENT column and that this column is the FIRST column of some index (errno 1075;
+// MyISAM alone also accepts a non-first position). A plan that adds an AUTO_INCREMENT column in
+// one ALTER and its backing key in the next therefore fails on the FIRST statement — the column
+// and its key must land in the SAME statement. These probes cover every grouping form the merge
+// pass emits (correctness-protocol.md gate 2: each generated plan, applied to a real `from`
+// database, must yield `to`), plus the no-merge control cases that must keep working ungrouped.
+//
+// The idempotence gate (gate 1) for the same forms is TestOracle_AutoIncGroupingIdempotence:
+// every `to` schema, read back from the engine, must self-plan to an empty migration.
+//
+// The harness reuses assertApplyCorrect / connectOracle / both / only from
+// migration_oracle_test.go and skips cleanly when the engines are unreachable.
+func autoIncMigrationProbes() []migrationProbe {
+	return []migrationProbe{
+		// ---- ADD direction: AUTO_INCREMENT column arrives without a pre-existing key ----
+
+		// The headline bug: adding an AUTO_INCREMENT column plus its UNIQUE backing key to an
+		// existing table. Ungrouped, the ADD COLUMN statement fails errno 1075.
+		{"aig-add-col-uk", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT, seq BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_seq (seq))", both()},
+		// A plain (non-unique) KEY also satisfies errno 1075.
+		{"aig-add-col-plain-key", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT, seq BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, KEY k_seq (seq))", both()},
+		// AUTO_INCREMENT column + new PRIMARY KEY on a table that had none.
+		{"aig-add-col-new-pk", "t",
+			"CREATE TABLE t (id INT NOT NULL, a INT)",
+			"CREATE TABLE t (id INT NOT NULL, a INT, seq BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, PRIMARY KEY (seq))", both()},
+		// Surrogate-key promotion: the new AUTO_INCREMENT column REPLACES an existing natural PK.
+		// The column add must join the combined DROP PRIMARY KEY / ADD PRIMARY KEY statement.
+		{"aig-add-col-promote-pk", "t",
+			"CREATE TABLE t (a INT NOT NULL PRIMARY KEY, b INT)",
+			"CREATE TABLE t (a INT NOT NULL, b INT, seq BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, PRIMARY KEY (seq))", both()},
+		// Surrogate-key promotion where the old PK member is ALSO dropped (forces the split PK
+		// path): the column add merges with the standalone ADD PRIMARY KEY instead.
+		{"aig-add-col-promote-pk-drop-old", "t",
+			"CREATE TABLE t (a INT NOT NULL PRIMARY KEY, b INT)",
+			"CREATE TABLE t (b INT, seq BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, PRIMARY KEY (seq))", both()},
+		// An EXISTING column gains AUTO_INCREMENT while its backing key arrives in the same plan.
+		{"aig-modify-gain-ai-new-key", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL)",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_c (c))", both()},
+		// CONTROL: gaining AUTO_INCREMENT on a column that is ALREADY keyed needs no grouping and
+		// must keep working as a single MODIFY.
+		{"aig-modify-gain-ai-existing-key", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL, UNIQUE KEY uk_c (c))",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_c (c))", both()},
+		// Composite backing key whose OTHER member is also added in this plan: the second column's
+		// add is pulled into the grouped statement so the key can reference it.
+		{"aig-add-col-composite-backing", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, seq BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, d INT NOT NULL, UNIQUE KEY uk_sd (seq, d))", both()},
+		// AUTO_INCREMENT migrates between EXISTING columns (both already keyed): the old column's
+		// de-AUTO_INCREMENT MODIFY must share the statement that makes the new column
+		// AUTO_INCREMENT (errno 1075's "only one auto column" half fires between two statements).
+		{"aig-ai-migrate-columns", "t",
+			"CREATE TABLE t (a INT NOT NULL AUTO_INCREMENT, b INT NOT NULL, UNIQUE KEY uk_a (a), UNIQUE KEY uk_b (b))",
+			"CREATE TABLE t (a INT NOT NULL, b INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_a (a), UNIQUE KEY uk_b (b))", both()},
+		// AUTO_INCREMENT migrates from an existing column to a NEW column (new backing key too).
+		{"aig-ai-migrate-to-new-col", "t",
+			"CREATE TABLE t (a INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_a (a))",
+			"CREATE TABLE t (a INT NOT NULL, b INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_a (a), UNIQUE KEY uk_b (b))", both()},
+		// AUTO_INCREMENT column + backing key grouped while UNRELATED changes ride along in the
+		// same plan (they must stay separate statements, unharmed).
+		{"aig-add-col-with-other-changes", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT, e VARCHAR(10))",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT, e VARCHAR(20), f INT, seq BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_seq (seq))", both()},
+		// MyISAM accepts a NON-first position in a multi-column key as the backing (probed: OK on
+		// MyISAM, errno 1075 on InnoDB/MEMORY) — the grouping must still fire for it.
+		{"aig-myisam-add-nonleftmost", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT NOT NULL) ENGINE=MyISAM",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT NOT NULL, seq INT NOT NULL AUTO_INCREMENT, KEY k_as (a, seq)) ENGINE=MyISAM", both()},
+		// CONTROL: MyISAM column gaining AUTO_INCREMENT backed by an EXISTING non-first-position
+		// key needs no grouping (probed OK on both versions).
+		{"aig-myisam-gain-ai-existing-nonleftmost", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT NOT NULL, c INT NOT NULL, KEY k (a, c)) ENGINE=MyISAM",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT NOT NULL, c INT NOT NULL AUTO_INCREMENT, KEY k (a, c)) ENGINE=MyISAM", both()},
+		// 8.0-only backing-key shapes that still satisfy errno 1075 (probed): DESC first column,
+		// INVISIBLE index, and a trailing functional part behind the plain first column.
+		{"aig-add-col-desc-key", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, seq INT NOT NULL AUTO_INCREMENT, KEY k_seq (seq DESC))", only(MySQL80)},
+		{"aig-add-col-invisible-key", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY)",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, seq INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_seq (seq) INVISIBLE)", only(MySQL80)},
+		{"aig-add-col-trailing-expr-key", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT)",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT, seq INT NOT NULL AUTO_INCREMENT, KEY k_se (seq, (a + 1)))", only(MySQL80)},
+
+		// ---- DROP direction: the last backing key leaves while the column is AUTO_INCREMENT ----
+
+		// The AUTO_INCREMENT column and its backing key are dropped together: the DROP INDEX must
+		// share the DROP COLUMN statement (ungrouped, the PhasePre DROP INDEX fails errno 1075).
+		{"aig-drop-key-and-column", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_c (c))",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY)", both()},
+		// The column loses AUTO_INCREMENT and its backing key is dropped: the DROP INDEX must
+		// share the de-AUTO_INCREMENT MODIFY statement.
+		{"aig-drop-key-deai", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_c (c))",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL)", both()},
+		// The backing key is RESHAPED (same name) while the column stays AUTO_INCREMENT: the
+		// DROP INDEX must share the re-ADD statement — the secondary-key analog of the combined
+		// PRIMARY KEY change.
+		{"aig-replace-backing-key", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, UNIQUE KEY uk_c (c))",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, UNIQUE KEY uk_c (c, a))", both()},
+		// The backing key is SWAPPED for a differently named one while the column stays
+		// AUTO_INCREMENT.
+		{"aig-swap-backing-key", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_c (c))",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, KEY k_c (c))", both()},
+		// Several covering keys all drop while a new one arrives: every covering drop joins the
+		// covering add's statement.
+		{"aig-multi-drop-plus-add", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk1 (c), KEY k2 (c))",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk3 (c))", both()},
+		// CONTROL: dropping ONE of several covering keys needs no grouping — another key still
+		// covers the column at every statement boundary.
+		{"aig-drop-covered-elsewhere", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk1 (c), KEY k2 (c))",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, KEY k2 (c))", both()},
+		// The PRIMARY KEY backs the AUTO_INCREMENT column and both leave: DROP PRIMARY KEY joins
+		// the DROP COLUMN statement.
+		{"aig-drop-pk-and-column", "t",
+			"CREATE TABLE t (c INT NOT NULL AUTO_INCREMENT PRIMARY KEY, a INT NOT NULL)",
+			"CREATE TABLE t (a INT NOT NULL)", both()},
+		// The PRIMARY KEY leaves and the column loses AUTO_INCREMENT: DROP PRIMARY KEY joins the
+		// MODIFY statement.
+		{"aig-drop-pk-deai", "t",
+			"CREATE TABLE t (c INT NOT NULL AUTO_INCREMENT PRIMARY KEY, a INT)",
+			"CREATE TABLE t (c INT NOT NULL, a INT)", both()},
+		// A COMPOSITE PK (AUTO_INCREMENT column first) leaves together with the column.
+		{"aig-drop-composite-pk-and-column", "t",
+			"CREATE TABLE t (c INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, PRIMARY KEY (c, a))",
+			"CREATE TABLE t (a INT NOT NULL)", both()},
+		// The PK moves ONTO the AUTO_INCREMENT column while its old secondary backing key drops:
+		// the covering drop joins the combined DROP+ADD PRIMARY KEY statement.
+		{"aig-pk-swap-drop-secondary", "t",
+			"CREATE TABLE t (x INT NOT NULL, c INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_c (c), PRIMARY KEY (x))",
+			"CREATE TABLE t (x INT NOT NULL, c INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (c))", both()},
+		// The AUTO_INCREMENT column keeps its attribute but is REDEFINED (type widen) while the
+		// backing key is reshaped in the same plan: the widen MODIFY stays its own statement
+		// (still covered by the old key) and the reshape is grouped.
+		{"aig-widen-ai-key-replaced", "t",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, UNIQUE KEY uk_c (c))",
+			"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c BIGINT NOT NULL AUTO_INCREMENT, a INT NOT NULL, UNIQUE KEY uk_c (c, a))", both()},
+	}
+}
+
+// TestOracle_AutoIncGroupingApplyCorrectness proves gate 2 for every grouping form: the
+// generated plan, applied statement-by-statement to a real `from` database, must yield `to`.
+// Before the merge pass, the hazard probes fail on the first ungrouped statement (errno 1075).
+func TestOracle_AutoIncGroupingApplyCorrectness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, probe := range autoIncMigrationProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				assertApplyCorrect(t, o, n, probe)
+			})
+		}
+	}
+}
+
+// TestOracle_AutoIncGroupingIdempotence proves gate 1 for the same forms: each `to` schema,
+// loaded from the engine's own readback, must self-plan to an EMPTY migration (the merge pass
+// must never manufacture ops on a no-op release), and the user-form round-trip must be empty.
+func TestOracle_AutoIncGroupingIdempotence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, probe := range autoIncMigrationProbes() {
+			if !containsVersion(probe.versions, version) || strings.TrimSpace(probe.toDDL) == "" {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				dbName := "aig_idem_" + strings.ReplaceAll(probe.id, "-", "_")
+				cat, _, rb, ok := o.catalogFromReadback(t, dbName, probe.toDDL, probe.table)
+				if !ok {
+					t.Skipf("[%s] could not obtain readback for %s", o.name, probe.id)
+				}
+				diff := DiffWithNormalizer(cat, cat, n)
+				plan := GenerateMigrationWithNormalizer(cat, cat, diff, n)
+				if plan.SQL() != "" {
+					t.Errorf("[%s] NON-EMPTY NO-OP PLAN for %s:\n  stored: %s\n  plan:\n%s",
+						o.name, probe.id, strings.TrimSpace(rb), plan.SQL())
+				}
+				userCat, _ := loadOneTable(t, serverCharsetFor(o.version), probe.toDDL, probe.table)
+				rtDiff := DiffWithNormalizer(userCat, cat, n)
+				rtPlan := GenerateMigrationWithNormalizer(userCat, cat, rtDiff, n)
+				if rtPlan.SQL() != "" {
+					t.Errorf("[%s] NON-EMPTY ROUND-TRIP PLAN for %s:\n  user:   %s\n  stored: %s\n  plan:\n%s",
+						o.name, probe.id, strings.TrimSpace(probe.toDDL), strings.TrimSpace(rb), rtPlan.SQL())
+				}
+			})
+		}
+	}
+}
+
+// TestOracle_AutoIncGroupingFKImplicitBacking proves the FK-implicit last-resort form on the
+// ALTER path (the analog of formatCreateTable's last-resort inline): an AUTO_INCREMENT column
+// added together with a FOREIGN KEY on it — and no user key — must have the FK's backing index
+// synthesized into the grouped ADD COLUMN statement; the deferred PhasePost FK then reuses that
+// index instead of auto-creating a duplicate (probed live: both versions accept the sequence).
+func TestOracle_AutoIncGroupingFKImplicitBacking(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	mc := fkMultiCase{
+		id: "aig-fk-implicit-backing",
+		fromSQL: "CREATE TABLE p (id INT NOT NULL PRIMARY KEY); " +
+			"CREATE TABLE c (id INT NOT NULL PRIMARY KEY, x INT)",
+		toSQL: "CREATE TABLE p (id INT NOT NULL PRIMARY KEY); " +
+			"CREATE TABLE c (id INT NOT NULL PRIMARY KEY, x INT, seq INT NOT NULL AUTO_INCREMENT, " +
+			"CONSTRAINT fk_seq FOREIGN KEY (seq) REFERENCES p (id))",
+		tables:   []string{"p", "c"},
+		versions: both(),
+	}
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		t.Run(fmt.Sprintf("%s/%s", o.name, mc.id), func(t *testing.T) {
+			assertFKMultiApplyCorrect(t, o, n, mc)
+		})
+	}
+}

--- a/mysql/catalog/migration_autoinc_test.go
+++ b/mysql/catalog/migration_autoinc_test.go
@@ -236,6 +236,83 @@ func TestAutoIncGrouping_Determinism(t *testing.T) {
 	requireOneStatementWith(t, p, "DROP INDEX `uk1`", "DROP INDEX `k2`", "ADD UNIQUE KEY `uk3` (`c`)")
 }
 
+func TestAutoIncGrouping_PKRelocateToSecondary(t *testing.T) {
+	// The PK moves off the auto column onto b while a NEW secondary key (name sorting AFTER
+	// "primary") takes over the coverage: split DROP PRIMARY KEY, the covering ADD KEY, and the
+	// replacement ADD PRIMARY KEY must share ONE statement — a standalone ADD PRIMARY KEY would
+	// sort before it and run while the old PK still exists (errno 1068).
+	p := aigPlan(t,
+		"CREATE TABLE t (c INT NOT NULL AUTO_INCREMENT, b INT NOT NULL, x INT, PRIMARY KEY (c));",
+		"CREATE TABLE t (c INT NOT NULL AUTO_INCREMENT, b INT NOT NULL, x INT, PRIMARY KEY (b), KEY zz_c (c));")
+	op := requireOneStatementWith(t, p, "DROP PRIMARY KEY", "ADD KEY `zz_c` (`c`)", "ADD PRIMARY KEY (`b`)")
+	if len(p.Ops) != 1 {
+		t.Errorf("want 1 grouped op, got %d:\n%s", len(p.Ops), p.SQL())
+	}
+	if strings.Count(op.SQL, "PRIMARY KEY") != 2 {
+		t.Errorf("statement must carry exactly the drop and one re-add: %s", op.SQL)
+	}
+}
+
+func TestAutoIncGrouping_DemotedMemberJoinsPKStatement(t *testing.T) {
+	// The auto column keeps the shrinking PK while another old-PK member is demoted to
+	// nullable: the demoting MODIFY joins the grouped DROP+ADD PRIMARY KEY statement (errno
+	// 1171 if it ran earlier, errno 1075 if the PK drop ran alone).
+	p := aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, PRIMARY KEY (id, a));",
+		"CREATE TABLE t (id INT NOT NULL AUTO_INCREMENT, a INT NULL, PRIMARY KEY (id));")
+	requireOneStatementWith(t, p, "DROP PRIMARY KEY", "ADD PRIMARY KEY (`id`)", "MODIFY COLUMN `a`")
+	if len(p.Ops) != 1 {
+		t.Errorf("want 1 grouped op, got %d:\n%s", len(p.Ops), p.SQL())
+	}
+}
+
+func TestAutoIncGrouping_GeneratedKeyPartPullsPlainAdds(t *testing.T) {
+	// A generated key part g rides in the backing key and references a new plain column d that
+	// is NOT itself a key part: d's ADD must be pulled into the grouped statement before g's.
+	p := aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY);",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, seq INT NOT NULL AUTO_INCREMENT, d INT NOT NULL, g INT GENERATED ALWAYS AS (d+1) VIRTUAL, UNIQUE KEY uk_sg (seq, g));")
+	op := requireOneStatementWith(t, p, "ADD COLUMN `seq`", "ADD COLUMN `d`", "ADD COLUMN `g`", "ADD UNIQUE KEY `uk_sg`")
+	if strings.Index(op.SQL, "ADD COLUMN `d`") > strings.Index(op.SQL, "ADD COLUMN `g`") {
+		t.Errorf("plain add must precede the generated add that references it: %s", op.SQL)
+	}
+	if len(p.Ops) != 1 {
+		t.Errorf("want 1 grouped op, got %d:\n%s", len(p.Ops), p.SQL())
+	}
+}
+
+func TestAutoIncGrouping_FKBackingDropJoinsColumnDrop(t *testing.T) {
+	// The AUTO_INCREMENT column's only covering key is the FK-implicit backing index and both
+	// the FK and the column leave: the FK node's leftover DROP INDEX (PhasePre, before column
+	// drops) would strand the still-AUTO_INCREMENT column, so its clause must join the DROP
+	// COLUMN statement — and it must NOT vanish from the plan when consumed.
+	p := aigPlan(t,
+		"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, CONSTRAINT fk_c FOREIGN KEY (c) REFERENCES p (id));",
+		"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE t (id INT NOT NULL PRIMARY KEY);")
+	op := requireOneStatementWith(t, p, "DROP INDEX `fk_c`", "DROP COLUMN `c`")
+	if op.Phase != PhasePre {
+		t.Errorf("grouped drop must stay in PhasePre, got %d", op.Phase)
+	}
+	// The FK constraint drop stays its own earlier statement.
+	requireOneStatementWith(t, p, "DROP FOREIGN KEY `fk_c`")
+	// No DROP INDEX clause may be lost: exactly one occurrence across the whole plan.
+	if got := strings.Count(p.SQL(), "DROP INDEX `fk_c`"); got != 1 {
+		t.Errorf("want the backing DROP INDEX exactly once in the plan, got %d:\n%s", got, p.SQL())
+	}
+}
+
+func TestAutoIncGrouping_MyISAMSharedKeyAIMigration(t *testing.T) {
+	// MyISAM corner: the composite key covers BOTH the old and the new auto column (any-position
+	// rule). The old column and the shared key drop in PhasePre, so the gaining MODIFY must
+	// still be grouped with the NEW backing key — a consumed covering drop that lands in a
+	// PhasePre statement does not keep covering PhaseMain.
+	p := aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c1 INT NOT NULL AUTO_INCREMENT, c2 INT NOT NULL, KEY k (c1, c2)) ENGINE=MyISAM;",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c2 INT NOT NULL AUTO_INCREMENT, KEY k2 (c2)) ENGINE=MyISAM;")
+	requireOneStatementWith(t, p, "DROP INDEX `k`", "DROP COLUMN `c1`")
+	requireOneStatementWith(t, p, "MODIFY COLUMN `c2`", "ADD KEY `k2` (`c2`)")
+}
+
 func TestAutoIncGrouping_IdempotenceHermetic(t *testing.T) {
 	// Self-diff of every grouped target form stays an empty plan under both normalizers.
 	schemas := []string{

--- a/mysql/catalog/migration_autoinc_test.go
+++ b/mysql/catalog/migration_autoinc_test.go
@@ -1,0 +1,255 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+)
+
+// Hermetic plan-shape tests for the AUTO_INCREMENT / backing-key ALTER grouping
+// (migration_autoinc.go). They assert WHICH clauses share a statement and how the surrounding
+// ops are (not) disturbed; the live-engine proof that the grouped statements are the forms
+// MySQL accepts is migration_autoinc_oracle_test.go.
+
+// aigPlan diffs two single-table schemas (already wrapped in dbDDL) and returns the plan under
+// the 8.0 normalizer.
+func aigPlan(t *testing.T, fromDDL, toDDL string) *MigrationPlan {
+	t.Helper()
+	return planFor(t, dbDDL+fromDDL, dbDDL+toDDL, NormalizerFor(MySQL80))
+}
+
+// opsContaining returns the plan ops whose SQL contains every fragment.
+func opsContaining(p *MigrationPlan, fragments ...string) []MigrationOp {
+	var out []MigrationOp
+	for _, op := range p.Ops {
+		all := true
+		for _, f := range fragments {
+			if !strings.Contains(op.SQL, f) {
+				all = false
+				break
+			}
+		}
+		if all {
+			out = append(out, op)
+		}
+	}
+	return out
+}
+
+// requireOneStatementWith asserts exactly one op carries ALL fragments (i.e. they were grouped
+// into one statement) and returns it.
+func requireOneStatementWith(t *testing.T, p *MigrationPlan, fragments ...string) MigrationOp {
+	t.Helper()
+	got := opsContaining(p, fragments...)
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 statement containing %q, got %d:\n%s", fragments, len(got), p.SQL())
+	}
+	return got[0]
+}
+
+func TestAutoIncGrouping_AddColumnWithUniqueKey(t *testing.T) {
+	p := aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT);",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT, seq BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_seq (seq));")
+	if len(p.Ops) != 1 {
+		t.Fatalf("want 1 grouped op, got %d:\n%s", len(p.Ops), p.SQL())
+	}
+	op := p.Ops[0]
+	for _, frag := range []string{"ADD COLUMN `seq`", "AUTO_INCREMENT", "ADD UNIQUE KEY `uk_seq` (`seq`)"} {
+		if !strings.Contains(op.SQL, frag) {
+			t.Errorf("grouped statement missing %q:\n%s", frag, op.SQL)
+		}
+	}
+	if op.Type != OpAddColumn || op.Phase != PhaseMain || op.Priority != priorityColumn {
+		t.Errorf("grouped op keeps the column op identity; got type=%s phase=%d prio=%d", op.Type, op.Phase, op.Priority)
+	}
+}
+
+func TestAutoIncGrouping_AddColumnWithPlainKeyAndNewPK(t *testing.T) {
+	// Plain KEY backing.
+	p := aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT);",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT, seq INT NOT NULL AUTO_INCREMENT, KEY k_seq (seq));")
+	requireOneStatementWith(t, p, "ADD COLUMN `seq`", "ADD KEY `k_seq` (`seq`)")
+
+	// New PRIMARY KEY backing on a PK-less table.
+	p = aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL, a INT);",
+		"CREATE TABLE t (id INT NOT NULL, a INT, seq INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (seq));")
+	requireOneStatementWith(t, p, "ADD COLUMN `seq`", "ADD PRIMARY KEY (`seq`)")
+}
+
+func TestAutoIncGrouping_PromotePKCombined(t *testing.T) {
+	// The new AUTO_INCREMENT column replaces a natural PK: the column add joins the combined
+	// DROP PRIMARY KEY / ADD PRIMARY KEY statement (three clauses, one statement).
+	p := aigPlan(t,
+		"CREATE TABLE t (a INT NOT NULL PRIMARY KEY, b INT);",
+		"CREATE TABLE t (a INT NOT NULL, b INT, seq INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (seq));")
+	requireOneStatementWith(t, p, "ADD COLUMN `seq`", "DROP PRIMARY KEY", "ADD PRIMARY KEY (`seq`)")
+}
+
+func TestAutoIncGrouping_ModifyGainAI(t *testing.T) {
+	// Backing key arrives in the same plan: grouped.
+	p := aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL);",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_c (c));")
+	requireOneStatementWith(t, p, "MODIFY COLUMN `c`", "AUTO_INCREMENT", "ADD UNIQUE KEY `uk_c` (`c`)")
+
+	// CONTROL: column already keyed — single ungrouped MODIFY.
+	p = aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL, UNIQUE KEY uk_c (c));",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_c (c));")
+	op := onlyOp(t, p)
+	if !strings.Contains(op.SQL, "MODIFY COLUMN `c`") || strings.Contains(op.SQL, "ADD") {
+		t.Errorf("already-keyed gain must stay a bare MODIFY: %s", op.SQL)
+	}
+}
+
+func TestAutoIncGrouping_CompositeBackingPullsSecondColumn(t *testing.T) {
+	p := aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY);",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, seq INT NOT NULL AUTO_INCREMENT, d INT NOT NULL, UNIQUE KEY uk_sd (seq, d));")
+	op := requireOneStatementWith(t, p, "ADD COLUMN `seq`", "ADD COLUMN `d`", "ADD UNIQUE KEY `uk_sd` (`seq`,`d`)")
+	// The key clause must come after both column clauses it references.
+	if strings.Index(op.SQL, "ADD UNIQUE KEY") < strings.Index(op.SQL, "ADD COLUMN `d`") {
+		t.Errorf("key clause must follow the pulled column clause: %s", op.SQL)
+	}
+	if len(p.Ops) != 1 {
+		t.Errorf("want 1 grouped op, got %d:\n%s", len(p.Ops), p.SQL())
+	}
+}
+
+func TestAutoIncGrouping_AIMigratesBetweenColumns(t *testing.T) {
+	// Both columns stay keyed; the de-AUTO_INCREMENT of `a` must share the statement that makes
+	// `b` AUTO_INCREMENT (two statements would momentarily hold two auto columns — errno 1075).
+	p := aigPlan(t,
+		"CREATE TABLE t (a INT NOT NULL AUTO_INCREMENT, b INT NOT NULL, UNIQUE KEY uk_a (a), UNIQUE KEY uk_b (b));",
+		"CREATE TABLE t (a INT NOT NULL, b INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_a (a), UNIQUE KEY uk_b (b));")
+	op := requireOneStatementWith(t, p, "MODIFY COLUMN `a`", "MODIFY COLUMN `b`", "AUTO_INCREMENT")
+	// The de-AI clause precedes the gain clause.
+	if strings.Index(op.SQL, "MODIFY COLUMN `a`") > strings.Index(op.SQL, "MODIFY COLUMN `b`") {
+		t.Errorf("de-AUTO_INCREMENT clause must precede the gaining clause: %s", op.SQL)
+	}
+	if len(p.Ops) != 1 {
+		t.Errorf("want 1 grouped op, got %d:\n%s", len(p.Ops), p.SQL())
+	}
+}
+
+func TestAutoIncGrouping_DropDirection(t *testing.T) {
+	// Column + backing key dropped together: one statement, in PhasePre at the column drop slot.
+	p := aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_c (c));",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY);")
+	op := requireOneStatementWith(t, p, "DROP INDEX `uk_c`", "DROP COLUMN `c`")
+	if op.Phase != PhasePre {
+		t.Errorf("grouped drop must stay in PhasePre, got %d", op.Phase)
+	}
+
+	// De-AUTO_INCREMENT + backing key drop: one statement.
+	p = aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_c (c));",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL);")
+	requireOneStatementWith(t, p, "MODIFY COLUMN `c`", "DROP INDEX `uk_c`")
+
+	// Backing key reshaped (same name), column stays AUTO_INCREMENT: DROP+ADD in one statement.
+	p = aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, UNIQUE KEY uk_c (c));",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, UNIQUE KEY uk_c (c, a));")
+	requireOneStatementWith(t, p, "DROP INDEX `uk_c`", "ADD UNIQUE KEY `uk_c` (`c`,`a`)")
+
+	// PRIMARY KEY backing dropped with the column.
+	p = aigPlan(t,
+		"CREATE TABLE t (c INT NOT NULL AUTO_INCREMENT PRIMARY KEY, a INT NOT NULL);",
+		"CREATE TABLE t (a INT NOT NULL);")
+	requireOneStatementWith(t, p, "DROP PRIMARY KEY", "DROP COLUMN `c`")
+
+	// PRIMARY KEY dropped, column de-AUTO_INCREMENTed.
+	p = aigPlan(t,
+		"CREATE TABLE t (c INT NOT NULL AUTO_INCREMENT PRIMARY KEY, a INT);",
+		"CREATE TABLE t (c INT NOT NULL, a INT);")
+	requireOneStatementWith(t, p, "MODIFY COLUMN `c`", "DROP PRIMARY KEY")
+}
+
+func TestAutoIncGrouping_DropControls(t *testing.T) {
+	// CONTROL: another key still covers the column — the drop stays a lone statement.
+	p := aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk1 (c), KEY k2 (c));",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, KEY k2 (c));")
+	op := onlyOp(t, p)
+	if op.SQL != "ALTER TABLE `app`.`t` DROP INDEX `uk1`" {
+		t.Errorf("covered-elsewhere drop must stay ungrouped: %s", op.SQL)
+	}
+
+	// CONTROL: dropping a key on a non-AUTO_INCREMENT column is untouched.
+	p = aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL, UNIQUE KEY uk_c (c));",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL);")
+	op = onlyOp(t, p)
+	if op.SQL != "ALTER TABLE `app`.`t` DROP INDEX `uk_c`" {
+		t.Errorf("non-AUTO_INCREMENT key drop must stay ungrouped: %s", op.SQL)
+	}
+}
+
+func TestAutoIncGrouping_MyISAMNonLeftmostBacking(t *testing.T) {
+	// MyISAM accepts a non-first key position as backing (oracle-probed), so the grouping fires
+	// with the (a, seq) key.
+	p := aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT NOT NULL) ENGINE=MyISAM;",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT NOT NULL, seq INT NOT NULL AUTO_INCREMENT, KEY k_as (a, seq)) ENGINE=MyISAM;")
+	requireOneStatementWith(t, p, "ADD COLUMN `seq`", "ADD KEY `k_as` (`a`,`seq`)")
+
+	// InnoDB requires the FIRST position (oracle-probed): a non-leftmost key is NOT a backing
+	// candidate, so no grouping happens and the plan is left to fail naturally on an invalid
+	// target (matching the CREATE path's stance on unkeyable AUTO_INCREMENT columns).
+	p = aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT NOT NULL);",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT NOT NULL, seq INT NOT NULL AUTO_INCREMENT, KEY k_as (a, seq));")
+	if got := opsContaining(p, "ADD COLUMN `seq`", "ADD KEY"); len(got) != 0 {
+		t.Errorf("InnoDB non-leftmost key must not be grouped as backing:\n%s", p.SQL())
+	}
+}
+
+func TestAutoIncGrouping_UnrelatedOpsUndisturbed(t *testing.T) {
+	p := aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT, e VARCHAR(10)); CREATE TABLE u (x INT NOT NULL PRIMARY KEY, y INT);",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT, e VARCHAR(20), f INT, seq INT NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_seq (seq)); CREATE TABLE u (x INT NOT NULL PRIMARY KEY, y BIGINT);")
+	requireOneStatementWith(t, p, "ADD COLUMN `seq`", "ADD UNIQUE KEY `uk_seq`")
+	// The unrelated t changes and the u change remain their own statements.
+	requireOneStatementWith(t, p, "MODIFY COLUMN `e` varchar(20)")
+	fOp := requireOneStatementWith(t, p, "ADD COLUMN `f`")
+	if strings.Contains(fOp.SQL, "seq") {
+		t.Errorf("unrelated column add must not be pulled into the group: %s", fOp.SQL)
+	}
+	requireOneStatementWith(t, p, "MODIFY COLUMN `y` bigint")
+}
+
+func TestAutoIncGrouping_Determinism(t *testing.T) {
+	fromDDL := "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, UNIQUE KEY uk1 (c), KEY k2 (c));"
+	toDDL := "CREATE TABLE t (id INT NOT NULL PRIMARY KEY, c INT NOT NULL AUTO_INCREMENT, a INT NOT NULL, UNIQUE KEY uk3 (c));"
+	first := aigPlan(t, fromDDL, toDDL).SQL()
+	for i := 0; i < 20; i++ {
+		if got := aigPlan(t, fromDDL, toDDL).SQL(); got != first {
+			t.Fatalf("plan not deterministic:\n%s\nvs\n%s", first, got)
+		}
+	}
+	// All covering drops share the covering add's statement.
+	p := aigPlan(t, fromDDL, toDDL)
+	requireOneStatementWith(t, p, "DROP INDEX `uk1`", "DROP INDEX `k2`", "ADD UNIQUE KEY `uk3` (`c`)")
+}
+
+func TestAutoIncGrouping_IdempotenceHermetic(t *testing.T) {
+	// Self-diff of every grouped target form stays an empty plan under both normalizers.
+	schemas := []string{
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, seq BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, UNIQUE KEY uk_seq (seq));",
+		"CREATE TABLE t (a INT NOT NULL, seq INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (seq));",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT NOT NULL, seq INT NOT NULL AUTO_INCREMENT, KEY k_as (a, seq)) ENGINE=MyISAM;",
+	}
+	for _, s := range schemas {
+		c := loadCat(t, dbDDL+s)
+		for _, n := range []*Normalizer{NormalizerFor(MySQL80), NormalizerFor(MySQL57)} {
+			diff := DiffWithNormalizer(c, c, n)
+			if plan := GenerateMigrationWithNormalizer(c, c, diff, n); plan.SQL() != "" {
+				t.Errorf("self-diff plan not empty (version=%d) for %q:\n%s", n.Version, s, plan.SQL())
+			}
+		}
+	}
+}

--- a/mysql/catalog/migration_autoinc_test.go
+++ b/mysql/catalog/migration_autoinc_test.go
@@ -332,6 +332,48 @@ func TestAutoIncGrouping_MyISAMSharedKeyAIMigration(t *testing.T) {
 	requireOneStatementWith(t, p, "MODIFY COLUMN `c2`", "ADD KEY `k2` (`c2`)")
 }
 
+func TestAutoIncGrouping_FunctionalKeyPartPullsColumnAdds(t *testing.T) {
+	// PR-review fix: a FUNCTIONAL key part may reference columns added in this plan; all
+	// column adds are pulled into the grouped statement so the expression resolves (1054).
+	p := aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY);",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, seq INT NOT NULL AUTO_INCREMENT, z INT, KEY k_sz (seq, (z + 1)));")
+	op := requireOneStatementWith(t, p, "ADD COLUMN `seq`", "ADD COLUMN `z`", "ADD KEY `k_sz`")
+	if strings.Index(op.SQL, "ADD COLUMN `z`") > strings.Index(op.SQL, "ADD KEY") {
+		t.Errorf("referenced column add must precede the key clause: %s", op.SQL)
+	}
+	if len(p.Ops) != 1 {
+		t.Errorf("want 1 grouped op, got %d:\n%s", len(p.Ops), p.SQL())
+	}
+}
+
+func TestAutoIncGrouping_PrefixKeyPullsWideningModify(t *testing.T) {
+	// PR-review fix: a prefix part over an existing column widened in this plan pulls the
+	// widening MODIFY into the grouped statement (1089 against the old length otherwise).
+	p := aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v VARCHAR(100));",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, v VARCHAR(500), seq INT NOT NULL AUTO_INCREMENT, KEY k_sv (seq, v(300)));")
+	requireOneStatementWith(t, p, "ADD COLUMN `seq`", "MODIFY COLUMN `v` varchar(500)", "ADD KEY `k_sv` (`seq`,`v`(300))")
+	if len(p.Ops) != 1 {
+		t.Errorf("want 1 grouped op, got %d:\n%s", len(p.Ops), p.SQL())
+	}
+}
+
+func TestAutoIncGrouping_FKRenameInPlaceSynthesis(t *testing.T) {
+	// PR-review fix: an FK re-pointed to a new auto column KEEPING its constraint name — the
+	// old implicit backing index (same name) is dropped in PhasePre, so the name is free and
+	// the backing synthesis must proceed.
+	p := aigPlan(t,
+		"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE c (id INT NOT NULL PRIMARY KEY, old_id INT, CONSTRAINT fk FOREIGN KEY (old_id) REFERENCES p (id));",
+		"CREATE TABLE p (id INT NOT NULL PRIMARY KEY); CREATE TABLE c (id INT NOT NULL PRIMARY KEY, old_id INT, seq INT NOT NULL AUTO_INCREMENT, CONSTRAINT fk FOREIGN KEY (seq) REFERENCES p (id));")
+	requireOneStatementWith(t, p, "ADD COLUMN `seq`", "ADD KEY `fk` (`seq`)")
+	// The old backing index drop and the FK constraint churn stay their own statements.
+	requireOneStatementWith(t, p, "DROP FOREIGN KEY `fk`")
+	if got := strings.Count(p.SQL(), "ADD KEY `fk` (`seq`)"); got != 1 {
+		t.Errorf("want the synthesized backing key exactly once, got %d:\n%s", got, p.SQL())
+	}
+}
+
 func TestAutoIncGrouping_IdempotenceHermetic(t *testing.T) {
 	// Self-diff of every grouped target form stays an empty plan under both normalizers.
 	schemas := []string{

--- a/mysql/catalog/migration_autoinc_test.go
+++ b/mysql/catalog/migration_autoinc_test.go
@@ -301,6 +301,25 @@ func TestAutoIncGrouping_FKBackingDropJoinsColumnDrop(t *testing.T) {
 	}
 }
 
+func TestAutoIncGrouping_MyISAMSharedKeyAIMigrationBothSurvive(t *testing.T) {
+	// MyISAM corner (cross-family review find): the shared key covers BOTH columns and the old
+	// auto column SURVIVES (de-AUTO_INCREMENTed), so the shared key's drop first folds into
+	// a's MODIFY, which is then pulled into b's gaining statement — the drop now executes IN
+	// the target statement itself, so b is NOT covered there and the replacement key must
+	// still be grouped in (4-clause statement, oracle-proven; 3-clause fails errno 1075).
+	p := aigPlan(t,
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT NOT NULL AUTO_INCREMENT, b INT NOT NULL, KEY k (a, b)) ENGINE=MyISAM;",
+		"CREATE TABLE t (id INT NOT NULL PRIMARY KEY, a INT NOT NULL, b INT NOT NULL AUTO_INCREMENT, KEY k2 (b)) ENGINE=MyISAM;")
+	op := requireOneStatementWith(t, p,
+		"MODIFY COLUMN `a`", "DROP INDEX `k`", "MODIFY COLUMN `b`", "ADD KEY `k2` (`b`)")
+	if len(p.Ops) != 1 {
+		t.Errorf("want 1 grouped op, got %d:\n%s", len(p.Ops), p.SQL())
+	}
+	if op.Phase != PhaseMain {
+		t.Errorf("grouped statement must run in PhaseMain, got %d", op.Phase)
+	}
+}
+
 func TestAutoIncGrouping_MyISAMSharedKeyAIMigration(t *testing.T) {
 	// MyISAM corner: the composite key covers BOTH the old and the new auto column (any-position
 	// rule). The old column and the shared key drop in PhasePre, so the gaining MODIFY must

--- a/mysql/catalog/migration_column.go
+++ b/mysql/catalog/migration_column.go
@@ -67,16 +67,17 @@ func generateColumnDDL(_, to *Catalog, diff *SchemaDiff, n *Normalizer) []Migrat
 					ops = append(ops, addColumnOp(entry, table, col.To, n))
 					continue
 				}
+				clause := fmt.Sprintf("MODIFY COLUMN %s", formatColumnDefinition(entry.To, col.To, n))
 				ops = append(ops, MigrationOp{
 					Type:         OpModifyColumn,
 					Database:     entry.Database,
 					ObjectName:   entry.Name,
 					ParentObject: entry.Name,
-					SQL: fmt.Sprintf("ALTER TABLE %s MODIFY COLUMN %s",
-						table, formatColumnDefinition(entry.To, col.To, n)),
-					Phase:    PhaseMain,
-					Priority: priorityColumn,
-					sortName: columnSortName(entry.Database, entry.Name, col.Name),
+					SQL:          fmt.Sprintf("ALTER TABLE %s %s", table, clause),
+					Phase:        PhaseMain,
+					Priority:     priorityColumn,
+					sortName:     columnSortName(entry.Database, entry.Name, col.Name),
+					alterClause:  clause,
 				})
 			}
 		}
@@ -105,15 +106,17 @@ func generateColumnDDL(_, to *Catalog, diff *SchemaDiff, n *Normalizer) []Migrat
 // dropColumnOp's generated-first rule (generated columns drop before, and add after, the plain
 // columns they depend on). The global sortMigrationOps honors Priority within PhaseMain.
 func addColumnOp(entry *TableDiffEntry, table string, to *Column, n *Normalizer) MigrationOp {
+	clause := fmt.Sprintf("ADD COLUMN %s", formatColumnDefinition(entry.To, to, n))
 	return MigrationOp{
 		Type:         OpAddColumn,
 		Database:     entry.Database,
 		ObjectName:   entry.Name,
 		ParentObject: entry.Name,
-		SQL:          fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s", table, formatColumnDefinition(entry.To, to, n)),
+		SQL:          fmt.Sprintf("ALTER TABLE %s %s", table, clause),
 		Phase:        PhaseMain,
 		Priority:     columnAddPriority(to),
 		sortName:     columnSortName(entry.Database, entry.Name, to.Name),
+		alterClause:  clause,
 	}
 }
 
@@ -131,15 +134,17 @@ func columnAddPriority(c *Column) int {
 // column a generated column depends on — error 3108). The global sortMigrationOps also honors
 // Priority within PhasePre, so the ordering holds across the whole plan.
 func dropColumnOp(entry *TableDiffEntry, table, colName string, from *Column) MigrationOp {
+	clause := fmt.Sprintf("DROP COLUMN %s", migrationQuoteIdent(colName))
 	return MigrationOp{
 		Type:         OpDropColumn,
 		Database:     entry.Database,
 		ObjectName:   entry.Name,
 		ParentObject: entry.Name,
-		SQL:          fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", table, migrationQuoteIdent(colName)),
+		SQL:          fmt.Sprintf("ALTER TABLE %s %s", table, clause),
 		Phase:        PhasePre,
 		Priority:     columnDropPriority(from),
 		sortName:     columnSortName(entry.Database, entry.Name, colName),
+		alterClause:  clause,
 	}
 }
 

--- a/mysql/catalog/migration_foreign_key.go
+++ b/mysql/catalog/migration_foreign_key.go
@@ -239,7 +239,9 @@ func dropForeignKeyOps(entry *TableDiffEntry, con *Constraint, seenBackingDrop m
 				// OpDropForeignKey keeps it out of the index node's op-type space, which its contract
 				// tests assert is empty on FK-only changes (no OpAddIndex/OpDropIndex). Nothing keys
 				// off OpDropForeignKey expecting only literal DROP FOREIGN KEY statements — the only
-				// consumer is MigrationPlan.SQL(), which concatenates op.SQL verbatim.
+				// consumer is MigrationPlan.SQL(), which concatenates op.SQL verbatim. The grouping
+				// metadata (alterClause/dropsIndex) still marks it as an index drop so the
+				// AUTO_INCREMENT hazard pass sees the coverage it removes (migration_autoinc.go).
 				Type:         OpDropForeignKey,
 				Database:     entry.Database,
 				ObjectName:   entry.Name,
@@ -248,6 +250,8 @@ func dropForeignKeyOps(entry *TableDiffEntry, con *Constraint, seenBackingDrop m
 				Phase:        PhasePre,
 				Priority:     priorityForeignKeyBackingIndexDrop,
 				sortName:     foreignKeySortName(entry.Database, entry.Name, idxName),
+				alterClause:  "DROP INDEX " + migrationQuoteIdent(idxName),
+				dropsIndex:   toLower(idxName),
 			})
 		}
 	}

--- a/mysql/catalog/migration_index.go
+++ b/mysql/catalog/migration_index.go
@@ -172,19 +172,13 @@ const priorityPrimaryKeyDrop = priorityIndexDrop - 1
 // no PK-member column drop forces the split. `to` always carries the PRIMARY index for a PK
 // change (the diff keys it by the PRIMARY name), so DROP PRIMARY KEY is unconditional.
 //
-// KNOWN LIMITATIONS (flagged, not handled) — both are rare AUTO_INCREMENT corner cases whose
-// correct emission needs control over the column generator's op ordering (cross-node), which this
-// node does not have; recorded for a follow-up rather than special-cased:
-//   - Relocating an AUTO_INCREMENT column OUT of the PK onto a NEW secondary index in the same
-//     migration (old PK has the auto-inc column, new PK does not, a new KEY covers it): the split
-//     path's standalone DROP PRIMARY KEY leaves the auto-inc column unkeyed before its new
-//     secondary key is added (errno 1075). Atomicity would require pairing the PK drop with that
-//     specific secondary-key ADD in one ALTER.
-//   - AUTO_INCREMENT keeps the PK while a DIFFERENT old-PK member is demoted to nullable in the
-//     same migration: combined is needed to avoid the unkeyed AUTO_INCREMENT window (errno 1075),
-//     but the column's MODIFY ... NULL runs (priorityColumn) before the combined PhaseMain op
-//     (priorityIndex) while the old PK still holds it (errno 1171). Satisfying both needs the PK
-//     change emitted before the column modify, i.e. a column-op ordering this node cannot impose.
+// The two AUTO_INCREMENT corner cases this function used to flag as unhandled — relocating the
+// auto column OUT of the PK onto a new secondary key, and keeping it in the PK while a different
+// old-PK member is demoted to nullable — are resolved by the AUTO_INCREMENT grouping pass
+// (mergeAutoIncrementKeyOps, migration_autoinc.go), which folds the split path's DROP PRIMARY
+// KEY, the covering key ADD, and any demoting MODIFY into one statement after this generator
+// runs. This function only picks the combined-vs-split shape; the pass owns the cross-op
+// statement grouping.
 func primaryKeyModifyOps(entry *TableDiffEntry, table string, to *Index, n *Normalizer) []MigrationOp {
 	if canCombinePrimaryKeyModify(entry, to) {
 		clause := "DROP PRIMARY KEY, ADD " + formatIndexDefinition(to, n)

--- a/mysql/catalog/migration_index.go
+++ b/mysql/catalog/migration_index.go
@@ -128,15 +128,18 @@ func indexOpsForModifiedTable(entry *TableDiffEntry, n *Normalizer) []MigrationO
 // other kind uses ADD <UNIQUE|FULLTEXT|SPATIAL> KEY `name` (...). The op runs in PhaseMain at
 // priorityIndex.
 func addIndexOp(entry *TableDiffEntry, table string, idx *Index, n *Normalizer) MigrationOp {
+	clause := "ADD " + formatIndexDefinition(idx, n)
 	return MigrationOp{
 		Type:         OpAddIndex,
 		Database:     entry.Database,
 		ObjectName:   entry.Name,
 		ParentObject: entry.Name,
-		SQL:          fmt.Sprintf("ALTER TABLE %s ADD %s", table, formatIndexDefinition(idx, n)),
+		SQL:          fmt.Sprintf("ALTER TABLE %s %s", table, clause),
 		Phase:        PhaseMain,
 		Priority:     priorityIndex,
 		sortName:     indexSortName(entry.Database, entry.Name, idx.Name),
+		alterClause:  clause,
+		addsIndex:    idx,
 	}
 }
 
@@ -184,15 +187,19 @@ const priorityPrimaryKeyDrop = priorityIndexDrop - 1
 //     change emitted before the column modify, i.e. a column-op ordering this node cannot impose.
 func primaryKeyModifyOps(entry *TableDiffEntry, table string, to *Index, n *Normalizer) []MigrationOp {
 	if canCombinePrimaryKeyModify(entry, to) {
+		clause := "DROP PRIMARY KEY, ADD " + formatIndexDefinition(to, n)
 		return []MigrationOp{{
 			Type:         OpAddIndex,
 			Database:     entry.Database,
 			ObjectName:   entry.Name,
 			ParentObject: entry.Name,
-			SQL:          fmt.Sprintf("ALTER TABLE %s DROP PRIMARY KEY, ADD %s", table, formatIndexDefinition(to, n)),
+			SQL:          fmt.Sprintf("ALTER TABLE %s %s", table, clause),
 			Phase:        PhaseMain,
 			Priority:     priorityIndex,
 			sortName:     indexSortName(entry.Database, entry.Name, to.Name),
+			alterClause:  clause,
+			addsIndex:    to,
+			dropsIndex:   primaryIndexKey,
 		}}
 	}
 	dropPK := MigrationOp{
@@ -204,6 +211,8 @@ func primaryKeyModifyOps(entry *TableDiffEntry, table string, to *Index, n *Norm
 		Phase:        PhasePre,
 		Priority:     priorityPrimaryKeyDrop,
 		sortName:     indexSortName(entry.Database, entry.Name, to.Name),
+		alterClause:  "DROP PRIMARY KEY",
+		dropsIndex:   primaryIndexKey,
 	}
 	addPK := addIndexOp(entry, table, to, n)
 	return []MigrationOp{dropPK, addPK}
@@ -298,8 +307,10 @@ const priorityIndexDrop = priorityColumn - 5
 // priorityIndexDrop), and so a dropped index name is free for re-creation in the same plan.
 func dropIndexOp(entry *TableDiffEntry, table string, idx *Index) MigrationOp {
 	var clause string
+	drops := toLower(idx.Name)
 	if idx.Primary {
 		clause = "DROP PRIMARY KEY"
+		drops = primaryIndexKey
 	} else {
 		clause = "DROP INDEX " + migrationQuoteIdent(idx.Name)
 	}
@@ -312,6 +323,8 @@ func dropIndexOp(entry *TableDiffEntry, table string, idx *Index) MigrationOp {
 		Phase:        PhasePre,
 		Priority:     priorityIndexDrop,
 		sortName:     indexSortName(entry.Database, entry.Name, idx.Name),
+		alterClause:  clause,
+		dropsIndex:   drops,
 	}
 }
 

--- a/mysql/catalog/migration_index_oracle_test.go
+++ b/mysql/catalog/migration_index_oracle_test.go
@@ -147,11 +147,9 @@ func indexMigrationProbes() []migrationProbe {
 			"CREATE TABLE t (a INT NOT NULL, b INT NOT NULL, PRIMARY KEY (a,b))",
 			"CREATE TABLE t (a INT NOT NULL, b INT NULL, PRIMARY KEY (a))", both()},
 		// NOTE: the combination "AUTO_INCREMENT keeps the PK AND a different old-PK member is
-		// demoted to nullable in the same migration" is a FLAGGED known limitation (see
-		// primaryKeyModifyOps): combined-vs-split cannot satisfy both the no-unkeyed-AUTO_INCREMENT
-		// constraint (needs combined) and the demote-after-PK-drop constraint (needs split) without
-		// reordering the column generator's ops, which this node does not control. It is recorded,
-		// not proven here.
+		// demoted to nullable in the same migration" is handled by the AUTO_INCREMENT grouping
+		// pass (mergeAutoIncrementKeyOps) and proven by the aig-pk-keep-ai-demote-member probe in
+		// migration_autoinc_oracle_test.go.
 		// 8.0-only: visibility flip and direction flip are MODIFYs.
 		{"modify-visibility", "t",
 			"CREATE TABLE t (id INT PRIMARY KEY, a INT, KEY k (a))",


### PR DESCRIPTION
## Problem

Found by the bytebase enterprise SDL smoke (live-apply oracle, MySQL 8.0.32 and 5.7.25): a declarative release that adds an AUTO_INCREMENT column together with its backing key to an EXISTING table generated two statements —

```sql
ALTER TABLE t ADD COLUMN `seq` bigint unsigned NOT NULL AUTO_INCREMENT;   -- Error 1075
ALTER TABLE t ADD UNIQUE KEY `uk_seq` (`seq`);
```

MySQL validates at the end of EVERY ALTER statement that the table holds at most one AUTO_INCREMENT column and that it is the first column of some key (errno 1075), so the first statement fails. The same per-statement rule breaks the DROP direction (dropping the last covering key while the column stays AUTO_INCREMENT) and the attribute migration between columns ("only one auto column" fires between two MODIFY statements).

## Fix

`mergeAutoIncrementKeyOps` (new `mysql/catalog/migration_autoinc.go`), a rule-based pass in `GenerateMigrationWithNormalizer` that folds exactly the hazard clauses into one statement, driven by grouping metadata (`alterClause`/`addsIndex`/`dropsIndex`) the op constructors now set. Non-hazard plans are untouched (op granularity, warnings, and global order preserved). This is the ALTER-path analog of `formatCreateTable`'s backing-key inline (`autoIncSupportingIndex`).

Grouped shapes (each proven live on both versions):
- ADD/MODIFY-gaining column + covering key ADD (UNIQUE / plain / PRIMARY / combined `DROP PRIMARY KEY, ADD PRIMARY KEY`), pulling in other new columns the key references (plain before generated) and the previous auto column's de-AUTO_INCREMENT MODIFY
- last covering key DROP + the column's DROP / de-AUTO_INCREMENT MODIFY / replacement covering ADD (plus the split-path `ADD PRIMARY KEY` and demoted old-PK-member MODIFYs when the PRIMARY KEY drop moves)
- FK-implicit backing index synthesized as a last resort (deferred FK reuses it)

Also resolves both formerly-flagged `primaryKeyModifyOps` limitations (PK relocation off the auto column; keep-PK with demoted member).

## Oracle matrix (probed live on 5.7.25 @13307 and 8.0.32 @13306 — identical behavior)

| Form | Ungrouped | Grouped (one ALTER) |
|---|---|---|
| ADD COLUMN c AUTO_INCREMENT alone | 1075 | — |
| + ADD UNIQUE / plain KEY / PRIMARY KEY (c first) | 1075 | OK (clause order free) |
| + key with c NON-first | 1075 | InnoDB/MEMORY: 1075; MyISAM: OK |
| + functional first part `((c+1))` | 1075 | 1075 (does not satisfy) |
| + DESC / INVISIBLE key (8.0) | 1075 | OK (both satisfy) |
| MODIFY gains AUTO_INCREMENT, key already exists | OK | — (control, unchanged) |
| MODIFY gains AUTO_INCREMENT + key added in plan | 1075 | OK |
| gain on one column while another is still auto | 1075 | OK with de-attribute MODIFY in-statement |
| DROP last covering key, column stays auto | 1075 | OK with column DROP / de-attr MODIFY / replacement ADD |
| DROP PRIMARY KEY variants (single, composite, + demote) | 1075/1171 | OK (incl. 3-clause promote, `DROP PK, ADD KEY, ADD PK`, demote pull-in) |
| DROP one of several covering keys | OK | — (control, unchanged) |

## Verification

- Repro green: the headline case now emits one grouped statement; plan applies and converges (self-diff empty)
- `mysql/catalog` full suite green (~200s, includes all live-oracle suites, both engines); full `./mysql/...` tree green
- New colocated tests: 15 hermetic plan-shape tests (`migration_autoinc_test.go`) + 30 oracle probes through `assertApplyCorrect`/idempotence + 2 FK multi-table cases = 126 live subtests across both engines
- `golangci-lint` at main baseline (55 pre-existing issues, none in touched files)

## Review

Cross-family review (Claude 8-angle + Codex, two rounds each). All blockers fixed with oracle-proven shapes: split `ADD PRIMARY KEY` ordering vs a relocated PK drop (1068), generated-key-part transitive column pulls, and a transitive-merge coverage hole (MyISAM shared-key migration). One flagged limitation documented, not fixed: a storage-ENGINE conversion (MyISAM→InnoDB) whose auto column is covered only non-first fails on the ENGINE statement — pre-existing, outside this pass's op family, documented in the file comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)