### PR TITLE
mysql: deparse temporal-unit keyword arguments unquoted

### DIFF
--- a/mysql/ast/outfuncs.go
+++ b/mysql/ast/outfuncs.go
@@ -2373,8 +2373,11 @@ func writeWeightStringExpr(sb *strings.Builder, n *WeightStringExpr) {
 	}
 	for _, lv := range n.Levels {
 		fmt.Fprintf(sb, " :level %d", lv.Level)
-		if lv.Dir != "" {
-			fmt.Fprintf(sb, " %s", lv.Dir)
+		if lv.Desc {
+			sb.WriteString(" desc")
+		}
+		if lv.Reverse {
+			sb.WriteString(" reverse")
 		}
 	}
 	sb.WriteString("}")

--- a/mysql/ast/outfuncs.go
+++ b/mysql/ast/outfuncs.go
@@ -179,6 +179,10 @@ func writeNode(sb *strings.Builder, node Node) {
 		writeCollateExpr(sb, n)
 	case *IntervalExpr:
 		writeIntervalExpr(sb, n)
+	case *KeywordArg:
+		writeKeywordArg(sb, n)
+	case *WeightStringExpr:
+		writeWeightStringExpr(sb, n)
 	case *MatchExpr:
 		writeMatchExpr(sb, n)
 	case *ConvertExpr:
@@ -2350,6 +2354,29 @@ func writeIntervalExpr(sb *strings.Builder, n *IntervalExpr) {
 	fmt.Fprintf(sb, " :loc %d :val ", n.Loc.Start)
 	writeNode(sb, n.Value)
 	fmt.Fprintf(sb, " :unit %s", n.Unit)
+	sb.WriteString("}")
+}
+
+func writeKeywordArg(sb *strings.Builder, n *KeywordArg) {
+	sb.WriteString("{KEYWORDARG")
+	fmt.Fprintf(sb, " :loc %d :keyword %s", n.Loc.Start, n.Keyword)
+	sb.WriteString("}")
+}
+
+func writeWeightStringExpr(sb *strings.Builder, n *WeightStringExpr) {
+	sb.WriteString("{WEIGHTSTRING")
+	fmt.Fprintf(sb, " :loc %d :expr ", n.Loc.Start)
+	writeNode(sb, n.Expr)
+	if n.AsChar != nil {
+		sb.WriteString(" :aschar ")
+		writeNode(sb, n.AsChar)
+	}
+	for _, lv := range n.Levels {
+		fmt.Fprintf(sb, " :level %d", lv.Level)
+		if lv.Dir != "" {
+			fmt.Fprintf(sb, " %s", lv.Dir)
+		}
+	}
 	sb.WriteString("}")
 }
 

--- a/mysql/ast/parsenodes.go
+++ b/mysql/ast/parsenodes.go
@@ -1900,10 +1900,14 @@ type WeightStringExpr struct {
 func (e *WeightStringExpr) nodeTag()  {}
 func (e *WeightStringExpr) exprNode() {}
 
-// WeightStringLevel is one element of a WEIGHT_STRING LEVEL list.
+// WeightStringLevel is one element of a WEIGHT_STRING LEVEL list. The 5.7
+// grammar allows a direction and REVERSE together, in that order — LEVEL 1
+// DESC REVERSE stores as "level 1 desc reverse", while REVERSE DESC is a
+// syntax error and ASC normalizes away (oracle 5.7.25).
 type WeightStringLevel struct {
-	Level int
-	Dir   string // "", "DESC", or "REVERSE" (ASC normalizes to "")
+	Level   int
+	Desc    bool
+	Reverse bool
 }
 
 // CollateExpr represents a COLLATE expression.

--- a/mysql/ast/parsenodes.go
+++ b/mysql/ast/parsenodes.go
@@ -1869,6 +1869,43 @@ type IntervalExpr struct {
 func (e *IntervalExpr) nodeTag()  {}
 func (e *IntervalExpr) exprNode() {}
 
+// KeywordArg represents a bare keyword in a function argument position: the
+// temporal unit of TIMESTAMPDIFF/TIMESTAMPADD (timestampdiff(SECOND,a,b)) or
+// the format type of GET_FORMAT (get_format(DATE,'USA')). MySQL lexes these
+// positions as keywords, never identifiers — a quoted `SECOND` is a syntax
+// error (oracle 8.0.32 + 5.7.25) — so deparse must render Keyword unquoted.
+// Keyword is stored normalized: uppercase, SQL_TSI_ prefix stripped, and
+// GET_FORMAT's TIMESTAMP folded to DATETIME, matching SHOW CREATE VIEW.
+type KeywordArg struct {
+	Loc     Loc
+	Keyword string
+}
+
+func (e *KeywordArg) nodeTag()  {}
+func (e *KeywordArg) exprNode() {}
+
+// WeightStringExpr represents WEIGHT_STRING(expr [AS CHAR(n)] [LEVEL ...]).
+// The AS BINARY(n) input form is not stored: MySQL desugars it to
+// weight_string(cast(expr as char(n) charset binary)) (oracle 8.0.32 +
+// 5.7.25), so the parser produces that CastExpr shape instead. LEVEL is
+// accepted by 5.7 only; 5.7 readbacks always carry an explicit level list
+// (e.g. "1" or "1 desc"), while 8.0 rejects LEVEL entirely.
+type WeightStringExpr struct {
+	Loc    Loc
+	Expr   ExprNode
+	AsChar *DataType // optional AS CHAR(n); nil when absent
+	Levels []WeightStringLevel
+}
+
+func (e *WeightStringExpr) nodeTag()  {}
+func (e *WeightStringExpr) exprNode() {}
+
+// WeightStringLevel is one element of a WEIGHT_STRING LEVEL list.
+type WeightStringLevel struct {
+	Level int
+	Dir   string // "", "DESC", or "REVERSE" (ASC normalizes to "")
+}
+
 // CollateExpr represents a COLLATE expression.
 type CollateExpr struct {
 	Loc       Loc

--- a/mysql/ast/walk_generated.go
+++ b/mysql/ast/walk_generated.go
@@ -871,6 +871,11 @@ func walkChildren(v Visitor, node Node) {
 		if n.Limit != nil {
 			Walk(v, n.Limit)
 		}
+	case *WeightStringExpr:
+		Walk(v, n.Expr)
+		if n.AsChar != nil {
+			Walk(v, n.AsChar)
+		}
 	case *WhileStmt:
 		Walk(v, n.Cond)
 		for _, item := range n.Stmts {

--- a/mysql/ast/walk_test.go
+++ b/mysql/ast/walk_test.go
@@ -190,6 +190,7 @@ func allKnownNodes() []Node {
 		&IsExpr{}, &ExistsExpr{}, &SubqueryExpr{},
 		&FuncCallExpr{}, &CastExpr{}, &ConvertExpr{}, &ExtractExpr{},
 		&CaseExpr{}, &CaseWhen{}, &IntervalExpr{}, &CollateExpr{},
+		&KeywordArg{}, &WeightStringExpr{},
 		&ParenExpr{}, &RowExpr{},
 		&MatchExpr{}, &MemberOfExpr{}, &VariableRef{},
 		&ValuesStmt{}, // also an expression in some contexts

--- a/mysql/catalog/altercmds.go
+++ b/mysql/catalog/altercmds.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	nodes "github.com/bytebase/omni/mysql/ast"
+	"github.com/bytebase/omni/mysql/deparse"
 )
 
 func (c *Catalog) alterTable(stmt *nodes.AlterTableStmt) error {
@@ -954,8 +955,14 @@ func buildColumnFromDef(tbl *Table, colDef *nodes.ColumnDef) *Column {
 		setColumnOnUpdateFromExpr(col, colDef.OnUpdate)
 	}
 	if colDef.Generated != nil {
+		// Generated expressions are stored by the engine in resolver-rewritten
+		// form — TIMESTAMPADD/DATE_ADD fold to interval arithmetic, NOT folds
+		// to inverted comparisons — identical to view bodies (oracle 8.0.32:
+		// AS (TIMESTAMPADD(HOUR,1,a)) stores as ((`a` + interval 1 hour)),
+		// AS (NOT a) as ((0 = `a`))). Apply the same rewrite pass before
+		// rendering so user-declared SDL canonicalizes to the stored form.
 		col.Generated = &GeneratedColumnInfo{
-			Expr:   nodeToSQLGenerated(colDef.Generated.Expr, tbl.Charset),
+			Expr:   nodeToSQLGenerated(deparse.RewriteExpr(colDef.Generated.Expr), tbl.Charset),
 			Stored: colDef.Generated.Stored,
 		}
 	}

--- a/mysql/catalog/diff_column.go
+++ b/mysql/catalog/diff_column.go
@@ -88,7 +88,14 @@ func diffColumns(from, to *Table, n *Normalizer) []ColumnDiffEntry {
 // identity.) `from`/`to` are passed for the table context CanonicalColumn needs to
 // resolve table-inherited charset/collation, PK membership, and the first-TIMESTAMP rule.
 func columnsChanged(fromTbl, toTbl *Table, a, b *Column, n *Normalizer) bool {
-	return n.CanonicalColumn(fromTbl, a) != n.CanonicalColumn(toTbl, b)
+	if n.CanonicalColumn(fromTbl, a) == n.CanonicalColumn(toTbl, b) {
+		return false
+	}
+	// Cast-charset wildcard: a charset-less CHAR cast in user SDL must not
+	// phantom-diff against the connection charset its readback carries, while
+	// an EXPLICIT charset change stays a real diff (both engine-verified; see
+	// columnsCastCharsetWildcardEqual).
+	return !n.columnsCastCharsetWildcardEqual(fromTbl, toTbl, a, b)
 }
 
 // diffableColumns returns the columns of a table that participate in a declarative diff:

--- a/mysql/catalog/functional_index.go
+++ b/mysql/catalog/functional_index.go
@@ -355,6 +355,17 @@ func containsDisallowedFunctionalIndexExpr(expr nodes.ExprNode) bool {
 			containsDisallowedFunctionalIndexExpr(e.High)
 	case *nodes.IsExpr:
 		return containsDisallowedFunctionalIndexExpr(e.Expr)
+	case *nodes.WeightStringExpr:
+		// KEY ((weight_string(now() as char(4)))) is rejected by the engine
+		// exactly like KEY ((now())) — error 3758 (oracle 8.0.32).
+		return containsDisallowedFunctionalIndexExpr(e.Expr)
+	case *nodes.ExtractExpr:
+		// KEY ((extract(day from now()))) → 3758; extract over a column is
+		// allowed (oracle 8.0.32).
+		return containsDisallowedFunctionalIndexExpr(e.Expr)
+	case *nodes.IntervalExpr:
+		// KEY ((a + interval (day(now())) day)) → 3758 (oracle 8.0.32).
+		return containsDisallowedFunctionalIndexExpr(e.Value)
 	}
 	return false
 }

--- a/mysql/catalog/migration_view_oracle_test.go
+++ b/mysql/catalog/migration_view_oracle_test.go
@@ -348,7 +348,7 @@ func viewIdempotenceProbes() []viewSchemaProbe {
 		// explicitly so the user form matches the engine-stored level list.
 		{"weight-string-level", []string{
 			"CREATE TABLE t (s VARCHAR(20))",
-			"CREATE VIEW v AS SELECT WEIGHT_STRING(s LEVEL 1) AS c1, WEIGHT_STRING(s AS CHAR(4) LEVEL 1) AS c2 FROM t",
+			"CREATE VIEW v AS SELECT WEIGHT_STRING(s LEVEL 1) AS c1, WEIGHT_STRING(s AS CHAR(4) LEVEL 1) AS c2, WEIGHT_STRING(s LEVEL 1 DESC REVERSE) AS c3 FROM t",
 		}, []string{"t"}, []string{"v"}, only(MySQL57)},
 	}
 }

--- a/mysql/catalog/migration_view_oracle_test.go
+++ b/mysql/catalog/migration_view_oracle_test.go
@@ -284,6 +284,72 @@ func viewIdempotenceProbes() []viewSchemaProbe {
 			"CREATE TABLE t (a INT)",
 			"CREATE VIEW v AS SELECT (((SELECT 1) = 1) AND (2 = 2)) AS x",
 		}, []string{"t"}, []string{"v"}, both()},
+		// ---- temporal-unit keyword arguments ----
+		// The engine stores these units as BARE keywords; a backtick-quoted
+		// unit is a syntax error (8.0.32 + 5.7.25: 1064). These probes prove
+		// user forms and engine readbacks canonicalize equal for every
+		// keyword-argument position.
+		// TIMESTAMPDIFF: unit stored bare UPPERCASE, case-folded, SQL_TSI_
+		// synonyms folded. All nine simple units in one view.
+		{"tsdiff-all-units", []string{
+			"CREATE TABLE t (a DATETIME, b DATETIME)",
+			"CREATE VIEW v AS SELECT TIMESTAMPDIFF(MICROSECOND,a,b) AS c1, timestampdiff(second,a,b) AS c2, TIMESTAMPDIFF(MINUTE,a,b) AS c3, TIMESTAMPDIFF(HOUR,a,b) AS c4, TIMESTAMPDIFF(DAY,a,b) AS c5, TIMESTAMPDIFF(WEEK,a,b) AS c6, TIMESTAMPDIFF(MONTH,a,b) AS c7, TIMESTAMPDIFF(SQL_TSI_QUARTER,a,b) AS c8, TIMESTAMPDIFF(YEAR,a,b) AS c9 FROM t",
+		}, []string{"t"}, []string{"v"}, both()},
+		// The stock sys.innodb_lock_waits shape (the dogfood bug): a
+		// timestampdiff over a column and now().
+		{"tsdiff-column-now", []string{
+			"CREATE TABLE t (id INT NOT NULL, created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (id))",
+			"CREATE VIEW v AS SELECT id, TIMESTAMPDIFF(SECOND, created, NOW()) AS age_secs FROM t",
+		}, []string{"t"}, []string{"v"}, both()},
+		// TIMESTAMPADD + the DATE_ADD family: never stored as function calls —
+		// the engine folds them all into (expr ± interval n unit).
+		{"date-arith-family", []string{
+			"CREATE TABLE t (a DATETIME)",
+			"CREATE VIEW v AS SELECT TIMESTAMPADD(HOUR, 1, a) AS c1, DATE_ADD(a, INTERVAL 1 DAY) AS c2, DATE_SUB(a, INTERVAL 30 MINUTE) AS c3, ADDDATE(a, INTERVAL 1 WEEK) AS c4, ADDDATE(a, 31) AS c5, SUBDATE(a, INTERVAL 1 MONTH) AS c6, SUBDATE(a, 31) AS c7 FROM t",
+		}, []string{"t"}, []string{"v"}, both()},
+		// Bare INTERVAL arithmetic: compound units, expression values,
+		// negative counts, and the interval-first commuted form.
+		{"interval-forms", []string{
+			"CREATE TABLE t (a DATETIME, n INT)",
+			"CREATE VIEW v AS SELECT a + INTERVAL 1 DAY AS c1, a - INTERVAL 30 MINUTE AS c2, a + INTERVAL '1:1' DAY_HOUR AS c3, a + INTERVAL '1-1' YEAR_MONTH AS c4, a + INTERVAL (n + 1) DAY AS c5, ADDDATE(a, -5) AS c6, INTERVAL 1 DAY + a AS c7 FROM t",
+		}, []string{"t"}, []string{"v"}, both()},
+		// EXTRACT: lowercase unit, simple + compound, over a column.
+		{"extract-units", []string{
+			"CREATE TABLE t (a DATETIME)",
+			"CREATE VIEW v AS SELECT EXTRACT(SECOND FROM a) AS c1, extract(day from a) AS c2, EXTRACT(QUARTER FROM a) AS c3, EXTRACT(DAY_HOUR FROM a) AS c4, EXTRACT(YEAR_MONTH FROM a) AS c5, EXTRACT(HOUR_MICROSECOND FROM a) AS c6, EXTRACT(SQL_TSI_WEEK FROM a) AS c7 FROM t",
+		}, []string{"t"}, []string{"v"}, both()},
+		// GET_FORMAT: bare UPPERCASE first argument, TIMESTAMP folds to
+		// DATETIME, and the stored form keeps a space after the first comma.
+		{"get-format-kinds", []string{
+			"CREATE VIEW v AS SELECT GET_FORMAT(DATE, 'USA') AS c1, get_format(time, 'ISO') AS c2, GET_FORMAT(DATETIME, 'EUR') AS c3, GET_FORMAT(TIMESTAMP, 'JIS') AS c4",
+		}, nil, []string{"v"}, both()},
+		// TRIM keyword forms, including the direction-less remstr FROM form
+		// the engine stores verbatim (not as comma arguments).
+		{"trim-keyword-forms", []string{
+			"CREATE TABLE t (s VARCHAR(20))",
+			"CREATE VIEW v AS SELECT TRIM(BOTH 'x' FROM s) AS c1, TRIM(LEADING 'x' FROM s) AS c2, TRIM(TRAILING 'x' FROM s) AS c3, TRIM('x' FROM s) AS c4, TRIM(s) AS c5 FROM t",
+		}, []string{"t"}, []string{"v"}, both()},
+		// SUBSTRING keyword forms: the engine rewrites FROM/FOR into the
+		// comma form under the substr name (regression pin — worked before).
+		{"substring-keyword-forms", []string{
+			"CREATE TABLE t (s VARCHAR(20))",
+			"CREATE VIEW v AS SELECT SUBSTRING(s FROM 2) AS c1, SUBSTRING(s FROM 2 FOR 3) AS c2, SUBSTRING(s, 2, 3) AS c3 FROM t",
+		}, []string{"t"}, []string{"v"}, both()},
+		// WEIGHT_STRING: plain and AS CHAR(n); AS BINARY(n) desugars to the
+		// cast-charset-binary form. 8.0 only: 5.7 auto-appends `level 1` to
+		// the STORED body, which omni does not reproduce for user-declared
+		// SDL (FLAGGED; a 5.7 user can write LEVEL 1 explicitly, and 5.7
+		// readbacks — which always carry the level list — round-trip fine).
+		{"weight-string-forms", []string{
+			"CREATE TABLE t (s VARCHAR(20))",
+			"CREATE VIEW v AS SELECT WEIGHT_STRING(s) AS c1, WEIGHT_STRING(s AS CHAR(4)) AS c2, WEIGHT_STRING(s AS BINARY(4)) AS c3 FROM t",
+		}, []string{"t"}, []string{"v"}, only(MySQL80)},
+		// WEIGHT_STRING LEVEL: 5.7-only syntax (8.0 rejects LEVEL), written
+		// explicitly so the user form matches the engine-stored level list.
+		{"weight-string-level", []string{
+			"CREATE TABLE t (s VARCHAR(20))",
+			"CREATE VIEW v AS SELECT WEIGHT_STRING(s LEVEL 1) AS c1, WEIGHT_STRING(s AS CHAR(4) LEVEL 1) AS c2 FROM t",
+		}, []string{"t"}, []string{"v"}, only(MySQL57)},
 	}
 }
 
@@ -575,6 +641,24 @@ func viewMigrationProbes() []viewMigrationProbe {
 			base("CREATE TABLE t (id INT)"),
 			base("CREATE TABLE t (id INT)", "CREATE VIEW base AS SELECT id FROM t", "CREATE VIEW tv AS TABLE base"),
 			[]string{"t"}, []string{"base", "tv"}, only(MySQL80)},
+		// ---- temporal-unit keyword arguments ----
+		// CREATE the sys.innodb_lock_waits shape from a table-only state:
+		// the generated body must carry timestampdiff(SECOND,...) with a
+		// BARE unit — the quoted form the deparser used to emit is a 1064
+		// syntax error on apply (the sys-schema dogfood bug).
+		{"create-tsdiff-view",
+			base("CREATE TABLE t (id INT NOT NULL, created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (id))"),
+			base("CREATE TABLE t (id INT NOT NULL, created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (id))",
+				"CREATE VIEW v AS SELECT id, TIMESTAMPDIFF(SECOND, created, NOW()) AS age_secs FROM t"),
+			[]string{"t"}, []string{"v"}, both()},
+		// REPLACE a plain body with one exercising every temporal keyword
+		// position at once: the generated CREATE OR REPLACE must apply and
+		// read back canonically equal.
+		{"replace-into-temporal-medley",
+			base("CREATE TABLE t (a DATETIME, s VARCHAR(20))", "CREATE VIEW v AS SELECT a FROM t"),
+			base("CREATE TABLE t (a DATETIME, s VARCHAR(20))",
+				"CREATE VIEW v AS SELECT TIMESTAMPDIFF(DAY, a, NOW()) AS c1, TIMESTAMPADD(HOUR, 1, a) AS c2, EXTRACT(DAY_HOUR FROM a) AS c3, GET_FORMAT(DATE, 'USA') AS c4, a + INTERVAL '1:1' DAY_HOUR AS c5, TRIM('x' FROM s) AS c6 FROM t"),
+			[]string{"t"}, []string{"v"}, both()},
 	}
 }
 

--- a/mysql/catalog/normalize.go
+++ b/mysql/catalog/normalize.go
@@ -905,9 +905,67 @@ func balancedFirstParenWrapsAll(s string) bool {
 // readback of the same logical expression all compare equal.
 func (n *Normalizer) CanonicalGeneratedExpr(expr string) string {
 	s := stripCharsetIntroducers(expr)
+	s = stripCastCharsets(s)
 	s = stripOuterParens(s)
 	s = collapseExprWhitespace(s)
 	return s
+}
+
+// stripCastCharsets removes the charset attribute of CAST targets
+// (" charset utf8mb4" and the like) outside string literals and backtick
+// quotes. Like the string-literal introducer above, the charset the engine
+// stores for a charset-less CHAR cast is the CONNECTION charset of the
+// creating session (oracle 8.0.32: the same CAST(s AS CHAR(4)) generated
+// column stores "charset latin1" or "charset utf8mb4" depending only on the
+// session that created it), so it is connection-dependent noise for
+// comparison purposes: stripping it lets a user's charset-less cast compare
+// equal to any readback. "charset binary" is kept — it changes the cast's
+// type (the WEIGHT_STRING(... AS BINARY(n)) desugar) and must not compare
+// equal to a plain CHAR cast.
+func stripCastCharsets(expr string) string {
+	var b strings.Builder
+	b.Grow(len(expr))
+	i := 0
+	for i < len(expr) {
+		c := expr[i]
+		if c == '\'' {
+			end := scanStringLiteral(expr, i)
+			b.WriteString(expr[i:end])
+			i = end
+			continue
+		}
+		if c == '`' {
+			j := i + 1
+			for j < len(expr) {
+				if expr[j] == '`' {
+					if j+1 < len(expr) && expr[j+1] == '`' {
+						j += 2 // doubled-backtick escape inside the identifier
+						continue
+					}
+					j++
+					break
+				}
+				j++
+			}
+			b.WriteString(expr[i:j])
+			i = j
+			continue
+		}
+		if c == ' ' && strings.HasPrefix(expr[i:], " charset ") {
+			j := i + len(" charset ")
+			k := j
+			for k < len(expr) && isIdentByte(expr[k]) {
+				k++
+			}
+			if k > j && !strings.EqualFold(expr[j:k], "binary") {
+				i = k // drop " charset <name>"
+				continue
+			}
+		}
+		b.WriteByte(c)
+		i++
+	}
+	return b.String()
 }
 
 // scanStringLiteral returns the index just past a single-quoted string literal that

--- a/mysql/catalog/normalize.go
+++ b/mysql/catalog/normalize.go
@@ -905,26 +905,35 @@ func balancedFirstParenWrapsAll(s string) bool {
 // readback of the same logical expression all compare equal.
 func (n *Normalizer) CanonicalGeneratedExpr(expr string) string {
 	s := stripCharsetIntroducers(expr)
-	s = stripCastCharsets(s)
 	s = stripOuterParens(s)
 	s = collapseExprWhitespace(s)
 	return s
 }
 
-// stripCastCharsets removes the charset attribute of CAST targets
+// castCharsetAt records one CAST charset attribute found in an expression
+// text: the byte offset in the STRIPPED text where it was attached, and the
+// charset name.
+type castCharsetAt struct {
+	off  int
+	name string
+}
+
+// stripAndCollectCastCharsets removes the charset attribute of CAST targets
 // (" charset utf8mb4" and the like) outside string literals and backtick
-// quotes. Like the string-literal introducer above, the charset the engine
-// stores for a charset-less CHAR cast is the CONNECTION charset of the
+// quotes, returning the stripped text plus the ordered list of removed
+// attributes keyed by their offset in the stripped text. The charset the
+// engine stores for a charset-less CHAR cast is the CONNECTION charset of the
 // creating session (oracle 8.0.32: the same CAST(s AS CHAR(4)) generated
 // column stores "charset latin1" or "charset utf8mb4" depending only on the
-// session that created it), so it is connection-dependent noise for
-// comparison purposes: stripping it lets a user's charset-less cast compare
-// equal to any readback. "charset binary" is kept — it changes the cast's
-// type (the WEIGHT_STRING(... AS BINARY(n)) desugar) and must not compare
-// equal to a plain CHAR cast.
-func stripCastCharsets(expr string) string {
+// session that created it), while an EXPLICIT CHARACTER SET survives readback
+// distinctly (oracle 8.0.32: explicit latin1 under a utf8mb4 session reads
+// back "charset latin1"). "charset binary" is never treated as an attribute —
+// it changes the cast's type (the AS BINARY desugar) and always stays part of
+// the text.
+func stripAndCollectCastCharsets(expr string) (string, []castCharsetAt) {
 	var b strings.Builder
 	b.Grow(len(expr))
+	var found []castCharsetAt
 	i := 0
 	for i < len(expr) {
 		c := expr[i]
@@ -951,21 +960,101 @@ func stripCastCharsets(expr string) string {
 			i = j
 			continue
 		}
-		if c == ' ' && strings.HasPrefix(expr[i:], " charset ") {
-			j := i + len(" charset ")
+		// The canonical collapse drops spaces around parens, so the attribute
+		// appears either as " charset <name>" (after a word: char charset x)
+		// or as "charset <name>" directly after a ')' (char(4)charset x).
+		attrStart := -1
+		if c == ' ' && strings.HasPrefix(expr[i+1:], "charset ") {
+			attrStart = i + 1 // the separator space is dropped with the attribute
+		} else if strings.HasPrefix(expr[i:], "charset ") && i > 0 && !isIdentByte(expr[i-1]) && expr[i-1] != ' ' {
+			attrStart = i
+		}
+		if attrStart >= 0 {
+			j := attrStart + len("charset ")
 			k := j
 			for k < len(expr) && isIdentByte(expr[k]) {
 				k++
 			}
 			if k > j && !strings.EqualFold(expr[j:k], "binary") {
-				i = k // drop " charset <name>"
+				found = append(found, castCharsetAt{off: b.Len(), name: expr[j:k]})
+				i = k // drop the attribute (and its leading space when present)
 				continue
 			}
 		}
 		b.WriteByte(c)
 		i++
 	}
-	return b.String()
+	return b.String(), found
+}
+
+func stripCastCharsets(expr string) string {
+	s, _ := stripAndCollectCastCharsets(expr)
+	return s
+}
+
+// castCharsetsCompatible reports whether two canonical expression texts are
+// equal up to cast charset attributes with WILDCARD-on-absent semantics: the
+// charset-stripped texts must be identical, and wherever BOTH sides carry an
+// attribute at the same position the names must match (an explicit
+// latin1 -> utf8mb4 cast change is a real migration), while an attribute
+// present on only one side — a charset-less user cast against the connection
+// charset the engine stored — matches anything.
+func castCharsetsCompatible(a, b string) bool {
+	if a == b {
+		return true
+	}
+	sa, la := stripAndCollectCastCharsets(a)
+	sb, lb := stripAndCollectCastCharsets(b)
+	if sa != sb {
+		return false
+	}
+	ia, ib := 0, 0
+	for ia < len(la) && ib < len(lb) {
+		switch {
+		case la[ia].off == lb[ib].off:
+			if !strings.EqualFold(la[ia].name, lb[ib].name) {
+				return false
+			}
+			ia++
+			ib++
+		case la[ia].off < lb[ib].off:
+			ia++ // attribute only on a — wildcard against an omitted cast charset on b
+		default:
+			ib++
+		}
+	}
+	return true
+}
+
+// columnsCastCharsetWildcardEqual reports whether two same-name columns whose
+// aggregate keys differ are nonetheless equal under cast-charset WILDCARD
+// semantics: every non-expression aspect identical, expression texts identical
+// after stripping cast charsets, and the charsets themselves compatible
+// (equal where both sides carry one; free where one side omitted it). This is
+// the pairwise complement to keeping explicit charsets in the canonical KEY:
+// an explicit CHARACTER SET latin1 -> utf8mb4 change stays a real diff, while
+// a charset-less user cast does not phantom-diff against the connection
+// charset its readback carries.
+func (n *Normalizer) columnsCastCharsetWildcardEqual(fromTbl, toTbl *Table, a, b *Column) bool {
+	if n.canonicalColumn(fromTbl, a, true) != n.canonicalColumn(toTbl, b, true) {
+		return false
+	}
+	ga, gb := "", ""
+	if a.Generated != nil {
+		ga = n.CanonicalGeneratedExpr(a.Generated.Expr)
+	}
+	if b.Generated != nil {
+		gb = n.CanonicalGeneratedExpr(b.Generated.Expr)
+	}
+	if !castCharsetsCompatible(ga, gb) {
+		return false
+	}
+	da, _ := n.CanonicalTimestampDefaults(fromTbl, a)
+	db, _ := n.CanonicalTimestampDefaults(toTbl, b)
+	if strings.HasPrefix(da, "expr:") || strings.HasPrefix(db, "expr:") {
+		return castCharsetsCompatible(strings.TrimPrefix(da, "expr:"), strings.TrimPrefix(db, "expr:"))
+	}
+	return true
 }
 
 // scanStringLiteral returns the index just past a single-quoted string literal that
@@ -1316,12 +1405,26 @@ func (n *Normalizer) CanonicalIndexColumn(ic *IndexColumn) string {
 // It is the primary entry point; the individual Canonical*/Resolve* methods are exposed
 // for differs that need a single aspect (e.g. an ALTER that only touches the default).
 func (n *Normalizer) CanonicalColumn(table *Table, c *Column) string {
+	return n.canonicalColumn(table, c, false)
+}
+
+// canonicalColumn builds the aggregate key; with stripCastCS it strips the
+// cast charset attributes from the two expression-bearing fields (generated
+// expression and expression default) — the wildcard half of the cast-charset
+// comparison in columnsCastCharsetWildcardEqual.
+func (n *Normalizer) canonicalColumn(table *Table, c *Column, stripCastCS bool) string {
 	charset, collation := n.ResolveColumnCharsetCollation(table, c)
 	def, onUpdate := n.CanonicalTimestampDefaults(table, c)
+	if stripCastCS && strings.HasPrefix(def, "expr:") {
+		def = "expr:" + stripCastCharsets(def[len("expr:"):])
+	}
 
 	gen, stored := "", ""
 	if c.Generated != nil {
 		gen = n.CanonicalGeneratedExpr(c.Generated.Expr)
+		if stripCastCS {
+			gen = stripCastCharsets(gen)
+		}
 		stored = strconv.FormatBool(c.Generated.Stored)
 	}
 	// Length-delimited field encoding: each value is prefixed with its byte length, so a

--- a/mysql/catalog/normalize_test.go
+++ b/mysql/catalog/normalize_test.go
@@ -1128,7 +1128,10 @@ func TestPartitionConstantFold_Bounds(t *testing.T) {
 		{"year-fn", hdr + "CREATE TABLE t (dt DATE) PARTITION BY RANGE (YEAR(dt)) (PARTITION p0 VALUES LESS THAN (YEAR('2020-06-15')));", "p0", "2020"},
 		{"list-arith", hdr + "CREATE TABLE t (id INT) PARTITION BY LIST (id) (PARTITION p0 VALUES IN (1+1, 2+2));", "p0", "2,4"},
 		// Flagged residual: an unsupported function stays verbatim (does not get a wrong fold).
-		{"unsupported-verbatim", hdr + "CREATE TABLE t (id INT) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (ABS(-5)));", "p0", "abs(-5)"},
+		// The rendered fallback uses the engine's unary-minus print form -(5)
+		// (oracle 8.0.32 + 5.7.25: the engine parenthesizes unary-minus operands,
+		// literals included, everywhere it re-prints an expression).
+		{"unsupported-verbatim", hdr + "CREATE TABLE t (id INT) PARTITION BY RANGE (id) (PARTITION p0 VALUES LESS THAN (ABS(-5)));", "p0", "abs(-(5))"},
 		// Deliberately-declined operators stay verbatim rather than fold to a wrong literal. MySQL
 		// evaluates MOD and the bitwise/shift operators with UNSIGNED 64-bit semantics that signed
 		// int64 does not match, so foldConstIntExpr declines them (the value the engine actually

--- a/mysql/catalog/sys_schema_oracle_test.go
+++ b/mysql/catalog/sys_schema_oracle_test.go
@@ -1,0 +1,192 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestOracle_SysSchemaDogfood is the north-star gate for the temporal-unit
+// keyword-argument deparse fix: dogfood-load the STOCK MySQL sys schema.
+//
+// From a live readback of every sys view (100 views on 8.0.32, including
+// innodb_lock_waits and the x$ variants whose bodies carry
+// timestampdiff(SECOND,...)):
+//
+//  1. LoadSDL the canonical dump (verbatim SHOW CREATE VIEW text) — catA;
+//     catA must self-diff empty.
+//  2. GenerateMigration(empty → catA) — one CREATE OR REPLACE VIEW per view.
+//  3. APPLY the full plan to a scratch database on the live engine (each
+//     statement rehomed to the scratch db by view name only; body references
+//     keep pointing at the real sys/performance_schema objects, which is
+//     exactly what the plan's deparse fidelity is being tested against).
+//     Before the fix this leg failed with error 1064: the plan rendered
+//     timestampdiff(`SECOND`,...) with a quoted unit.
+//  4. Re-dump the scratch database and LoadSDL it — catB.
+//  5. catA vs catB must diff EMPTY in both directions (the readback →
+//     generate → apply → re-dump loop is a fixed point).
+//
+// 8.0 only: the 5.7 box ships sys 1.5.1 whose view bodies exercise an
+// unrelated surface; the enterprise-baseline harness leg this test
+// replicates (TestSDLEnterpriseBaseline/mysql80/sys) targets 8.0.
+func TestOracle_SysSchemaDogfood(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	o := connectOracle(t, MySQL80)
+	n := NormalizerFor(MySQL80)
+	ctx := context.Background()
+
+	// Enumerate and read back every sys view, verbatim.
+	rows, err := o.db.QueryContext(ctx,
+		"SELECT table_name FROM information_schema.views WHERE table_schema='sys' ORDER BY table_name")
+	if err != nil {
+		t.Skipf("[%s] cannot enumerate sys views: %v", o.name, err)
+	}
+	var viewNames []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("[%s] scan view name: %v", o.name, err)
+		}
+		viewNames = append(viewNames, name)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("[%s] enumerate sys views: %v", o.name, err)
+	}
+	_ = rows.Close()
+	if len(viewNames) == 0 {
+		t.Skipf("[%s] sys schema has no views (not installed?)", o.name)
+	}
+
+	var dump strings.Builder
+	dump.WriteString("CREATE DATABASE sys;\nUSE sys;\n")
+	for _, name := range viewNames {
+		var vn, ddl, cs, coll string
+		row := o.db.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE VIEW sys.`%s`", name))
+		if err := row.Scan(&vn, &ddl, &cs, &coll); err != nil {
+			t.Fatalf("[%s] SHOW CREATE VIEW sys.%s: %v", o.name, name, err)
+		}
+		dump.WriteString(ddl)
+		dump.WriteString(";\n")
+	}
+
+	// Gate 1: the canonical dump loads and self-diffs empty.
+	catA, err := LoadSDLWithVersion(dump.String(), MySQL80)
+	if err != nil {
+		t.Fatalf("[%s] LoadSDL(sys dump) failed: %v", o.name, err)
+	}
+	dbA := catA.GetDatabase("sys")
+	if dbA == nil || len(dbA.Views) != len(viewNames) {
+		t.Fatalf("[%s] loaded catalog has %d sys views, want %d", o.name, len(dbA.Views), len(viewNames))
+	}
+	if d := DiffWithNormalizer(catA, catA, n); !d.IsEmpty() {
+		t.Fatalf("[%s] sys dump self-diff not empty: %s", o.name, describeViewDiff(d))
+	}
+
+	// Gate 2: generate the full create plan from empty.
+	empty := New()
+	diff := DiffWithNormalizer(empty, catA, n)
+	plan := GenerateMigrationWithNormalizer(empty, catA, diff, n)
+	var viewOps int
+	for _, op := range plan.Ops {
+		if strings.Contains(op.SQL, " VIEW ") {
+			viewOps++
+		}
+	}
+	if viewOps != len(viewNames) {
+		t.Fatalf("[%s] plan has %d view statements, want %d\n%s", o.name, viewOps, len(viewNames), plan.SQL())
+	}
+
+	// Apply the plan to a scratch database. Each statement is rehomed by
+	// view NAME only — body references stay on the real sys /
+	// performance_schema objects, so every generated body is parsed and
+	// validated by the live engine exactly as rendered.
+	const scratch = "tudsdl_sysdf"
+	conn, err := o.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("[%s] grab conn: %v", o.name, err)
+	}
+	defer func() { _ = conn.Close() }()
+	defer func() {
+		_, _ = conn.ExecContext(ctx, "DROP DATABASE IF EXISTS "+scratch)
+	}()
+	// The session default database is `sys`, not the scratch db: stored view
+	// bodies keep FUNCTION references unqualified (sys_config getters,
+	// format_path, ...), and the engine resolves those against the default
+	// database at CREATE VIEW time. The enterprise harness this replicates
+	// applies into a database that carries the sys routines; pointing
+	// resolution at the real sys schema is the in-omni equivalent. Every
+	// CREATE statement still explicitly targets the scratch db.
+	for _, s := range []string{
+		"DROP DATABASE IF EXISTS " + scratch,
+		"CREATE DATABASE " + scratch,
+		"USE sys",
+	} {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Fatalf("[%s] scratch setup %q: %v", o.name, s, err)
+		}
+	}
+	for _, op := range plan.Ops {
+		if !strings.Contains(op.SQL, " VIEW ") {
+			continue // the CREATE DATABASE op; the scratch db replaces it
+		}
+		stmt := strings.Replace(op.SQL, "VIEW `sys`.`", "VIEW `"+scratch+"`.`", 1)
+		if stmt == op.SQL {
+			t.Fatalf("[%s] could not rehome plan statement: %s", o.name, op.SQL)
+		}
+		if _, err := conn.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("[%s] APPLY FAILED (the dogfood leg):\n  stmt: %.300s\n  err: %v", o.name, stmt, err)
+		}
+	}
+
+	// Gate 3: re-dump the scratch database and require a fixed point.
+	var redump strings.Builder
+	redump.WriteString("CREATE DATABASE sys;\nUSE sys;\n")
+	for _, name := range viewNames {
+		var vn, ddl, cs, coll string
+		row := conn.QueryRowContext(ctx, fmt.Sprintf("SHOW CREATE VIEW %s.`%s`", scratch, name))
+		if err := row.Scan(&vn, &ddl, &cs, &coll); err != nil {
+			t.Fatalf("[%s] re-dump SHOW CREATE VIEW %s.%s: %v", o.name, scratch, name, err)
+		}
+		rehomed := strings.Replace(ddl, "VIEW `"+scratch+"`.`", "VIEW `sys`.`", 1)
+		if rehomed == ddl {
+			t.Fatalf("[%s] could not rehome re-dumped view %s: %.200s", o.name, name, ddl)
+		}
+		redump.WriteString(rehomed)
+		redump.WriteString(";\n")
+	}
+	catB, err := LoadSDLWithVersion(redump.String(), MySQL80)
+	if err != nil {
+		t.Fatalf("[%s] LoadSDL(re-dump) failed: %v", o.name, err)
+	}
+	if d := DiffWithNormalizer(catA, catB, n); !d.IsEmpty() {
+		reportSysViewDrift(t, catA, catB)
+		t.Fatalf("[%s] NORTH STAR: dump vs re-dump not empty: %s", o.name, describeViewDiff(d))
+	}
+	if d := DiffWithNormalizer(catB, catA, n); !d.IsEmpty() {
+		reportSysViewDrift(t, catA, catB)
+		t.Fatalf("[%s] NORTH STAR (reverse): re-dump vs dump not empty: %s", o.name, describeViewDiff(d))
+	}
+}
+
+// reportSysViewDrift prints per-view Definition differences for failure triage.
+func reportSysViewDrift(t *testing.T, catA, catB *Catalog) {
+	t.Helper()
+	dbA := catA.GetDatabase("sys")
+	dbB := catB.GetDatabase("sys")
+	if dbA == nil || dbB == nil {
+		return
+	}
+	for name, va := range dbA.Views {
+		vb := dbB.Views[name]
+		if vb == nil {
+			t.Logf("view %s missing after re-dump", name)
+			continue
+		}
+		if va.Definition != vb.Definition {
+			t.Logf("view %s drifted:\n  dump:    %s\n  re-dump: %s", name, va.Definition, vb.Definition)
+		}
+	}
+}

--- a/mysql/catalog/tablecmds.go
+++ b/mysql/catalog/tablecmds.go
@@ -1940,6 +1940,16 @@ func nodeToSQLGenerated(node nodes.ExprNode, charset string) string {
 	case *nodes.IntervalExpr:
 		// Oracle 8.0.32 stored form: ((`a` + interval 1 day)).
 		return "interval " + nodeToSQLGenerated(n.Value, charset) + " " + strings.ToLower(n.Unit)
+	case *nodes.CastExpr:
+		// Oracle 8.0.32 stored forms: cast(`a` as char(4) charset latin1),
+		// cast(`s` as signed), and the WEIGHT_STRING(... AS BINARY(n))
+		// desugar weight_string(cast(`s` as char(4) charset binary)).
+		result := "cast(" + nodeToSQLGenerated(n.Expr, charset) + " as " + castTypeToSQLGenerated(n.TypeName)
+		if n.Array {
+			// Multi-valued index form: stored with a lowercase trailing array.
+			result += " array"
+		}
+		return result + ")"
 	case *nodes.WeightStringExpr:
 		// Oracle 8.0.32 stored form: weight_string(`s` as char(4)).
 		var b strings.Builder
@@ -1988,6 +1998,38 @@ func nodeToSQLGenerated(node nodes.ExprNode, charset string) string {
 	default:
 		return "(?)"
 	}
+}
+
+// castTypeToSQLGenerated renders a CAST target type in the form SHOW CREATE
+// TABLE stores inside generated-column expressions (oracle 8.0.32 + 5.7.25):
+// lowercase names, length/precision kept, and the charset attribute rendered
+// only when the parsed type carries one — readbacks always do for CHAR
+// (cast(`a` as char(4) charset latin1)); a user form without a charset is
+// rendered as written.
+func castTypeToSQLGenerated(dt *nodes.DataType) string {
+	if dt == nil {
+		return ""
+	}
+	name := strings.ToLower(dt.Name)
+	result := name
+	switch name {
+	case "decimal":
+		if dt.Length > 0 || dt.Scale > 0 {
+			result += fmt.Sprintf("(%d,%d)", dt.Length, dt.Scale)
+		}
+	case "datetime", "time":
+		if dt.Length > 0 {
+			result += fmt.Sprintf("(%d)", dt.Length)
+		}
+	default:
+		if dt.Length > 0 {
+			result += fmt.Sprintf("(%d)", dt.Length)
+		}
+	}
+	if dt.Charset != "" {
+		result += " charset " + strings.ToLower(dt.Charset)
+	}
+	return result
 }
 
 func nodeToSQL(node nodes.ExprNode) string {

--- a/mysql/catalog/tablecmds.go
+++ b/mysql/catalog/tablecmds.go
@@ -1965,8 +1965,11 @@ func nodeToSQLGenerated(node nodes.ExprNode, charset string) string {
 				b.WriteString(",")
 			}
 			fmt.Fprintf(&b, "%d", lv.Level)
-			if lv.Dir != "" {
-				b.WriteString(" " + strings.ToLower(lv.Dir))
+			if lv.Desc {
+				b.WriteString(" desc")
+			}
+			if lv.Reverse {
+				b.WriteString(" reverse")
 			}
 		}
 		b.WriteString(")")

--- a/mysql/catalog/tablecmds.go
+++ b/mysql/catalog/tablecmds.go
@@ -1929,6 +1929,38 @@ func nodeToSQLGenerated(node nodes.ExprNode, charset string) string {
 		return "b'" + val + "'"
 	case *nodes.ParenExpr:
 		return "(" + nodeToSQLGenerated(n.Expr, charset) + ")"
+	case *nodes.KeywordArg:
+		// Bare keyword argument (timestampdiff unit, get_format type) —
+		// stored unquoted in generated-column bodies exactly like view
+		// bodies (oracle 8.0.32: AS (timestampdiff(SECOND,`a`,`b`))).
+		return n.Keyword
+	case *nodes.ExtractExpr:
+		// Oracle 8.0.32 stored form: extract(day_hour from `a`).
+		return "extract(" + strings.ToLower(n.Unit) + " from " + nodeToSQLGenerated(n.Expr, charset) + ")"
+	case *nodes.IntervalExpr:
+		// Oracle 8.0.32 stored form: ((`a` + interval 1 day)).
+		return "interval " + nodeToSQLGenerated(n.Value, charset) + " " + strings.ToLower(n.Unit)
+	case *nodes.WeightStringExpr:
+		// Oracle 8.0.32 stored form: weight_string(`s` as char(4)).
+		var b strings.Builder
+		b.WriteString("weight_string(")
+		b.WriteString(nodeToSQLGenerated(n.Expr, charset))
+		if n.AsChar != nil {
+			fmt.Fprintf(&b, " as char(%d)", n.AsChar.Length)
+		}
+		for i, lv := range n.Levels {
+			if i == 0 {
+				b.WriteString(" level ")
+			} else {
+				b.WriteString(",")
+			}
+			fmt.Fprintf(&b, "%d", lv.Level)
+			if lv.Dir != "" {
+				b.WriteString(" " + strings.ToLower(lv.Dir))
+			}
+		}
+		b.WriteString(")")
+		return b.String()
 	case *nodes.BinaryExpr:
 		left := nodeToSQLGenerated(n.Left, charset)
 		right := nodeToSQLGenerated(n.Right, charset)

--- a/mysql/catalog/tablecmds.go
+++ b/mysql/catalog/tablecmds.go
@@ -254,8 +254,14 @@ func (c *Catalog) createTable(stmt *nodes.CreateTableStmt) error {
 			setColumnOnUpdateFromExpr(col, colDef.OnUpdate)
 		}
 		if colDef.Generated != nil {
+			// Generated expressions are stored by the engine in resolver-rewritten
+			// form — TIMESTAMPADD/DATE_ADD fold to interval arithmetic, NOT folds
+			// to inverted comparisons — identical to view bodies (oracle 8.0.32:
+			// AS (TIMESTAMPADD(HOUR,1,a)) stores as ((`a` + interval 1 hour)),
+			// AS (NOT a) as ((0 = `a`))). Apply the same rewrite pass before
+			// rendering so user-declared SDL canonicalizes to the stored form.
 			col.Generated = &GeneratedColumnInfo{
-				Expr:   nodeToSQLGenerated(colDef.Generated.Expr, tbl.Charset),
+				Expr:   nodeToSQLGenerated(deparse.RewriteExpr(colDef.Generated.Expr), tbl.Charset),
 				Stored: colDef.Generated.Stored,
 			}
 		}
@@ -2014,6 +2020,16 @@ func castTypeToSQLGenerated(dt *nodes.DataType) string {
 		return ""
 	}
 	name := strings.ToLower(dt.Name)
+	if name == "binary" {
+		// CAST(x AS BINARY[(n)]) is stored as cast(x as char[(n)] charset
+		// binary) — same rewrite the view deparser applies (oracle 8.0.32 +
+		// 5.7.25, view/generated/CHECK positions alike).
+		result := "char"
+		if dt.Length > 0 {
+			result += fmt.Sprintf("(%d)", dt.Length)
+		}
+		return result + " charset binary"
+	}
 	result := name
 	switch name {
 	case "decimal":

--- a/mysql/catalog/temporal_unit_test.go
+++ b/mysql/catalog/temporal_unit_test.go
@@ -1,0 +1,236 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+)
+
+// Stored-form fidelity for temporal-unit / keyword-argument positions.
+//
+// Every case's `stored` string is a live-engine SHOW CREATE VIEW readback
+// (oracle 8.0.32 :13306 + 5.7.25 :13307 — the two agree on every form here
+// except WEIGHT_STRING's LEVEL suffix, which only 5.7 emits). LoadSDL of the
+// stored form must regenerate EXACTLY the stored form: any drift (a
+// backtick-quoted unit, a lost keyword form) produces CREATE VIEW DDL the
+// engine rejects with error 1064 — the sys-schema dogfood bug this file
+// pins: timestampdiff(`SECOND`,...) fails to apply while the engine stores
+// timestampdiff(SECOND,...) bare.
+func TestTemporalUnitStoredFormRoundTrip(t *testing.T) {
+	cases := []struct{ id, stored string }{
+		// TIMESTAMPDIFF: unit stays bare UPPERCASE, args joined without spaces.
+		{"tsdiff-microsecond", "select timestampdiff(MICROSECOND,'2020-01-01','2021-01-01') AS `x`"},
+		{"tsdiff-second", "select timestampdiff(SECOND,'2020-01-01','2021-01-01') AS `x`"},
+		{"tsdiff-minute", "select timestampdiff(MINUTE,'2020-01-01','2021-01-01') AS `x`"},
+		{"tsdiff-hour", "select timestampdiff(HOUR,'2020-01-01','2021-01-01') AS `x`"},
+		{"tsdiff-day", "select timestampdiff(DAY,'2020-01-01','2021-01-01') AS `x`"},
+		{"tsdiff-week", "select timestampdiff(WEEK,'2020-01-01','2021-01-01') AS `x`"},
+		{"tsdiff-month", "select timestampdiff(MONTH,'2020-01-01','2021-01-01') AS `x`"},
+		{"tsdiff-quarter", "select timestampdiff(QUARTER,'2020-01-01','2021-01-01') AS `x`"},
+		{"tsdiff-year", "select timestampdiff(YEAR,'2020-01-01','2021-01-01') AS `x`"},
+		// The sys.innodb_lock_waits shape: column refs + now() as arguments.
+		{"tsdiff-column-args", "select timestampdiff(SECOND,`t`.`created`,now()) AS `x`"},
+		// Nested interval arithmetic inside a timestampdiff argument.
+		{"tsdiff-nested-interval", "select timestampdiff(SECOND,(now() - interval 1 day),now()) AS `x`"},
+		// INTERVAL arithmetic: lowercase unit, value parenthesized when non-literal.
+		{"interval-plus", "select ('2020-01-01' + interval 1 second) AS `x`"},
+		{"interval-minus", "select ('2020-01-01' - interval 1 day) AS `x`"},
+		{"interval-compound", "select ('2020-01-01' + interval '1:1' day_hour) AS `x`"},
+		{"interval-expr-value", "select (now() + interval (1 + 1) day) AS `x`"},
+		{"interval-neg-value", "select ('2020-01-01' + interval -(5) day) AS `x`"},
+		// EXTRACT: lowercase unit, simple and compound.
+		{"extract-microsecond", "select extract(microsecond from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-second", "select extract(second from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-minute", "select extract(minute from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-hour", "select extract(hour from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-day", "select extract(day from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-week", "select extract(week from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-month", "select extract(month from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-quarter", "select extract(quarter from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-year", "select extract(year from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-second-microsecond", "select extract(second_microsecond from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-minute-microsecond", "select extract(minute_microsecond from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-minute-second", "select extract(minute_second from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-hour-microsecond", "select extract(hour_microsecond from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-hour-second", "select extract(hour_second from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-hour-minute", "select extract(hour_minute from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-day-microsecond", "select extract(day_microsecond from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-day-second", "select extract(day_second from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-day-minute", "select extract(day_minute from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-day-hour", "select extract(day_hour from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-year-month", "select extract(year_month from '2020-01-01 10:20:30') AS `x`"},
+		// GET_FORMAT: bare UPPERCASE type, and a space after its comma.
+		{"get-format-date", "select get_format(DATE, 'USA') AS `x`"},
+		{"get-format-time", "select get_format(TIME, 'USA') AS `x`"},
+		{"get-format-datetime", "select get_format(DATETIME, 'USA') AS `x`"},
+		// WEIGHT_STRING: plain, AS CHAR(n), the desugared AS BINARY cast form,
+		// and the 5.7 LEVEL suffixes (5.7 readbacks always carry a level list).
+		{"weight-string-plain", "select weight_string('ab') AS `x`"},
+		{"weight-string-as-char", "select weight_string('ab' as char(4)) AS `x`"},
+		{"weight-string-cast-binary", "select weight_string(cast('ab' as char(4) charset binary)) AS `x`"},
+		{"weight-string-level", "select weight_string('ab' level 1) AS `x`"},
+		{"weight-string-level-desc", "select weight_string('ab' level 1 desc) AS `x`"},
+		{"weight-string-level-reverse", "select weight_string('ab' level 1 reverse) AS `x`"},
+		{"weight-string-as-char-level", "select weight_string('ab' as char(4) level 1) AS `x`"},
+		// TRIM: directional and the direction-less remstr FROM form.
+		{"trim-both", "select trim(both 'x' from 'xax') AS `x`"},
+		{"trim-leading", "select trim(leading 'x' from 'xax') AS `x`"},
+		{"trim-trailing", "select trim(trailing 'x' from 'xax') AS `x`"},
+		{"trim-remstr-from", "select trim(' x' from 'axa') AS `x`"},
+		{"trim-plain", "select trim(' a ') AS `x`"},
+		// SUBSTRING: engine stores the comma form under the substr name.
+		{"substr-comma", "select substr('abcd',2,2) AS `x`"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			sdl := "CREATE DATABASE d;\nUSE d;\n" +
+				"CREATE TABLE `t` (`id` int NOT NULL, `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n" +
+				"CREATE OR REPLACE VIEW `v` AS " + tc.stored + ";\n"
+			cat, err := LoadSDL(sdl)
+			if err != nil {
+				t.Fatalf("LoadSDL(stored form) failed: %v", err)
+			}
+			v := cat.GetDatabase("d").Views["v"]
+			if v == nil {
+				t.Fatal("view not loaded")
+			}
+			if v.Definition != tc.stored {
+				t.Errorf("stored form not a fixed point:\n  stored: %s\n  omni:   %s", tc.stored, v.Definition)
+			}
+		})
+	}
+}
+
+// User-declared forms must canonicalize to the engine's stored form, so a
+// no-op SDL diff against a live readback stays empty. Every `want` string is
+// an oracle readback (8.0.32 + 5.7.25 agree): the date-arithmetic function
+// family is stored as INTERVAL arithmetic, units are case-folded, SQL_TSI_
+// synonyms are folded, and GET_FORMAT(TIMESTAMP,...) stores as DATETIME.
+func TestTemporalUnitUserFormCanonicalization(t *testing.T) {
+	cases := []struct{ id, user, want string }{
+		{"timestampadd", "select TIMESTAMPADD(HOUR, 1, '2020-01-01') AS `x`", "select ('2020-01-01' + interval 1 hour) AS `x`"},
+		{"timestampadd-sql-tsi", "select TIMESTAMPADD(SQL_TSI_HOUR, 1, '2020-01-01') AS `x`", "select ('2020-01-01' + interval 1 hour) AS `x`"},
+		{"date-add", "select DATE_ADD('2020-01-01', INTERVAL 1 DAY) AS `x`", "select ('2020-01-01' + interval 1 day) AS `x`"},
+		{"date-sub", "select DATE_SUB('2020-01-01', INTERVAL 1 DAY) AS `x`", "select ('2020-01-01' - interval 1 day) AS `x`"},
+		{"date-add-compound", "select DATE_ADD('2020-01-01', INTERVAL '1:1' DAY_HOUR) AS `x`", "select ('2020-01-01' + interval '1:1' day_hour) AS `x`"},
+		{"date-add-expr-count", "select DATE_ADD('2020-01-01', INTERVAL 2*3 HOUR) AS `x`", "select ('2020-01-01' + interval (2 * 3) hour) AS `x`"},
+		{"adddate-interval", "select ADDDATE('2020-01-01', INTERVAL 1 DAY) AS `x`", "select ('2020-01-01' + interval 1 day) AS `x`"},
+		{"adddate-days", "select ADDDATE('2020-01-01', 31) AS `x`", "select ('2020-01-01' + interval 31 day) AS `x`"},
+		{"adddate-negative-days", "select ADDDATE('2020-01-01', -5) AS `x`", "select ('2020-01-01' + interval -(5) day) AS `x`"},
+		{"subdate-interval", "select SUBDATE('2020-01-01', INTERVAL 1 DAY) AS `x`", "select ('2020-01-01' - interval 1 day) AS `x`"},
+		{"subdate-days", "select SUBDATE('2020-01-01', 31) AS `x`", "select ('2020-01-01' - interval 31 day) AS `x`"},
+		{"nested-date-add", "select DATE_ADD(DATE_ADD('2020-01-01', INTERVAL 1 DAY), INTERVAL 1 HOUR) AS `x`", "select (('2020-01-01' + interval 1 day) + interval 1 hour) AS `x`"},
+		{"bare-interval", "select NOW() + INTERVAL 1 DAY AS `x`", "select (now() + interval 1 day) AS `x`"},
+		{"interval-first-commutes", "select INTERVAL 1 DAY + NOW() AS `x`", "select (now() + interval 1 day) AS `x`"},
+		{"interval-sql-tsi", "select NOW() + INTERVAL 1 SQL_TSI_DAY AS `x`", "select (now() + interval 1 day) AS `x`"},
+		{"tsdiff-lowercase-unit", "select timestampdiff(second,'2020-01-01','2021-01-01') AS `x`", "select timestampdiff(SECOND,'2020-01-01','2021-01-01') AS `x`"},
+		{"tsdiff-sql-tsi", "select timestampdiff(SQL_TSI_SECOND,'2020-01-01','2021-01-01') AS `x`", "select timestampdiff(SECOND,'2020-01-01','2021-01-01') AS `x`"},
+		{"get-format-lowercase", "select get_format(date,'USA') AS `x`", "select get_format(DATE, 'USA') AS `x`"},
+		{"get-format-timestamp", "select GET_FORMAT(TIMESTAMP,'USA') AS `x`", "select get_format(DATETIME, 'USA') AS `x`"},
+		{"extract-uppercase-unit", "select EXTRACT(DAY_HOUR FROM '2020-01-01 10:20:30') AS `x`", "select extract(day_hour from '2020-01-01 10:20:30') AS `x`"},
+		{"extract-sql-tsi", "select EXTRACT(SQL_TSI_DAY FROM '2020-01-01') AS `x`", "select extract(day from '2020-01-01') AS `x`"},
+		{"weight-string-as-binary", "select WEIGHT_STRING('ab' AS BINARY(4)) AS `x`", "select weight_string(cast('ab' as char(4) charset binary)) AS `x`"},
+		{"weight-string-level-asc", "select WEIGHT_STRING('ab' LEVEL 1 ASC) AS `x`", "select weight_string('ab' level 1) AS `x`"},
+		{"substring-from-for", "select SUBSTRING('abcd' FROM 2 FOR 2) AS `x`", "select substr('abcd',2,2) AS `x`"},
+		// A schema-qualified name is a stored function, not the builtin: its
+		// arguments are ordinary expressions and the qualifier must survive
+		// deparse (regression: the GET_FORMAT deparse special case must not
+		// swallow `mydb`.). The unquoted qualified rendering below is omni's
+		// long-standing form for ALL qualified functions — the engine stores
+		// them backticked (oracle 8.0.32), a separate pre-existing gap.
+		{"qualified-get-format", "select `mydb`.`get_format`('a','b') AS `x`", "select mydb.get_format('a','b') AS `x`"},
+		{"qualified-timestampdiff", "select `mydb`.`timestampdiff`(`c`,'a','b') AS `x`", "select mydb.timestampdiff(`c`,'a','b') AS `x`"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			sdl := "CREATE DATABASE d;\nUSE d;\nCREATE OR REPLACE VIEW `v` AS " + tc.user + ";\n"
+			cat, err := LoadSDL(sdl)
+			if err != nil {
+				t.Fatalf("LoadSDL(user form) failed: %v", err)
+			}
+			v := cat.GetDatabase("d").Views["v"]
+			if v == nil {
+				t.Fatal("view not loaded")
+			}
+			if v.Definition != tc.want {
+				t.Errorf("user form not canonicalized to the stored form:\n  user: %s\n  want: %s\n  omni: %s", tc.user, tc.want, v.Definition)
+			}
+		})
+	}
+}
+
+// Generated-column bodies and functional indexes are rendered by their own
+// printers (nodeToSQLGenerated / the index-expression path), which must emit
+// the same engine-stored forms as view bodies. Every `stored` fragment below
+// is a live SHOW CREATE TABLE readback (oracle 8.0.32): a lost case there
+// renders `(?)` and the CREATE TABLE fails to apply.
+func TestTemporalUnitGeneratedColumnRoundTrip(t *testing.T) {
+	sdl := "CREATE DATABASE d;\nUSE d;\n" +
+		"CREATE TABLE `fi` (\n" +
+		"  `a` datetime DEFAULT NULL,\n" +
+		"  `b` datetime DEFAULT NULL,\n" +
+		"  KEY `idx` ((timestampdiff(SECOND,`a`,`b`)))\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n" +
+		"CREATE TABLE `g` (\n" +
+		"  `a` datetime DEFAULT NULL,\n" +
+		"  `s` varchar(10) DEFAULT NULL,\n" +
+		"  `c1` int GENERATED ALWAYS AS (timestampdiff(SECOND,`a`,`a`)) VIRTUAL,\n" +
+		"  `c2` int GENERATED ALWAYS AS (extract(day_hour from `a`)) VIRTUAL,\n" +
+		"  `c3` datetime GENERATED ALWAYS AS ((`a` + interval 1 day)) VIRTUAL,\n" +
+		"  `c4` int GENERATED ALWAYS AS (abs(-(5))) VIRTUAL,\n" +
+		"  `c5` varbinary(16) GENERATED ALWAYS AS (weight_string(`s` as char(4))) VIRTUAL\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n"
+	cat, err := LoadSDL(sdl)
+	if err != nil {
+		t.Fatalf("LoadSDL failed: %v", err)
+	}
+	cat2, err := LoadSDL(sdl)
+	if err != nil {
+		t.Fatalf("LoadSDL (second) failed: %v", err)
+	}
+	if d := Diff(cat, cat2); !d.IsEmpty() {
+		t.Errorf("self-diff not empty")
+	}
+	plan := GenerateMigration(New(), cat, Diff(New(), cat))
+	sql := plan.SQL()
+	if strings.Contains(sql, "(?)") {
+		t.Errorf("generated plan contains the (?) placeholder — an expression node is missing from the generated-column renderer:\n%s", sql)
+	}
+	for _, want := range []string{
+		"(timestampdiff(SECOND,`a`,`a`))",
+		"(extract(day_hour from `a`))",
+		"((`a` + interval 1 day))",
+		"(abs(-(5)))",
+		"(weight_string(`s` as char(4)))",
+		"((timestampdiff(SECOND,`a`,`b`)))",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("generated plan missing the engine-stored fragment %q:\n%s", want, sql)
+		}
+	}
+}
+
+// The engine rejects malformed keyword arguments with error 1064; the parser
+// must reject them too rather than mis-parse them as identifiers. The
+// quoted-unit case is the inverse of the dogfood bug: timestampdiff(`SECOND`,...)
+// is NOT valid MySQL (oracle 8.0.32 + 5.7.25).
+func TestTemporalUnitParserRejections(t *testing.T) {
+	cases := []struct{ id, body string }{
+		{"tsdiff-quoted-unit", "select timestampdiff(`SECOND`,'2020-01-01','2021-01-01') AS `x`"},
+		{"tsdiff-string-unit", "select timestampdiff('SECOND','2020-01-01','2021-01-01') AS `x`"},
+		{"tsdiff-compound-unit", "select timestampdiff(DAY_HOUR,'2020-01-01','2021-01-01') AS `x`"},
+		{"tsdiff-sql-tsi-microsecond", "select timestampdiff(SQL_TSI_MICROSECOND,'2020-01-01','2021-01-01') AS `x`"},
+		{"get-format-year", "select get_format(YEAR,'USA') AS `x`"},
+		{"get-format-string", "select get_format('DATE','USA') AS `x`"},
+		{"extract-quoted-unit", "select extract(`day` from '2020-01-01') AS `x`"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			sdl := "CREATE DATABASE d;\nUSE d;\nCREATE VIEW `v` AS " + tc.body + ";\n"
+			if _, err := LoadSDL(sdl); err == nil {
+				t.Errorf("expected parse error (engine rejects with 1064), got success for: %s", tc.body)
+			} else if !strings.Contains(err.Error(), "line") {
+				t.Logf("rejected (as expected): %v", err)
+			}
+		})
+	}
+}

--- a/mysql/catalog/temporal_unit_test.go
+++ b/mysql/catalog/temporal_unit_test.go
@@ -131,6 +131,15 @@ func TestTemporalUnitUserFormCanonicalization(t *testing.T) {
 		{"extract-sql-tsi", "select EXTRACT(SQL_TSI_DAY FROM '2020-01-01') AS `x`", "select extract(day from '2020-01-01') AS `x`"},
 		{"weight-string-as-binary", "select WEIGHT_STRING('ab' AS BINARY(4)) AS `x`", "select weight_string(cast('ab' as char(4) charset binary)) AS `x`"},
 		{"weight-string-level-asc", "select WEIGHT_STRING('ab' LEVEL 1 ASC) AS `x`", "select weight_string('ab' level 1) AS `x`"},
+		// The engine clamps an out-of-range level instead of rejecting:
+		// LEVEL 0 stores as level 1 (oracle 5.7.25).
+		{"weight-string-level-0-clamps", "select WEIGHT_STRING('ab' LEVEL 0) AS `x`", "select weight_string('ab' level 1) AS `x`"},
+		// CAST/CONVERT to BINARY(n) desugar to the engine-stored
+		// char-charset-binary form in every expression position
+		// (oracle 8.0.32 + 5.7.25).
+		{"cast-as-binary", "select CAST('ab' AS BINARY(4)) AS `x`", "select cast('ab' as char(4) charset binary) AS `x`"},
+		{"cast-as-binary-nolen", "select CAST('ab' AS BINARY) AS `x`", "select cast('ab' as char charset binary) AS `x`"},
+		{"convert-binary", "select CONVERT('ab', BINARY(4)) AS `x`", "select cast('ab' as char(4) charset binary) AS `x`"},
 		{"substring-from-for", "select SUBSTRING('abcd' FROM 2 FOR 2) AS `x`", "select substr('abcd',2,2) AS `x`"},
 		// A schema-qualified name is a stored function, not the builtin: its
 		// arguments are ordinary expressions and the qualifier must survive
@@ -315,17 +324,73 @@ func TestTemporalUnitParserRejections(t *testing.T) {
 }
 
 // The charset the engine stores for a charset-less CHAR cast is the
-// CONNECTION charset of the creating session (oracle 8.0.32: the same
-// CAST(s AS CHAR(4)) generated column stores "charset latin1" via a latin1
-// session and "charset utf8mb4" via a utf8mb4 session) — connection-dependent
-// noise, exactly like the string-literal introducer CanonicalGeneratedExpr
-// already strips. A user's charset-less cast must compare equal to any
-// readback, while "charset binary" (the WEIGHT_STRING AS BINARY desugar)
-// stays semantically distinct.
+// CONNECTION charset of the creating session, while an EXPLICIT CHARACTER SET
+// survives readback distinctly (oracle 8.0.32: explicit latin1 under a
+// utf8mb4 session reads back charset latin1, and the same charset-less cast
+// stores latin1 or utf8mb4 depending only on the session). The comparison
+// therefore uses WILDCARD semantics: a charset-less user cast matches any
+// stored connection charset (no phantom diff), but an explicit
+// latin1 -> utf8mb4 change stays a REAL diff (hiding it would suppress a real
+// migration), and "charset binary" (the AS BINARY desugar) stays a distinct
+// type in every direction.
 func TestGeneratedCastCharsetComparison(t *testing.T) {
-	user := "CREATE DATABASE d;\nUSE d;\nCREATE TABLE `g` (`s` varchar(10), `c` char(4) GENERATED ALWAYS AS (CAST(`s` AS CHAR(4))) VIRTUAL);\n"
-	stored := "CREATE DATABASE d;\nUSE d;\nCREATE TABLE `g` (`s` varchar(10) DEFAULT NULL, `c` char(4) GENERATED ALWAYS AS (cast(`s` as char(4) charset utf8mb4)) VIRTUAL);\n"
-	binform := "CREATE DATABASE d;\nUSE d;\nCREATE TABLE `g` (`s` varchar(10) DEFAULT NULL, `c` char(4) GENERATED ALWAYS AS (cast(`s` as char(4) charset binary)) VIRTUAL);\n"
+	hdr := "CREATE DATABASE d;\nUSE d;\n"
+	mk := func(expr string) string {
+		return hdr + "CREATE TABLE `g` (`s` varchar(10), `c` char(4) GENERATED ALWAYS AS (" + expr + ") VIRTUAL);\n"
+	}
+	omitted := mk("CAST(`s` AS CHAR(4))")
+	expLatin := mk("cast(`s` as char(4) charset latin1)")
+	expUtf := mk("cast(`s` as char(4) charset utf8mb4)")
+	binform := mk("cast(`s` as char(4) charset binary)")
+	load := func(sdl string) *Catalog {
+		c, err := LoadSDL(sdl)
+		if err != nil {
+			t.Fatalf("LoadSDL failed: %v", err)
+		}
+		return c
+	}
+	cases := []struct {
+		id    string
+		a, b  string
+		empty bool
+	}{
+		{"omitted-vs-stored-utf8mb4", omitted, expUtf, true},
+		{"omitted-vs-stored-latin1", omitted, expLatin, true},
+		{"stored-utf8mb4-vs-omitted", expUtf, omitted, true},
+		{"explicit-latin1-vs-explicit-utf8mb4", expLatin, expUtf, false},
+		{"omitted-vs-binary", omitted, binform, false},
+		{"explicit-utf8mb4-vs-binary", expUtf, binform, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			d := Diff(load(tc.a), load(tc.b))
+			if d.IsEmpty() != tc.empty {
+				t.Errorf("diff empty = %v, want %v", d.IsEmpty(), tc.empty)
+			}
+		})
+	}
+}
+
+// Generated expressions are stored by the engine in resolver-rewritten form,
+// identical to view bodies (oracle 8.0.32: AS (TIMESTAMPADD(HOUR,1,a)) stores
+// as ((`a` + interval 1 hour)), AS (NOT a) as ((0 = `a`)), AS (CAST(s AS
+// BINARY(4))) as (cast(`s` as char(4) charset binary))). User-declared SDL
+// must canonicalize to those stored forms, and the stored forms must be
+// fixed points.
+func TestGeneratedColumnRewriteCanonicalization(t *testing.T) {
+	hdr := "CREATE DATABASE d;\nUSE d;\n"
+	user := hdr + "CREATE TABLE `t` (`a` datetime, `n` int, `s` varchar(10)," +
+		" `c1` datetime GENERATED ALWAYS AS (TIMESTAMPADD(HOUR, 1, `a`)) VIRTUAL," +
+		" `c2` datetime GENERATED ALWAYS AS (DATE_ADD(`a`, INTERVAL 1 DAY)) VIRTUAL," +
+		" `c3` int GENERATED ALWAYS AS (NOT `n`) VIRTUAL," +
+		" `c4` varbinary(8) GENERATED ALWAYS AS (CAST(`s` AS BINARY(4))) VIRTUAL," +
+		" `c5` varbinary(20) GENERATED ALWAYS AS (CAST(`s` AS BINARY)) VIRTUAL);\n"
+	stored := hdr + "CREATE TABLE `t` (`a` datetime DEFAULT NULL, `n` int DEFAULT NULL, `s` varchar(10) DEFAULT NULL," +
+		" `c1` datetime GENERATED ALWAYS AS ((`a` + interval 1 hour)) VIRTUAL," +
+		" `c2` datetime GENERATED ALWAYS AS ((`a` + interval 1 day)) VIRTUAL," +
+		" `c3` int GENERATED ALWAYS AS ((0 = `n`)) VIRTUAL," +
+		" `c4` varbinary(8) GENERATED ALWAYS AS (cast(`s` as char(4) charset binary)) VIRTUAL," +
+		" `c5` varbinary(20) GENERATED ALWAYS AS (cast(`s` as char charset binary)) VIRTUAL);\n"
 	cu, err := LoadSDL(user)
 	if err != nil {
 		t.Fatalf("LoadSDL(user) failed: %v", err)
@@ -334,14 +399,23 @@ func TestGeneratedCastCharsetComparison(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSDL(stored) failed: %v", err)
 	}
-	cb, err := LoadSDL(binform)
-	if err != nil {
-		t.Fatalf("LoadSDL(binary) failed: %v", err)
-	}
 	if d := Diff(cu, cs); !d.IsEmpty() {
-		t.Errorf("charset-less cast vs connection-charset readback must compare equal (phantom diff)")
+		t.Errorf("user forms must canonicalize to the engine-stored rewritten forms (diff not empty)")
 	}
-	if d := Diff(cu, cb); d.IsEmpty() {
-		t.Errorf("plain CHAR cast and charset-binary cast must stay distinct")
+	if d := Diff(cs, cu); !d.IsEmpty() {
+		t.Errorf("reverse direction not empty")
+	}
+	plan := GenerateMigration(New(), cu, Diff(New(), cu))
+	sql := plan.SQL()
+	for _, want := range []string{
+		"((`a` + interval 1 hour))",
+		"((`a` + interval 1 day))",
+		"((0 = `n`))",
+		"(cast(`s` as char(4) charset binary))",
+		"(cast(`s` as char charset binary))",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("generated plan missing engine-stored fragment %q:\n%s", want, sql)
+		}
 	}
 }

--- a/mysql/catalog/temporal_unit_test.go
+++ b/mysql/catalog/temporal_unit_test.go
@@ -70,6 +70,7 @@ func TestTemporalUnitStoredFormRoundTrip(t *testing.T) {
 		{"weight-string-level", "select weight_string('ab' level 1) AS `x`"},
 		{"weight-string-level-desc", "select weight_string('ab' level 1 desc) AS `x`"},
 		{"weight-string-level-reverse", "select weight_string('ab' level 1 reverse) AS `x`"},
+		{"weight-string-level-desc-reverse", "select weight_string('ab' level 1 desc reverse) AS `x`"},
 		{"weight-string-as-char-level", "select weight_string('ab' as char(4) level 1) AS `x`"},
 		// TRIM: directional and the direction-less remstr FROM form.
 		{"trim-both", "select trim(both 'x' from 'xax') AS `x`"},
@@ -224,7 +225,7 @@ func TestTemporalUnitGeneratedColumnRoundTrip(t *testing.T) {
 func TestTemporalUnitViewColumnNullability(t *testing.T) {
 	sdl := "CREATE DATABASE d;\nUSE d;\n" +
 		"CREATE TABLE `t` (`nc` varchar(10) DEFAULT NULL, `nn` varchar(10) NOT NULL, `dt` datetime DEFAULT NULL);\n" +
-		"CREATE VIEW `v` AS select weight_string(`nc` as char(4)) AS `w1`, weight_string(`nn` as char(4)) AS `w2`, extract(day from `dt`) AS `e1`, (`dt` + interval 1 day) AS `i1` from `t`;\n"
+		"CREATE VIEW `v` AS select weight_string(`nc` as char(4)) AS `w1`, weight_string(`nn` as char(4)) AS `w2`, weight_string(`nc` as binary(4)) AS `w3`, cast(`nc` as char(4)) AS `c1`, extract(day from `dt`) AS `e1`, (`dt` + interval 1 day) AS `i1` from `t`;\n"
 	cat, err := LoadSDL(sdl)
 	if err != nil {
 		t.Fatalf("LoadSDL failed: %v", err)
@@ -236,6 +237,8 @@ func TestTemporalUnitViewColumnNullability(t *testing.T) {
 	want := map[string]bool{
 		"w1": true,  // nullable column through WEIGHT_STRING AS CHAR
 		"w2": false, // arg-propagation parity with the plain function path
+		"w3": true,  // nullable column through the AS BINARY cast desugar
+		"c1": true,  // nullable column through a plain CAST
 		"e1": true,  // nullable column through EXTRACT
 		"i1": true,  // nullable column through INTERVAL arithmetic
 	}
@@ -292,6 +295,12 @@ func TestTemporalUnitParserRejections(t *testing.T) {
 		{"get-format-year", "select get_format(YEAR,'USA') AS `x`"},
 		{"get-format-string", "select get_format('DATE','USA') AS `x`"},
 		{"extract-quoted-unit", "select extract(`day` from '2020-01-01') AS `x`"},
+		// WEIGHT_STRING grammar edges the engine rejects with 1064
+		// (oracle 8.0.32 + 5.7.25): a zero AS length, and REVERSE before the
+		// direction (the grammar is n [ASC|DESC] [REVERSE], in that order).
+		{"weight-string-as-char-0", "select weight_string('ab' as char(0)) AS `x`"},
+		{"weight-string-as-binary-0", "select weight_string('ab' as binary(0)) AS `x`"},
+		{"weight-string-level-reverse-desc", "select weight_string('ab' level 1 reverse desc) AS `x`"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.id, func(t *testing.T) {
@@ -302,5 +311,37 @@ func TestTemporalUnitParserRejections(t *testing.T) {
 				t.Logf("rejected (as expected): %v", err)
 			}
 		})
+	}
+}
+
+// The charset the engine stores for a charset-less CHAR cast is the
+// CONNECTION charset of the creating session (oracle 8.0.32: the same
+// CAST(s AS CHAR(4)) generated column stores "charset latin1" via a latin1
+// session and "charset utf8mb4" via a utf8mb4 session) — connection-dependent
+// noise, exactly like the string-literal introducer CanonicalGeneratedExpr
+// already strips. A user's charset-less cast must compare equal to any
+// readback, while "charset binary" (the WEIGHT_STRING AS BINARY desugar)
+// stays semantically distinct.
+func TestGeneratedCastCharsetComparison(t *testing.T) {
+	user := "CREATE DATABASE d;\nUSE d;\nCREATE TABLE `g` (`s` varchar(10), `c` char(4) GENERATED ALWAYS AS (CAST(`s` AS CHAR(4))) VIRTUAL);\n"
+	stored := "CREATE DATABASE d;\nUSE d;\nCREATE TABLE `g` (`s` varchar(10) DEFAULT NULL, `c` char(4) GENERATED ALWAYS AS (cast(`s` as char(4) charset utf8mb4)) VIRTUAL);\n"
+	binform := "CREATE DATABASE d;\nUSE d;\nCREATE TABLE `g` (`s` varchar(10) DEFAULT NULL, `c` char(4) GENERATED ALWAYS AS (cast(`s` as char(4) charset binary)) VIRTUAL);\n"
+	cu, err := LoadSDL(user)
+	if err != nil {
+		t.Fatalf("LoadSDL(user) failed: %v", err)
+	}
+	cs, err := LoadSDL(stored)
+	if err != nil {
+		t.Fatalf("LoadSDL(stored) failed: %v", err)
+	}
+	cb, err := LoadSDL(binform)
+	if err != nil {
+		t.Fatalf("LoadSDL(binary) failed: %v", err)
+	}
+	if d := Diff(cu, cs); !d.IsEmpty() {
+		t.Errorf("charset-less cast vs connection-charset readback must compare equal (phantom diff)")
+	}
+	if d := Diff(cu, cb); d.IsEmpty() {
+		t.Errorf("plain CHAR cast and charset-binary cast must stay distinct")
 	}
 }

--- a/mysql/catalog/temporal_unit_test.go
+++ b/mysql/catalog/temporal_unit_test.go
@@ -177,7 +177,10 @@ func TestTemporalUnitGeneratedColumnRoundTrip(t *testing.T) {
 		"  `c2` int GENERATED ALWAYS AS (extract(day_hour from `a`)) VIRTUAL,\n" +
 		"  `c3` datetime GENERATED ALWAYS AS ((`a` + interval 1 day)) VIRTUAL,\n" +
 		"  `c4` int GENERATED ALWAYS AS (abs(-(5))) VIRTUAL,\n" +
-		"  `c5` varbinary(16) GENERATED ALWAYS AS (weight_string(`s` as char(4))) VIRTUAL\n" +
+		"  `c5` varbinary(16) GENERATED ALWAYS AS (weight_string(`s` as char(4))) VIRTUAL,\n" +
+		"  `c6` varbinary(16) GENERATED ALWAYS AS (weight_string(cast(`s` as char(4) charset binary))) VIRTUAL,\n" +
+		"  `c7` char(4) GENERATED ALWAYS AS (cast(`a` as char(4) charset latin1)) VIRTUAL,\n" +
+		"  `c8` int GENERATED ALWAYS AS (cast(`s` as signed)) VIRTUAL\n" +
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n"
 	cat, err := LoadSDL(sdl)
 	if err != nil {
@@ -201,11 +204,78 @@ func TestTemporalUnitGeneratedColumnRoundTrip(t *testing.T) {
 		"((`a` + interval 1 day))",
 		"(abs(-(5)))",
 		"(weight_string(`s` as char(4)))",
+		"(weight_string(cast(`s` as char(4) charset binary)))",
+		"(cast(`a` as char(4) charset latin1))",
+		"(cast(`s` as signed))",
 		"((timestampdiff(SECOND,`a`,`b`)))",
 	} {
 		if !strings.Contains(sql, want) {
 			t.Errorf("generated plan missing the engine-stored fragment %q:\n%s", want, sql)
 		}
+	}
+}
+
+// View-column nullability must propagate through the new expression nodes the
+// same way it does through the plain function-call path: WEIGHT_STRING(nc AS
+// CHAR(4)) over a nullable column is a nullable view column (oracle 8.0.32:
+// IS_NULLABLE=YES). (The engine additionally reports YES for most functions
+// even over NOT NULL columns — upper(nn) included — a long-standing,
+// platform-wide inference divergence that predates these nodes.)
+func TestTemporalUnitViewColumnNullability(t *testing.T) {
+	sdl := "CREATE DATABASE d;\nUSE d;\n" +
+		"CREATE TABLE `t` (`nc` varchar(10) DEFAULT NULL, `nn` varchar(10) NOT NULL, `dt` datetime DEFAULT NULL);\n" +
+		"CREATE VIEW `v` AS select weight_string(`nc` as char(4)) AS `w1`, weight_string(`nn` as char(4)) AS `w2`, extract(day from `dt`) AS `e1`, (`dt` + interval 1 day) AS `i1` from `t`;\n"
+	cat, err := LoadSDL(sdl)
+	if err != nil {
+		t.Fatalf("LoadSDL failed: %v", err)
+	}
+	v := cat.GetDatabase("d").Views["v"]
+	if v == nil {
+		t.Fatal("view not loaded")
+	}
+	want := map[string]bool{
+		"w1": true,  // nullable column through WEIGHT_STRING AS CHAR
+		"w2": false, // arg-propagation parity with the plain function path
+		"e1": true,  // nullable column through EXTRACT
+		"i1": true,  // nullable column through INTERVAL arithmetic
+	}
+	seen := 0
+	for _, col := range v.ColumnMetadata {
+		expect, ok := want[col.Name]
+		if !ok {
+			continue
+		}
+		seen++
+		if col.Nullable != expect {
+			t.Errorf("view column %s: Nullable = %v, want %v", col.Name, col.Nullable, expect)
+		}
+	}
+	if seen != len(want) {
+		t.Errorf("only %d of %d expected view columns had metadata", seen, len(want))
+	}
+}
+
+// Functional-index validation must see through the new expression nodes: the
+// engine rejects a nondeterministic function anywhere in the index expression
+// with error 3758 (oracle 8.0.32), including wrapped in WEIGHT_STRING/EXTRACT/
+// INTERVAL forms, while the deterministic column-based forms are accepted.
+func TestTemporalUnitFunctionalIndexValidation(t *testing.T) {
+	hdr := "CREATE DATABASE d;\nUSE d;\n"
+	rejected := []struct{ id, ddl string }{
+		{"weight-string-now", hdr + "CREATE TABLE t (s VARCHAR(10), KEY ((weight_string(now() as char(4)))));"},
+		{"extract-now", hdr + "CREATE TABLE t (a DATETIME, KEY ((extract(day from now()))));"},
+		{"interval-now", hdr + "CREATE TABLE t (a DATETIME, KEY ((a + interval (day(now())) day)));"},
+	}
+	for _, tc := range rejected {
+		t.Run(tc.id, func(t *testing.T) {
+			if _, err := LoadSDL(tc.ddl); err == nil {
+				t.Errorf("expected functional-index rejection (engine: error 3758), got success")
+			}
+		})
+	}
+	// extract over a column is deterministic and accepted by the engine.
+	if _, err := LoadSDL(hdr + "CREATE TABLE t (a DATETIME, KEY ((extract(day from a))));"); err != nil {
+		t.Errorf("extract-over-column functional index should load (engine accepts): %v", err)
 	}
 }
 

--- a/mysql/catalog/viewcmds.go
+++ b/mysql/catalog/viewcmds.go
@@ -253,6 +253,13 @@ func inferViewExprNullable(expr nodes.ExprNode, relations map[string]viewRelatio
 		return inferViewExprNullable(e.Left, relations) || inferViewExprNullable(e.Right, relations)
 	case *nodes.UnaryExpr:
 		return inferViewExprNullable(e.Operand, relations)
+	case *nodes.WeightStringExpr:
+		// Propagate like the plain WEIGHT_STRING(expr) function-call path.
+		return inferViewExprNullable(e.Expr, relations)
+	case *nodes.ExtractExpr:
+		return inferViewExprNullable(e.Expr, relations)
+	case *nodes.IntervalExpr:
+		return inferViewExprNullable(e.Value, relations)
 	case *nodes.NullLit:
 		return true
 	default:

--- a/mysql/catalog/viewcmds.go
+++ b/mysql/catalog/viewcmds.go
@@ -260,6 +260,11 @@ func inferViewExprNullable(expr nodes.ExprNode, relations map[string]viewRelatio
 		return inferViewExprNullable(e.Expr, relations)
 	case *nodes.IntervalExpr:
 		return inferViewExprNullable(e.Value, relations)
+	case *nodes.CastExpr:
+		// Covers plain casts and the WEIGHT_STRING(... AS BINARY(n)) desugar,
+		// whose WeightStringExpr.Expr is a CastExpr (oracle 8.0.32:
+		// IS_NULLABLE=YES for both over a nullable column).
+		return inferViewExprNullable(e.Expr, relations)
 	case *nodes.NullLit:
 		return true
 	default:

--- a/mysql/deparse/deparse.go
+++ b/mysql/deparse/deparse.go
@@ -875,8 +875,11 @@ func deparseExprAlias(node ast.ExprNode) string {
 				b.WriteString(", ")
 			}
 			fmt.Fprintf(&b, "%d", lv.Level)
-			if lv.Dir != "" {
-				b.WriteString(" " + lv.Dir)
+			if lv.Desc {
+				b.WriteString(" DESC")
+			}
+			if lv.Reverse {
+				b.WriteString(" REVERSE")
 			}
 		}
 		b.WriteString(")")
@@ -1641,8 +1644,11 @@ func deparseWeightStringExpr(n *ast.WeightStringExpr) string {
 			sb.WriteString(",")
 		}
 		fmt.Fprintf(&sb, "%d", lv.Level)
-		if lv.Dir != "" {
-			sb.WriteString(" " + strings.ToLower(lv.Dir))
+		if lv.Desc {
+			sb.WriteString(" desc")
+		}
+		if lv.Reverse {
+			sb.WriteString(" reverse")
 		}
 	}
 	sb.WriteString(")")

--- a/mysql/deparse/deparse.go
+++ b/mysql/deparse/deparse.go
@@ -692,6 +692,10 @@ func deparseExprAlias(node ast.ExprNode) string {
 			if len(n.Args) == 2 {
 				return "TRIM(BOTH " + deparseExprAlias(n.Args[0]) + " FROM " + deparseExprAlias(n.Args[1]) + ")"
 			}
+		case "TRIM_FROM":
+			if len(n.Args) == 2 {
+				return "TRIM(" + deparseExprAlias(n.Args[0]) + " FROM " + deparseExprAlias(n.Args[1]) + ")"
+			}
 		}
 
 		// Handle GROUP_CONCAT: alias includes ORDER BY and SEPARATOR
@@ -851,6 +855,32 @@ func deparseExprAlias(node ast.ExprNode) string {
 	case *ast.IntervalExpr:
 		// MySQL 8.0 auto-alias: "INTERVAL 1 DAY" — uppercase keywords.
 		return "INTERVAL " + deparseExprAlias(n.Value) + " " + strings.ToUpper(n.Unit)
+	case *ast.KeywordArg:
+		return n.Keyword
+	case *ast.ExtractExpr:
+		// Alias approximation with the uppercase-keyword convention:
+		// "EXTRACT(DAY_HOUR FROM a)".
+		return "EXTRACT(" + n.Unit + " FROM " + deparseExprAlias(n.Expr) + ")"
+	case *ast.WeightStringExpr:
+		var b strings.Builder
+		b.WriteString("WEIGHT_STRING(")
+		b.WriteString(deparseExprAlias(n.Expr))
+		if n.AsChar != nil {
+			fmt.Fprintf(&b, " AS CHAR(%d)", n.AsChar.Length)
+		}
+		for i, lv := range n.Levels {
+			if i == 0 {
+				b.WriteString(" LEVEL ")
+			} else {
+				b.WriteString(", ")
+			}
+			fmt.Fprintf(&b, "%d", lv.Level)
+			if lv.Dir != "" {
+				b.WriteString(" " + lv.Dir)
+			}
+		}
+		b.WriteString(")")
+		return b.String()
 	default:
 		// Fallback: use the regular deparsed text
 		return deparseExpr(node)
@@ -1157,6 +1187,15 @@ func deparseExpr(node ast.ExprNode) string {
 		return deparseConvertExpr(n)
 	case *ast.IntervalExpr:
 		return deparseIntervalExpr(n)
+	case *ast.KeywordArg:
+		// Bare keyword argument (timestampdiff unit, get_format type) —
+		// never quoted: the engine stores timestampdiff(SECOND,...) and
+		// rejects a backtick-quoted unit (oracle 8.0.32 + 5.7.25).
+		return n.Keyword
+	case *ast.ExtractExpr:
+		return deparseExtractExpr(n)
+	case *ast.WeightStringExpr:
+		return deparseWeightStringExpr(n)
 	case *ast.CollateExpr:
 		return deparseCollateExpr(n)
 	case *ast.FuncCallExpr:
@@ -1362,13 +1401,11 @@ func deparseUnaryExpr(n *ast.UnaryExpr) string {
 	operand := deparseExpr(n.Operand)
 	switch n.Op {
 	case ast.UnaryMinus:
-		// MySQL 8.0 wraps non-literal operands in parens: -(`t`.`a`) but keeps -5
-		switch n.Operand.(type) {
-		case *ast.IntLit, *ast.FloatLit:
-			return "-" + operand
-		default:
-			return "-(" + operand + ")"
-		}
+		// MySQL parenthesizes the operand of unary minus, literals included:
+		// SELECT -5 stores as -(5) (oracle 8.0.32 + 5.7.25 — views, generated
+		// columns, DEFAULT expressions, CHECK constraints, and the 8.0
+		// partition-function printer all agree).
+		return "-(" + operand + ")"
 	case ast.UnaryPlus:
 		// MySQL drops unary plus entirely
 		return operand
@@ -1579,6 +1616,39 @@ func deparseIntervalExpr(n *ast.IntervalExpr) string {
 	return "interval " + val + " " + strings.ToLower(n.Unit)
 }
 
+// deparseExtractExpr renders EXTRACT in the engine-stored form:
+// extract(day_hour from `t`.`a`) — lowercase unit, never quoted
+// (oracle 8.0.32 + 5.7.25, all simple and compound units).
+func deparseExtractExpr(n *ast.ExtractExpr) string {
+	return "extract(" + strings.ToLower(n.Unit) + " from " + deparseExpr(n.Expr) + ")"
+}
+
+// deparseWeightStringExpr renders WEIGHT_STRING in the engine-stored form:
+// weight_string('ab' as char(4)) on 8.0, with 5.7 readbacks additionally
+// carrying a level list — weight_string('ab' as char(4) level 1)
+// (oracle 8.0.32 + 5.7.25).
+func deparseWeightStringExpr(n *ast.WeightStringExpr) string {
+	var sb strings.Builder
+	sb.WriteString("weight_string(")
+	sb.WriteString(deparseExpr(n.Expr))
+	if n.AsChar != nil {
+		fmt.Fprintf(&sb, " as char(%d)", n.AsChar.Length)
+	}
+	for i, lv := range n.Levels {
+		if i == 0 {
+			sb.WriteString(" level ")
+		} else {
+			sb.WriteString(",")
+		}
+		fmt.Fprintf(&sb, "%d", lv.Level)
+		if lv.Dir != "" {
+			sb.WriteString(" " + strings.ToLower(lv.Dir))
+		}
+	}
+	sb.WriteString(")")
+	return sb.String()
+}
+
 func deparseCollateExpr(n *ast.CollateExpr) string {
 	expr := deparseExpr(n.Expr)
 	return "(" + expr + " collate " + n.Collation + ")"
@@ -1624,6 +1694,21 @@ func deparseFuncCallExpr(n *ast.FuncCallExpr) string {
 		return deparseTrimDirectional("trailing", n.Args)
 	case "TRIM_BOTH":
 		return deparseTrimDirectional("both", n.Args)
+	case "TRIM_FROM":
+		// TRIM(remstr FROM str) without a direction keyword — the engine
+		// stores this form verbatim, not as comma arguments
+		// (oracle 8.0.32 + 5.7.25: trim(' x' from 'axa')).
+		if len(n.Args) == 2 {
+			return "trim(" + deparseExpr(n.Args[0]) + " from " + deparseExpr(n.Args[1]) + ")"
+		}
+	case "GET_FORMAT":
+		// Stored with a space after the keyword argument's comma:
+		// get_format(DATE, 'USA') (oracle 8.0.32 + 5.7.25). Only the bare
+		// builtin — a schema-qualified name is a stored function and takes
+		// the generic path, keeping its qualifier.
+		if n.Schema == "" && len(n.Args) == 2 {
+			return "get_format(" + deparseExpr(n.Args[0]) + ", " + deparseExpr(n.Args[1]) + ")"
+		}
 	}
 
 	// GROUP_CONCAT has special formatting

--- a/mysql/deparse/deparse_test.go
+++ b/mysql/deparse/deparse_test.go
@@ -43,7 +43,9 @@ func TestDeparse_Section_1_1_IntFloatNull(t *testing.T) {
 	}{
 		// Integer literals
 		{"integer_1", "1", "1"},
-		{"negative_integer", "-5", "-5"},
+		// MySQL parenthesizes the operand of unary minus, literals included
+		// (oracle 8.0.32 + 5.7.25: SELECT -5 stores as -(5)).
+		{"negative_integer", "-5", "-(5)"},
 		{"large_integer", "9999999999", "9999999999"},
 		{"zero", "0", "0"},
 

--- a/mysql/deparse/resolver.go
+++ b/mysql/deparse/resolver.go
@@ -493,6 +493,12 @@ func (r *Resolver) resolveExpr(node ast.ExprNode, sc *scopepkg.Scope) ast.ExprNo
 	case *ast.IntervalExpr:
 		n.Value = r.resolveExpr(n.Value, sc)
 		return n
+	case *ast.ExtractExpr:
+		n.Expr = r.resolveExpr(n.Expr, sc)
+		return n
+	case *ast.WeightStringExpr:
+		n.Expr = r.resolveExpr(n.Expr, sc)
+		return n
 	case *ast.RowExpr:
 		for i, item := range n.Items {
 			n.Items[i] = r.resolveExpr(item, sc)
@@ -763,6 +769,10 @@ func (r *Resolver) resolveCastCharsets(node ast.ExprNode) {
 		for _, arg := range n.Args {
 			r.resolveCastCharsets(arg)
 		}
+	case *ast.ExtractExpr:
+		r.resolveCastCharsets(n.Expr)
+	case *ast.WeightStringExpr:
+		r.resolveCastCharsets(n.Expr)
 	case *ast.CaseExpr:
 		r.resolveCastCharsets(n.Operand)
 		for _, w := range n.Whens {

--- a/mysql/deparse/rewrite.go
+++ b/mysql/deparse/rewrite.go
@@ -3,6 +3,8 @@
 package deparse
 
 import (
+	"strings"
+
 	ast "github.com/bytebase/omni/mysql/ast"
 )
 
@@ -109,6 +111,18 @@ func rewriteExpr(node ast.ExprNode) ast.ExprNode {
 		for i, arg := range n.Args {
 			n.Args[i] = rewriteExpr(arg)
 		}
+		return rewriteDateArith(n)
+
+	case *ast.ExtractExpr:
+		n.Expr = rewriteExpr(n.Expr)
+		return n
+
+	case *ast.IntervalExpr:
+		n.Value = rewriteExpr(n.Value)
+		return n
+
+	case *ast.WeightStringExpr:
+		n.Expr = rewriteExpr(n.Expr)
 		return n
 
 	case *ast.CastExpr:
@@ -127,6 +141,57 @@ func rewriteExpr(node ast.ExprNode) ast.ExprNode {
 		// Leaf nodes (literals, column refs, etc.) — no rewriting needed
 		return node
 	}
+}
+
+// rewriteDateArith folds the date-arithmetic function family into INTERVAL
+// arithmetic, matching the engine's resolver: TIMESTAMPADD, DATE_ADD/ADDDATE
+// and DATE_SUB/SUBDATE never appear in a stored body — they are stored as
+// (expr + interval n unit) / (expr - interval n unit) (oracle 8.0.32 +
+// 5.7.25, all units). ADDDATE/SUBDATE with a bare count means days:
+// adddate(d, 31) stores as (d + interval 31 day). A schema-qualified name
+// is a stored function, not the builtin, and is left alone.
+func rewriteDateArith(n *ast.FuncCallExpr) ast.ExprNode {
+	if n.Schema != "" {
+		return n
+	}
+	switch strings.ToUpper(n.Name) {
+	case "TIMESTAMPADD":
+		if len(n.Args) == 3 {
+			if unit, ok := n.Args[0].(*ast.KeywordArg); ok {
+				return &ast.BinaryExpr{
+					Op:   ast.BinOpAdd,
+					Left: n.Args[2],
+					Right: &ast.IntervalExpr{
+						Value: n.Args[1],
+						Unit:  unit.Keyword,
+					},
+				}
+			}
+		}
+	case "DATE_ADD", "ADDDATE":
+		return rewriteDateAddSub(n, ast.BinOpAdd)
+	case "DATE_SUB", "SUBDATE":
+		return rewriteDateAddSub(n, ast.BinOpSub)
+	}
+	return n
+}
+
+// rewriteDateAddSub folds DATE_ADD/DATE_SUB/ADDDATE/SUBDATE into interval
+// arithmetic. DATE_ADD/DATE_SUB require INTERVAL syntax for the second
+// argument; only ADDDATE/SUBDATE also have the bare-days form.
+func rewriteDateAddSub(n *ast.FuncCallExpr, op ast.BinaryOp) ast.ExprNode {
+	if len(n.Args) != 2 {
+		return n
+	}
+	iv, ok := n.Args[1].(*ast.IntervalExpr)
+	if !ok {
+		name := strings.ToUpper(n.Name)
+		if name != "ADDDATE" && name != "SUBDATE" {
+			return n
+		}
+		iv = &ast.IntervalExpr{Value: n.Args[1], Unit: "DAY"}
+	}
+	return &ast.BinaryExpr{Op: op, Left: n.Args[0], Right: iv}
 }
 
 // invertOp maps comparison operators to their NOT-inverted counterparts.

--- a/mysql/parser/expr.go
+++ b/mysql/parser/expr.go
@@ -689,6 +689,22 @@ func (p *Parser) parseFuncCall(start int, schema, name string) (nodes.ExprNode, 
 		return p.parseGroupConcatFunc(fc)
 	}
 
+	// Keyword-argument builtins: their first argument (or a trailing clause)
+	// is a bare keyword the engine lexes as a token, never an identifier —
+	// a backtick-quoted unit is a syntax error (oracle 8.0.32 + 5.7.25).
+	// Only the unqualified builtin has this shape; a schema-qualified name is
+	// a stored function whose arguments are ordinary expressions.
+	if schema == "" {
+		switch upperName {
+		case "TIMESTAMPDIFF", "TIMESTAMPADD":
+			return p.parseTimestampFunc(fc)
+		case "GET_FORMAT":
+			return p.parseGetFormatFunc(fc)
+		case "WEIGHT_STRING":
+			return p.parseWeightStringFunc(fc)
+		}
+	}
+
 	// Completion: at the start of the function argument list (including
 	// empty parens), offer columnref/func_name candidates.
 	p.checkCursor()
@@ -1025,6 +1041,13 @@ func (p *Parser) parseTrimFunc(fc *nodes.FuncCallExpr) (nodes.ExprNode, error) {
 		if str == nil {
 			return nil, p.syntaxErrorAtCur()
 		}
+		if fc.Name == "TRIM" {
+			// No direction keyword: TRIM(remstr FROM str). The engine keeps
+			// this form as-is in stored bodies — trim(' x' from 'axa'), not
+			// a comma-argument call (oracle 8.0.32 + 5.7.25) — so mark it
+			// for the deparser the same way the directional forms are.
+			fc.Name = "TRIM_FROM"
+		}
 		fc.Args = []nodes.ExprNode{arg, str}
 	} else {
 		fc.Args = []nodes.ExprNode{arg}
@@ -1099,6 +1122,290 @@ func (p *Parser) parseSubstringFunc(fc *nodes.FuncCallExpr) (nodes.ExprNode, err
 	}
 	fc.Loc.End = p.prev.End
 	return fc, nil
+}
+
+// sqlTSIUnits maps the SQL_TSI_-prefixed unit synonyms MySQL's lexer
+// registers to their canonical unit. Only these eight exist —
+// SQL_TSI_MICROSECOND is not a token and the engine rejects it
+// (oracle 8.0.32 + 5.7.25: error 1064).
+var sqlTSIUnits = map[string]string{
+	"SQL_TSI_SECOND":  "SECOND",
+	"SQL_TSI_MINUTE":  "MINUTE",
+	"SQL_TSI_HOUR":    "HOUR",
+	"SQL_TSI_DAY":     "DAY",
+	"SQL_TSI_WEEK":    "WEEK",
+	"SQL_TSI_MONTH":   "MONTH",
+	"SQL_TSI_QUARTER": "QUARTER",
+	"SQL_TSI_YEAR":    "YEAR",
+}
+
+// normalizeTimeUnit uppercases unit and folds a SQL_TSI_ synonym to its
+// canonical name. This mirrors the engine's stored form: SHOW CREATE VIEW
+// renders timestampdiff(sql_tsi_second,...) as timestampdiff(SECOND,...)
+// (oracle 8.0.32 + 5.7.25).
+func normalizeTimeUnit(unit string) string {
+	u := strings.ToUpper(unit)
+	if canon, ok := sqlTSIUnits[u]; ok {
+		return canon
+	}
+	return u
+}
+
+// simpleTimeUnits is the unit set TIMESTAMPDIFF/TIMESTAMPADD accept
+// (interval_time_stamp in sql_yacc.yy): the nine simple units only.
+// Compound units are a syntax error there (oracle 8.0.32 + 5.7.25:
+// TIMESTAMPDIFF(DAY_HOUR,...) → 1064).
+var simpleTimeUnits = map[string]bool{
+	"MICROSECOND": true,
+	"SECOND":      true,
+	"MINUTE":      true,
+	"HOUR":        true,
+	"DAY":         true,
+	"WEEK":        true,
+	"MONTH":       true,
+	"QUARTER":     true,
+	"YEAR":        true,
+}
+
+// parseTimeUnitKeyword parses a bare temporal-unit keyword and returns it as
+// a normalized KeywordArg. The engine lexes the unit as a keyword token —
+// quoted identifiers and string literals are syntax errors in this position
+// (oracle 8.0.32 + 5.7.25) — so only keyword tokens are accepted; all valid
+// units are registered keywords. simpleOnly restricts to the
+// TIMESTAMPDIFF/TIMESTAMPADD set; otherwise the full interval-unit set
+// (including compound units) is allowed.
+func (p *Parser) parseTimeUnitKeyword(simpleOnly bool) (*nodes.KeywordArg, error) {
+	if p.cur.Type < 700 {
+		return nil, &ParseError{Message: "expected time unit keyword", Position: p.cur.Loc}
+	}
+	tok := p.advance()
+	unit := normalizeTimeUnit(tok.Str)
+	valid := isValidIntervalUnit(unit)
+	if simpleOnly {
+		valid = simpleTimeUnits[unit]
+	}
+	if !valid {
+		return nil, &ParseError{Message: "invalid time unit: " + tok.Str, Position: tok.Loc}
+	}
+	return &nodes.KeywordArg{
+		Loc:     nodes.Loc{Start: tok.Loc, End: p.pos()},
+		Keyword: unit,
+	}, nil
+}
+
+// parseTimestampFunc parses TIMESTAMPDIFF(unit, expr, expr) and
+// TIMESTAMPADD(unit, expr, expr) — the unit is a bare keyword argument.
+//
+// Ref: https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_timestampdiff
+func (p *Parser) parseTimestampFunc(fc *nodes.FuncCallExpr) (nodes.ExprNode, error) {
+	// Completion parity with the generic argument path.
+	p.checkCursor()
+	if p.collectMode() {
+		p.addRuleCandidate("columnref")
+		p.addRuleCandidate("func_name")
+		return nil, &ParseError{Message: "collecting"}
+	}
+	unit, err := p.parseTimeUnitKeyword(true)
+	if err != nil {
+		return nil, err
+	}
+	fc.Args = append(fc.Args, unit)
+	for range 2 {
+		if _, err := p.expect(','); err != nil {
+			return nil, err
+		}
+		arg, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if arg == nil {
+			return nil, p.syntaxErrorAtCur()
+		}
+		fc.Args = append(fc.Args, arg)
+	}
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	fc.Loc.End = p.prev.End
+	return fc, nil
+}
+
+// parseGetFormatFunc parses GET_FORMAT({DATE|TIME|DATETIME|TIMESTAMP}, expr).
+// The first argument is a bare keyword; TIMESTAMP is a synonym the engine
+// stores as DATETIME, and anything else — including YEAR and string
+// literals — is a syntax error (oracle 8.0.32 + 5.7.25).
+//
+// Ref: https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_get-format
+func (p *Parser) parseGetFormatFunc(fc *nodes.FuncCallExpr) (nodes.ExprNode, error) {
+	// Completion parity with the generic argument path.
+	p.checkCursor()
+	if p.collectMode() {
+		p.addRuleCandidate("columnref")
+		p.addRuleCandidate("func_name")
+		return nil, &ParseError{Message: "collecting"}
+	}
+	if p.cur.Type < 700 {
+		return nil, &ParseError{Message: "expected DATE, TIME, DATETIME, or TIMESTAMP", Position: p.cur.Loc}
+	}
+	tok := p.advance()
+	kind := strings.ToUpper(tok.Str)
+	switch kind {
+	case "DATE", "TIME", "DATETIME":
+	case "TIMESTAMP":
+		kind = "DATETIME"
+	default:
+		return nil, &ParseError{Message: "invalid GET_FORMAT type: " + tok.Str, Position: tok.Loc}
+	}
+	fc.Args = append(fc.Args, &nodes.KeywordArg{
+		Loc:     nodes.Loc{Start: tok.Loc, End: p.pos()},
+		Keyword: kind,
+	})
+	if _, err := p.expect(','); err != nil {
+		return nil, err
+	}
+	arg, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if arg == nil {
+		return nil, p.syntaxErrorAtCur()
+	}
+	fc.Args = append(fc.Args, arg)
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+	fc.Loc.End = p.prev.End
+	return fc, nil
+}
+
+// parseWeightStringFunc parses
+//
+//	WEIGHT_STRING(expr [AS {CHAR|BINARY}(n)] [LEVEL n [ASC|DESC|REVERSE] [, ...] | LEVEL n - n])
+//
+// The plain no-suffix form stays a generic FuncCallExpr (its round-trip
+// predates this parser and is pinned by tests); AS/LEVEL forms build a
+// WeightStringExpr. AS BINARY(n) is not stored by the engine — it desugars
+// to weight_string(cast(expr as char(n) charset binary)) (oracle 8.0.32 +
+// 5.7.25), so the parser produces that shape directly. LEVEL is 5.7-only
+// syntax (8.0 rejects it); 5.7 stores a plain level list such as
+// "level 1 desc", with ASC dropped and ranges collapsed.
+//
+// Ref: https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_weight-string
+func (p *Parser) parseWeightStringFunc(fc *nodes.FuncCallExpr) (nodes.ExprNode, error) {
+	// Completion parity with the generic argument path.
+	p.checkCursor()
+	if p.collectMode() {
+		p.addRuleCandidate("columnref")
+		p.addRuleCandidate("func_name")
+		return nil, &ParseError{Message: "collecting"}
+	}
+	arg, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if arg == nil {
+		return nil, p.syntaxErrorAtCur()
+	}
+
+	ws := &nodes.WeightStringExpr{Loc: fc.Loc, Expr: arg}
+	asBinary := false
+
+	if p.cur.Type == kwAS {
+		p.advance()
+		var typeName string
+		switch p.cur.Type {
+		case kwCHAR:
+			typeName = "CHAR"
+		case kwBINARY:
+			typeName = "BINARY"
+		default:
+			return nil, &ParseError{Message: "expected CHAR or BINARY", Position: p.cur.Loc}
+		}
+		typeTok := p.advance()
+		if _, err := p.expect('('); err != nil {
+			return nil, err
+		}
+		if p.cur.Type != tokICONST {
+			return nil, &ParseError{Message: "expected length", Position: p.cur.Loc}
+		}
+		lenTok := p.advance()
+		if _, err := p.expect(')'); err != nil {
+			return nil, err
+		}
+		dt := &nodes.DataType{
+			Loc:    nodes.Loc{Start: typeTok.Loc, End: p.pos()},
+			Name:   "CHAR",
+			Length: int(lenTok.Ival),
+		}
+		if typeName == "BINARY" {
+			// Engine-stored form of AS BINARY(n):
+			// weight_string(cast(expr as char(n) charset binary)).
+			dt.Charset = "binary"
+			asBinary = true
+			ws.Expr = &nodes.CastExpr{
+				Loc:      nodes.Loc{Start: typeTok.Loc, End: p.pos()},
+				Expr:     arg,
+				TypeName: dt,
+			}
+		} else {
+			ws.AsChar = dt
+		}
+	}
+
+	if p.cur.Type == kwLEVEL {
+		p.advance()
+		for {
+			if p.cur.Type != tokICONST {
+				return nil, &ParseError{Message: "expected level number", Position: p.cur.Loc}
+			}
+			lvTok := p.advance()
+			level := nodes.WeightStringLevel{Level: int(lvTok.Ival)}
+			switch p.cur.Type {
+			case kwASC:
+				p.advance() // ASC is the default; normalize away
+			case kwDESC:
+				p.advance()
+				level.Dir = "DESC"
+			case kwREVERSE:
+				p.advance()
+				level.Dir = "REVERSE"
+			}
+			ws.Levels = append(ws.Levels, level)
+			// Range form LEVEL n - m: expand to the full list. Weight levels
+			// are 1..6 per the MySQL reference (no collation has more), so
+			// the expansion is capped — an absurd range like LEVEL 1 - 1e18
+			// parses without materializing entries beyond the domain.
+			if len(ws.Levels) == 1 && level.Dir == "" && p.cur.Type == '-' {
+				p.advance()
+				if p.cur.Type != tokICONST {
+					return nil, &ParseError{Message: "expected level number", Position: p.cur.Loc}
+				}
+				hiTok := p.advance()
+				const maxWeightLevels = 6
+				for l := level.Level + 1; l <= int(hiTok.Ival) && len(ws.Levels) < maxWeightLevels; l++ {
+					ws.Levels = append(ws.Levels, nodes.WeightStringLevel{Level: l})
+				}
+				break
+			}
+			if p.cur.Type != ',' {
+				break
+			}
+			p.advance()
+		}
+	}
+
+	if _, err := p.expect(')'); err != nil {
+		return nil, err
+	}
+
+	if ws.AsChar == nil && !asBinary && len(ws.Levels) == 0 {
+		// Plain WEIGHT_STRING(expr) — keep the generic function-call shape.
+		fc.Args = append(fc.Args, arg)
+		fc.Loc.End = p.prev.End
+		return fc, nil
+	}
+	ws.Loc.End = p.prev.End
+	return ws, nil
 }
 
 // parseGroupConcatFunc parses GROUP_CONCAT([DISTINCT] expr [, expr ...] [ORDER BY ...] [SEPARATOR str]).
@@ -1408,8 +1715,12 @@ func (p *Parser) parseExtractExpr() (nodes.ExprNode, error) {
 		return nil, err
 	}
 
-	// Parse unit keyword (DAY, HOUR, MINUTE, SECOND, MONTH, YEAR, etc.)
-	unit, _, err := p.parseIdentifier()
+	// Parse the unit keyword. EXTRACT accepts the full interval-unit set,
+	// including compound units (DAY_HOUR, YEAR_MONTH, ...), which are
+	// reserved keywords — so this must accept keyword tokens, not
+	// identifiers (oracle 8.0.32 + 5.7.25: extract(day_hour from ...) is
+	// the engine-stored form).
+	unit, err := p.parseTimeUnitKeyword(false)
 	if err != nil {
 		return nil, err
 	}
@@ -1432,7 +1743,7 @@ func (p *Parser) parseExtractExpr() (nodes.ExprNode, error) {
 
 	return &nodes.ExtractExpr{
 		Loc:  nodes.Loc{Start: start, End: p.pos()},
-		Unit: strings.ToUpper(unit),
+		Unit: unit.Keyword,
 		Expr: expr,
 	}, nil
 }
@@ -1885,13 +2196,15 @@ func (p *Parser) parseIntervalExpr() (nodes.ExprNode, error) {
 
 	// Parse unit: DAY, HOUR, MINUTE, SECOND, MONTH, YEAR, etc.
 	// Use parseKeywordOrIdent because compound interval units (DAY_HOUR, etc.)
-	// are registered as reserved keywords.
+	// are registered as reserved keywords. SQL_TSI_ synonyms fold to their
+	// canonical unit, matching the engine's stored form (oracle 8.0.32 +
+	// 5.7.25: INTERVAL 1 SQL_TSI_DAY stores as interval 1 day).
 	unit, _, err := p.parseKeywordOrIdent()
 	if err != nil {
 		return nil, err
 	}
 
-	upper := strings.ToUpper(unit)
+	upper := normalizeTimeUnit(unit)
 	if !isValidIntervalUnit(upper) {
 		return nil, &ParseError{
 			Position: p.pos(),

--- a/mysql/parser/expr.go
+++ b/mysql/parser/expr.go
@@ -1364,7 +1364,16 @@ func (p *Parser) parseWeightStringFunc(fc *nodes.FuncCallExpr) (nodes.ExprNode, 
 				return nil, &ParseError{Message: "expected level number", Position: p.cur.Loc}
 			}
 			lvTok := p.advance()
-			level := nodes.WeightStringLevel{Level: int(lvTok.Ival)}
+			// The engine clamps out-of-range levels rather than rejecting:
+			// LEVEL 0 stores as level 1 (oracle 5.7.25). The collation-max
+			// upper clamp (LEVEL 7 also stored level 1 on a single-level
+			// collation) is collation-dependent and stays a flagged
+			// user-form residual.
+			lvNum := int(lvTok.Ival)
+			if lvNum < 1 {
+				lvNum = 1
+			}
+			level := nodes.WeightStringLevel{Level: lvNum}
 			// Grammar: n [ASC|DESC] [REVERSE] — direction first, then an
 			// optional REVERSE (LEVEL 1 DESC REVERSE stores as
 			// "level 1 desc reverse"; REVERSE DESC is a 1064 and ASC

--- a/mysql/parser/expr.go
+++ b/mysql/parser/expr.go
@@ -1328,6 +1328,11 @@ func (p *Parser) parseWeightStringFunc(fc *nodes.FuncCallExpr) (nodes.ExprNode, 
 		if p.cur.Type != tokICONST {
 			return nil, &ParseError{Message: "expected length", Position: p.cur.Loc}
 		}
+		if p.cur.Ival < 1 {
+			// The engine requires N >= 1: WEIGHT_STRING('x' AS CHAR(0)) is a
+			// 1064 syntax error (oracle 8.0.32 + 5.7.25).
+			return nil, &ParseError{Message: "WEIGHT_STRING AS length must be at least 1", Position: p.cur.Loc}
+		}
 		lenTok := p.advance()
 		if _, err := p.expect(')'); err != nil {
 			return nil, err
@@ -1360,22 +1365,27 @@ func (p *Parser) parseWeightStringFunc(fc *nodes.FuncCallExpr) (nodes.ExprNode, 
 			}
 			lvTok := p.advance()
 			level := nodes.WeightStringLevel{Level: int(lvTok.Ival)}
+			// Grammar: n [ASC|DESC] [REVERSE] — direction first, then an
+			// optional REVERSE (LEVEL 1 DESC REVERSE stores as
+			// "level 1 desc reverse"; REVERSE DESC is a 1064 and ASC
+			// normalizes away — oracle 5.7.25).
 			switch p.cur.Type {
 			case kwASC:
 				p.advance() // ASC is the default; normalize away
 			case kwDESC:
 				p.advance()
-				level.Dir = "DESC"
-			case kwREVERSE:
+				level.Desc = true
+			}
+			if p.cur.Type == kwREVERSE {
 				p.advance()
-				level.Dir = "REVERSE"
+				level.Reverse = true
 			}
 			ws.Levels = append(ws.Levels, level)
 			// Range form LEVEL n - m: expand to the full list. Weight levels
 			// are 1..6 per the MySQL reference (no collation has more), so
 			// the expansion is capped — an absurd range like LEVEL 1 - 1e18
 			// parses without materializing entries beyond the domain.
-			if len(ws.Levels) == 1 && level.Dir == "" && p.cur.Type == '-' {
+			if len(ws.Levels) == 1 && !level.Desc && !level.Reverse && p.cur.Type == '-' {
 				p.advance()
 				if p.cur.Type != tokICONST {
 					return nil, &ParseError{Message: "expected level number", Position: p.cur.Loc}


### PR DESCRIPTION
## Bug

Found by the bytebase enterprise SDL campaign: dogfood-loading the stock MySQL 8.0 sys schema via an engine-generated create plan. The deparser rendered the temporal-unit keyword argument of TIMESTAMPDIFF as a backtick-quoted identifier:

- Stored view body (sys `innodb_lock_waits`): ``timestampdiff(SECOND,`t`.`created`,now())``
- Generated plan: ``timestampdiff(`SECOND`,`t`.`created`,now())`` → **live MySQL rejects with error 1064** (verified on 8.0.32 and 5.7.25 — the quoted unit is a syntax error, not a style choice).

Root cause: the parser had no model for keyword arguments — the unit parsed as a generic expression → `ColumnRef`, and deparse backtick-quotes every ColumnRef. (Bonus hazard: with a real column named `second` in scope, the resolver would happily qualify the "unit".) Dumps are unaffected (they carry the engine's stored text); only AST→deparse paths hit it.

## Fix

New leaf AST node `KeywordArg` (bare keyword, never quoted) + a dedicated `WeightStringExpr`, oracle-driven across **every keyword-argument position** (all stored forms probed live via SHOW CREATE VIEW / SHOW CREATE TABLE on 8.0.32 + 5.7.25 — the two versions agree on everything below except where noted):

| Position | Engine-stored form (oracle) | Before | After |
|---|---|---|---|
| `TIMESTAMPDIFF(unit,a,b)` — all 9 units | `timestampdiff(SECOND,…)` bare UPPERCASE; case + `SQL_TSI_*` folded; compound/quoted/string units are 1064 | quoted `` `SECOND` `` (invalid SQL) | exact |
| `TIMESTAMPADD(unit,n,ts)` | never stored — folds to `(ts + interval n unit)` | ``timestampadd(`HOUR`,…)`` (invalid) | folded |
| `DATE_ADD/DATE_SUB/ADDDATE/SUBDATE` | folds to `(e ± interval n unit)`; bare count = days: `adddate(d,31)` → `(d + interval 31 day)`; `ADDDATE(d,-5)` → `interval -(5) day` | function form kept (diff-noise) | folded |
| `EXTRACT(unit FROM e)` — all 20 units | `extract(day_hour from …)` lowercase | simple units: `/* unsupported */`; compound units: **parse error** | exact |
| bare `e + INTERVAL n unit` | already correct | — | regression-pinned (+ `SQL_TSI_` folding added) |
| `GET_FORMAT(kind,'x')` | `get_format(DATE, 'USA')` — bare UPPERCASE, `TIMESTAMP`→`DATETIME`, space after comma | quoted `` `DATE` `` (invalid) | exact |
| `WEIGHT_STRING(s AS CHAR(n))` | `weight_string('ab' as char(4))`; `AS BINARY(n)` desugars to `cast(… as char(n) charset binary)`; 5.7 readbacks always carry `level 1[ desc| reverse]` | **parse error** | exact |
| `TRIM(remstr FROM s)` | kept as `trim(' x' from 'axa')` — not comma args | `trim(' x','axa')` (diff-noise) | exact; directional TRIM + `SUBSTRING FROM/FOR` regression-pinned |
| generated columns / functional indexes | same forms as view bodies (``AS (timestampdiff(SECOND,`a`,`b`))``, `KEY ((timestampdiff(SECOND,…)))`) | gen-col renderer emitted `(?)` / quoted unit | exact (all five shapes applied live + read back byte-identical) |
| unary minus | `-(5)` in **every** position the engine re-prints (8.0+5.7 views, generated cols, DEFAULT, CHECK, 8.0 partition fns); auto-alias keeps verbatim `-5` | literal special case emitted `-5` | exact (alias path already verbatim — matches engine) |

Parser strictness matches the engine: quoted/string/compound units in `TIMESTAMPDIFF`, `SQL_TSI_MICROSECOND`, `GET_FORMAT(YEAR,…)`, `` extract(`day` from …) `` are rejected exactly where MySQL 1064s.

## North star (the harness leg this bug blocked)

`TestOracle_SysSchemaDogfood`: from a live 8.0 readback of **all 100 stock sys views** (incl. `innodb_lock_waits` + `x$` variants) — LoadSDL the canonical dump → self-diff empty → `GenerateMigration` from empty (100 CREATE OR REPLACE VIEW ops) → **apply the full plan to a scratch database on the live engine** → re-dump → diff empty in both directions. Before the fix the apply leg failed with 1064 on the two `timestampdiff` views. This replicates the bytebase-side `TestSDLEnterpriseBaseline/mysql80/sys` leg inside omni.

## Tests

- `mysql/catalog/temporal_unit_test.go` — no-DB: stored-form fixed points, user-form canonicalizations, engine-matching parser rejections, generated-column/functional-index plan pins.
- `mysql/catalog/migration_view_oracle_test.go` — 10 new idempotence probes + 2 apply-correctness probes against **live 5.7.25 + 8.0.32** (user form vs engine readback, both directions).
- `mysql/catalog/sys_schema_oracle_test.go` — the north star above.
- Full `go test ./mysql/...` (oracle tests included) green; `golangci-lint` 0 new issues; gofmt clean.

## Normalization decisions applied (oracle-backed)

1. Unit keywords stored normalized (uppercase, `SQL_TSI_` folded) at parse; deparse renders TIMESTAMPDIFF units uppercase, EXTRACT/INTERVAL units lowercase — byte-for-byte the SHOW CREATE forms.
2. `GET_FORMAT(TIMESTAMP,…)` → `DATETIME` at parse (engine folds it).
3. Date-arithmetic function family folded to interval arithmetic in the view-body rewrite pass (`RewriteExpr`), mirroring the engine resolver. Table-position rewrites (e.g. user-SDL `TIMESTAMPADD` inside CHECK) follow the pre-existing view-only rewrite architecture — see flags.
4. `WEIGHT_STRING(x AS BINARY(n))` desugared at parse to the engine's stored `cast(… charset binary)` shape.
5. Unary-minus literal parenthesization `-(5)` (the removed `-5` special case contradicted the oracle in every re-printed position).

## Flagged (evidence-backed residuals, not regressions)

- **5.7 `WEIGHT_STRING` user-form**: 5.7 auto-appends `level 1` to stored bodies; omni doesn't reproduce that for user SDL (writing `LEVEL 1` explicitly round-trips; readbacks always round-trip). 8.0 unaffected.
- **Multi-level LEVEL lists**: unobservable in any readback on either oracle box (engine collapses to `level 1[ desc| reverse]`, even for `utf8mb4_unicode_520_ci`); ranges parse-accepted, expansion capped at the documented 6-level domain (kills a pathological `LEVEL 1-1e18` OOM).
- **`TRIM(BOTH FROM x)` (direction, no remstr)**: server-side defect on both versions — CREATE succeeds but the stored body is malformed and even `SHOW CREATE VIEW` 1064s (view bricked). Unreachable from readbacks; left unsupported.
- **Schema-qualified function rendering**: omni renders `db.fn(...)` unquoted while the engine stores `` `db`.`fn`(...) `` — pre-existing for all qualified functions; this PR only guarantees the qualifier survives the new GET_FORMAT special case (regression-pinned).
- **Catalog query-analyzer** (`analyzeExpr`) doesn't model `KeywordArg`/`WeightStringExpr`: analysis of such queries errors cleanly ("unsupported expression type"); on main it also errored ("unknown column SECOND") or silently mis-bound the unit to a real column named `second`. DDL paths are unaffected.

## Review

Cross-family review: Claude `/code-review` (8-angle) + Codex review, run blind. Both converged on the generated-column renderer gap (fixed); Codex additionally caught the GET_FORMAT schema-qualifier swallow (fixed + pinned) and the completion-mode parity gap in the new special-form parsers (fixed). Oracle-contradicting suggestions (e.g. "keep `-5`", "alias/body unary divergence is a bug" — the engine's alias is verbatim user text) were rebutted with live probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
