### PR TITLE
feat(trino): parse boolean test IS [NOT] TRUE|FALSE|UNKNOWN; fix lexer oracle corpus

### DIFF
--- a/trino/analysis/query_span.go
+++ b/trino/analysis/query_span.go
@@ -633,6 +633,8 @@ func (ew exprWalk) walk(expr parser.Expr) {
 	case *parser.IsDistinctFromExpr:
 		ew.walk(e.Value)
 		ew.walk(e.Right)
+	case *parser.IsBooleanExpr:
+		ew.walk(e.Value)
 	case *parser.FuncCall:
 		ew.walkList(e.Args)
 		for _, item := range e.OrderBy {

--- a/trino/internal/trinooracle/container.go
+++ b/trino/internal/trinooracle/container.go
@@ -8,8 +8,11 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 )
 
-// DefaultImage is the Trino image used by StartContainer.
-const DefaultImage = "trinodb/trino:latest"
+// DefaultImage is the Trino image used by StartContainer. Pinned so
+// differential results are reproducible — a floating `latest` tag lets new
+// Trino releases silently shift the accept/reject oracle. Bump deliberately
+// and re-run the differentials when moving to a new Trino version.
+const DefaultImage = "trinodb/trino:482"
 
 // StartContainer starts a disposable Trino server via testcontainers and returns
 // an Oracle pointed at it plus a terminate func. Trino's JVM takes ~30-60s to

--- a/trino/parser/expr_structure_test.go
+++ b/trino/parser/expr_structure_test.go
@@ -71,6 +71,12 @@ func renderSExpr(e Expr) string {
 			not = "!"
 		}
 		return fmt.Sprintf("(%sdistinct %s %s)", not, renderSExpr(n.Value), renderSExpr(n.Right))
+	case *IsBooleanExpr:
+		not := ""
+		if n.Not {
+			not = "!"
+		}
+		return fmt.Sprintf("(%sis%s %s)", not, strings.ToLower(n.Test), renderSExpr(n.Value))
 	case *LikeExpr:
 		not := ""
 		if n.Not {
@@ -125,6 +131,11 @@ func TestExpr_Precedence(t *testing.T) {
 		{"a BETWEEN 1 + 1 AND 2 * 2", "(between a (+ 1 1) (* 2 2))"},
 		// LIKE / DISTINCT FROM operate on value expressions
 		{"a IS DISTINCT FROM b + c", "(distinct a (+ b c))"},
+		// boolean test binds the whole value expression, NOT tighter than +
+		{"a IS TRUE", "(istrue a)"},
+		{"a IS NOT FALSE", "(!isfalse a)"},
+		{"a + b IS UNKNOWN", "(isunknown (+ a b))"},
+		{"a IS NOT UNKNOWN", "(!isunknown a)"},
 	}
 	for _, tc := range cases {
 		t.Run(truncateName(tc.expr), func(t *testing.T) {
@@ -324,6 +335,14 @@ func writeExpr(b *strings.Builder, e Expr) {
 			b.WriteString(" IS DISTINCT FROM ")
 		}
 		writeExpr(b, n.Right)
+	case *IsBooleanExpr:
+		writeExpr(b, n.Value)
+		if n.Not {
+			b.WriteString(" IS NOT ")
+		} else {
+			b.WriteString(" IS ")
+		}
+		b.WriteString(n.Test)
 	case *CaseExpr:
 		b.WriteString("CASE")
 		if n.Operand != nil {

--- a/trino/parser/expr_test.go
+++ b/trino/parser/expr_test.go
@@ -112,6 +112,12 @@ var exprAcceptCorpus = []string{
 	"a IS NOT NULL",              // nullPredicate
 	"a IS DISTINCT FROM b",       // distinctFrom
 	"a IS NOT DISTINCT FROM b",   // distinctFrom (negated)
+	"a IS TRUE",                  // boolean test (engine-verified: Trino 482 accepts)
+	"a IS NOT TRUE",              // boolean test (negated)
+	"a IS FALSE",                 // boolean test
+	"a IS NOT FALSE",             // boolean test (negated)
+	"a IS UNKNOWN",               // boolean test
+	"a IS NOT UNKNOWN",           // boolean test (negated)
 	"a || b = c",                 // || binds tighter than predicate (P2)
 
 	// --- constructors (rowConstructor/arrayConstructor) ---
@@ -257,11 +263,6 @@ var exprRejectCorpus = []string{
 	"a IN (1) IN (2)",
 	"a IS NULL IS NULL",
 	"a BETWEEN 1 AND 2 BETWEEN 3 AND 4",
-
-	// IS variants Trino does not have
-	"a IS TRUE",
-	"a IS NOT FALSE",
-	"a IS UNKNOWN",
 
 	// reserved special-function keywords reject ordinary readings
 	"trim",              // reserved: not a bare column reference

--- a/trino/parser/lexer_oracle_test.go
+++ b/trino/parser/lexer_oracle_test.go
@@ -50,7 +50,11 @@ var oracleCorpus = []string{
 	"SELECT a <> b, a != b, a <= b, a >= b, a < b, a > b FROM t",
 	"SELECT a + b - c * d / e % f FROM t",
 	"SELECT count(*) FILTER (WHERE a > 0) FROM t",
-	"SELECT \"quoted col\", `backtick col` FROM \"quoted tbl\"",
+	// Backtick identifiers deliberately excluded: Trino's lexer tokenizes
+	// BACKQUOTED_IDENTIFIER_ (as does omni's) but the statement is a parser
+	// SYNTAX_ERROR, and this corpus must be all-Trino-accepted. Backtick
+	// tokenization is pinned by the identifier unit tests instead.
+	"SELECT \"quoted col\" FROM \"quoted tbl\"",
 	"SELECT timestamp '2012-10-31 01:00 UTC' AT TIME ZONE 'America/Los_Angeles'",
 	"SELECT ARRAY[1, 2, 3], ROW(1, 'a')",
 	"SELECT filter(ARRAY[1,2,3], x -> x > 1)",

--- a/trino/parser/predicate.go
+++ b/trino/parser/predicate.go
@@ -43,9 +43,9 @@ import (
 // `a IN (1) IN (2)`, `a IS NULL IS NULL`, `a BETWEEN 1 AND 2 BETWEEN 3 AND 4` are
 // all SYNTAX_ERRORs. parsePredicateSuffix therefore consumes at most one
 // predicate and never loops; a trailing predicate operator is left for the
-// caller, where it surfaces as the syntax error Trino reports. Note Trino has NO
-// `IS [NOT] TRUE/FALSE/UNKNOWN` predicate (those spellings are rejected) — only
-// IS [NOT] NULL and IS [NOT] DISTINCT FROM.
+// caller, where it surfaces as the syntax error Trino reports. The IS forms
+// are IS [NOT] NULL, IS [NOT] DISTINCT FROM, and the boolean test
+// IS [NOT] TRUE/FALSE/UNKNOWN (engine-verified on Trino 482).
 
 // ComparisonExpr is `left <op> right` where <op> is one of = <> < <= > >=
 // (the comparison predicate). Op holds the source operator spelling.

--- a/trino/parser/predicate.go
+++ b/trino/parser/predicate.go
@@ -1,6 +1,10 @@
 package parser
 
-import "github.com/bytebase/omni/trino/ast"
+import (
+	"strings"
+
+	"github.com/bytebase/omni/trino/ast"
+)
 
 // This file is part of the `expressions` DAG node (with expr.go and
 // function.go): it implements the predicate suffix of Trino's `booleanExpression`
@@ -137,6 +141,18 @@ type IsDistinctFromExpr struct {
 
 func (n *IsDistinctFromExpr) Span() ast.Loc { return n.Loc }
 func (*IsDistinctFromExpr) exprNode()       {}
+
+// IsBooleanExpr is the boolean test `value IS [NOT] TRUE | FALSE | UNKNOWN`.
+// Test holds the uppercased test keyword ("TRUE", "FALSE", or "UNKNOWN").
+type IsBooleanExpr struct {
+	Not   bool
+	Value Expr
+	Test  string
+	Loc   ast.Loc
+}
+
+func (n *IsBooleanExpr) Span() ast.Loc { return n.Loc }
+func (*IsBooleanExpr) exprNode()       {}
 
 // parsePredicateSuffix attaches at most one predicate to the already-parsed
 // valueExpression `left`, returning `left` unchanged when no predicate follows.
@@ -330,10 +346,11 @@ func (p *Parser) parseLike(left Expr, not bool, start int) (Expr, error) {
 	return like, nil
 }
 
-// parseIsPredicate parses `IS [NOT] NULL` or `IS [NOT] DISTINCT FROM right`
-// (IS already current). Trino has no other IS predicate — `IS TRUE`, `IS FALSE`,
-// `IS UNKNOWN` are SYNTAX_ERRORs, so a token other than NULL/DISTINCT after the
-// optional NOT is an error.
+// parseIsPredicate parses `IS [NOT] NULL`, `IS [NOT] DISTINCT FROM right`, or
+// the boolean test `IS [NOT] TRUE | FALSE | UNKNOWN` (IS already current).
+// The boolean test is engine-verified: Trino 482 accepts `a IS TRUE`,
+// `a IS NOT FALSE`, and `a IS UNKNOWN` (CI differential caught omni rejecting
+// them).
 func (p *Parser) parseIsPredicate(left Expr) (Expr, error) {
 	isTok := p.advance() // consume IS
 	not := false
@@ -364,10 +381,16 @@ func (p *Parser) parseIsPredicate(left Expr) (Expr, error) {
 			Right: right,
 			Loc:   ast.Loc{Start: left.Span().Start, End: right.Span().End},
 		}, nil
+	case kwTRUE, kwFALSE, kwUNKNOWN:
+		boolTok := p.advance()
+		return &IsBooleanExpr{
+			Not:   not,
+			Value: left,
+			Test:  strings.ToUpper(boolTok.Str),
+			Loc:   ast.Loc{Start: left.Span().Start, End: boolTok.Loc.End},
+		}, nil
 	default:
-		// Point the error at IS so the diagnostic is actionable for the common
-		// `IS TRUE` / `IS UNKNOWN` mistake.
-		return nil, &ParseError{Loc: isTok.Loc, Msg: "expected NULL or DISTINCT FROM after IS"}
+		return nil, &ParseError{Loc: isTok.Loc, Msg: "expected NULL, DISTINCT FROM, TRUE, FALSE, or UNKNOWN after IS"}
 	}
 }
 


### PR DESCRIPTION
## Problem

The nightly trino container differential (enabled by the all-engine CI rollout) caught two gaps vs Trino 482:

1. omni rejected `a IS TRUE`, `a IS NOT FALSE`, `a IS UNKNOWN` — the parser comment claimed Trino has no boolean IS predicate, but the live engine accepts all six `[NOT] TRUE/FALSE/UNKNOWN` forms.
2. The lexer oracle corpus (meant to be all-Trino-accepted) contained a backtick-identifier statement: Trino tokenizes `BACKQUOTED_IDENTIFIER_` (as does omni's lexer, deliberately) but rejects it at parse — the corpus entry conflated lexer-level and statement-level acceptance and flagged a false lexer mismatch.

## Changes

- `parseIsPredicate` gains the boolean-test branch: `IS [NOT] TRUE | FALSE | UNKNOWN` → new `IsBooleanExpr` node (`Test` holds the uppercased keyword); error message updated
- `query_span` expression walker wired for the new node (the only Expr consumer)
- Expr corpora corrected: the six boolean-test forms move from reject to accept, with s-expression structure pins (`a + b IS UNKNOWN` = `(isunknown (+ a b))` — the test binds the whole value expression)
- Lexer oracle corpus: backtick statement replaced with its double-quoted part; backtick tokenization stays pinned by the identifier unit tests

## Verification

- Full `./trino/...` suite green against a live Trino 482 container (`TRINO_ORACLE_URL` set), including `TestExpr_OracleDifferential` and `TestLexer_OracleDifferential` with **zero mismatches**
- No new gofmt/vet findings

Closes task #19 (CI rollout follow-up). After merge, @omni-dev flips the trino container job back to PR-triggered + required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)