### PR TITLE
mysql: model column SRID presence so explicit SRID 0 round-trips

### DIFF
--- a/mysql/ast/outfuncs.go
+++ b/mysql/ast/outfuncs.go
@@ -2837,6 +2837,11 @@ func writeDataType(sb *strings.Builder, n *DataType) {
 	if n.ArrayDim > 0 {
 		fmt.Fprintf(sb, " :array_dim %d", n.ArrayDim)
 	}
+	// Dump the SRID clause on presence, not on a nonzero value — `SRID 0` is a distinct,
+	// present clause and must be visible in the AST dump (and separable from no-SRID).
+	if n.HasSRID {
+		fmt.Fprintf(sb, " :srid %d", n.SRID)
+	}
 	sb.WriteString("}")
 }
 

--- a/mysql/ast/parsenodes.go
+++ b/mysql/ast/parsenodes.go
@@ -583,7 +583,12 @@ type DataType struct {
 	Binary     bool     // standalone BINARY modifier
 	EnumValues []string // for ENUM and SET types
 	ArrayDim   int      // not used in MySQL, but here for consistency
-	SRID       int      // Spatial Reference ID for spatial types (0 = not set)
+	SRID       int      // Spatial Reference ID for spatial types (valid only when HasSRID)
+	// HasSRID records whether the column declared an explicit SRID clause at all. MySQL
+	// treats `SRID 0` as present-and-distinct from a column with no SRID clause (SHOW
+	// CREATE echoes `/*!80003 SRID 0 */`; information_schema reports SRS_ID=0 vs NULL), so
+	// presence cannot be inferred from SRID != 0 — a `SRID 0` column has SRID==0 yet is set.
+	HasSRID bool
 }
 
 func (t *DataType) nodeTag() {}

--- a/mysql/catalog/altercmds.go
+++ b/mysql/catalog/altercmds.go
@@ -948,6 +948,12 @@ func buildColumnFromDef(tbl *Table, colDef *nodes.ColumnDef) *Column {
 	if colDef.Comment != "" {
 		col.Comment = colDef.Comment
 	}
+	// SRID, copied by PRESENCE (HasSRID) so an explicit `SRID 0` on an ALTER ADD/MODIFY
+	// COLUMN is preserved and distinct from a no-SRID column (mirrors tablecmds.go).
+	if colDef.TypeName != nil && colDef.TypeName.HasSRID {
+		col.SRID = colDef.TypeName.SRID
+		col.HasSRID = true
+	}
 	if colDef.DefaultValue != nil {
 		setColumnDefaultFromExpr(col, colDef.DefaultValue)
 	}

--- a/mysql/catalog/migration_column.go
+++ b/mysql/catalog/migration_column.go
@@ -273,8 +273,10 @@ func formatColumnDefinition(tbl *Table, c *Column, n *Normalizer) string {
 		b.WriteString(" NULL")
 	}
 
-	// SRID (spatial) — MySQL places it after NOT NULL, before DEFAULT.
-	if c.SRID != 0 {
+	// SRID (spatial) — MySQL places it after NOT NULL, before DEFAULT. Emit on PRESENCE so
+	// an explicit `SRID 0` round-trips (SHOW CREATE echoes `/*!80003 SRID 0 */`); a no-SRID
+	// column leaves HasSRID false and emits nothing.
+	if c.HasSRID {
 		fmt.Fprintf(&b, " /*!80003 SRID %d */", c.SRID)
 	}
 

--- a/mysql/catalog/normalize.go
+++ b/mysql/catalog/normalize.go
@@ -1408,6 +1408,20 @@ func (n *Normalizer) CanonicalColumn(table *Table, c *Column) string {
 	return n.canonicalColumn(table, c, false)
 }
 
+// canonicalSRID keys a column's spatial SRID by PRESENCE, not by value. MySQL treats an
+// explicit `SRID 0` as present-and-distinct from a column with no SRID clause (SHOW CREATE
+// echoes `/*!80003 SRID 0 */`; ST_GEOMETRY_COLUMNS.SRS_ID is 0 vs NULL). Keying on the raw
+// int would collapse `SRID 0` and no-SRID onto the same "0" — making an add/remove of an
+// explicit `SRID 0` an invisible no-op. The absent case uses a sentinel ("-") that no
+// present value can produce (a present SRID renders as a non-negative decimal), so present
+// and absent never share a key.
+func canonicalSRID(c *Column) string {
+	if !c.HasSRID {
+		return "-"
+	}
+	return strconv.Itoa(c.SRID)
+}
+
 // canonicalColumn builds the aggregate key; with stripCastCS it strips the
 // cast charset attributes from the two expression-bearing fields (generated
 // expression and expression default) — the wildcard half of the cast-charset
@@ -1443,7 +1457,7 @@ func (n *Normalizer) canonicalColumn(table *Table, c *Column, stripCastCS bool) 
 		"gen", gen,
 		"stored", stored,
 		"invisible", strconv.FormatBool(c.Invisible),
-		"srid", strconv.Itoa(c.SRID),
+		"srid", canonicalSRID(c),
 	)
 }
 

--- a/mysql/catalog/show.go
+++ b/mysql/catalog/show.go
@@ -255,8 +255,10 @@ func showColumnWithTable(col *Column, tbl *Table) string {
 		b.WriteString(" NULL")
 	}
 
-	// SRID for spatial types — MySQL 8.0 places it after NOT NULL, before DEFAULT.
-	if col.SRID != 0 {
+	// SRID for spatial types — MySQL 8.0 places it after NOT NULL, before DEFAULT. Emit on
+	// PRESENCE so an explicit `SRID 0` round-trips (SHOW CREATE echoes `/*!80003 SRID 0 */`);
+	// a no-SRID column leaves HasSRID false and emits nothing.
+	if col.HasSRID {
 		b.WriteString(fmt.Sprintf(" /*!80003 SRID %d */", col.SRID))
 	}
 

--- a/mysql/catalog/srid_presence_oracle_test.go
+++ b/mysql/catalog/srid_presence_oracle_test.go
@@ -1,0 +1,280 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// The oracle proof for column SRID presence (correctness-protocol.md gates 1 & 2), against
+// the LIVE MySQL 8.0 engine. The spatial column `SRID` clause is 8.0-only (MySQL 5.7 has no
+// column-level SRID), so every probe here is gated to 8.0; 5.7 is skipped, not proven.
+//
+// The bug this locks in: the catalog used to model SRID as a plain int where 0 doubled as
+// "not set", gating every emit/diff site on `SRID != 0`. But MySQL keeps an explicit
+// `SRID 0` as present-and-distinct from a column with no SRID clause: SHOW CREATE echoes
+// `/*!80003 SRID 0 */`, and ST_GEOMETRY_COLUMNS.SRS_ID is 0 vs NULL. Modeling presence
+// (Column.HasSRID) makes `SRID 0` round-trip and makes add/remove/change of an explicit
+// `SRID 0` a real MODIFY instead of a silent no-op.
+//
+// Two properties, both mechanically proven:
+//   - Idempotence (gate 1): user form vs the engine's SHOW CREATE readback diffs EMPTY, and
+//     the stored form self-diffs / self-plans empty, for every SRID form (0, nonzero, none,
+//     and with a spatial index).
+//   - Presence distinctness + apply-correctness (gate 2): SRID 0 / none / 4326 produce
+//     distinct canonical keys, and add/remove/change of the SRID clause generates a MODIFY
+//     that, applied to a real from-state database, yields a to-equal table.
+//
+// The harness reuses connectOracle / showCreate / assertDiffEmptyAgainstReadback /
+// assertApplyCorrect / loadColumn / serverCharsetFor / loadOneTable / both() / only() from
+// the sibling oracle tests. It skips cleanly when the engine is unreachable (go test -short
+// skips it entirely), so the unit suite stays hermetic.
+
+// sridIdempotenceProbes enumerates the spatial-column FORMS that must round-trip EMPTY: an
+// explicit `SRID 0`, a nonzero SRID, a no-SRID spatial column, and a spatial column with a
+// SPATIAL index (SRID matters for spatial indexes). Each is 8.0-only.
+func sridIdempotenceProbes() []diffProbe {
+	return []diffProbe{
+		// Explicit SRID 0 — the headline case. Must not collapse to no-SRID.
+		{"srid-zero", "CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 0)", "t", only(MySQL80)},
+		// Nonzero SRID — the previously-working case must stay working.
+		{"srid-4326", "CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 4326)", "t", only(MySQL80)},
+		// No-SRID spatial column — must stay no-SRID (no phantom SRID 0 emitted).
+		{"srid-none", "CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL)", "t", only(MySQL80)},
+		// Nullable spatial column with an explicit SRID 0 (nullable geometry has no spatial
+		// index requirement; proves presence is independent of nullability).
+		{"srid-zero-nullable", "CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY SRID 0)", "t", only(MySQL80)},
+		// Multiple spatial types carrying SRID 0 (POINT/LINESTRING/POLYGON) — the clause is a
+		// column attribute, not specific to GEOMETRY.
+		{"srid-zero-multi-type",
+			"CREATE TABLE t (id INT PRIMARY KEY, p POINT NOT NULL SRID 0, l LINESTRING NOT NULL SRID 0, y POLYGON NOT NULL SRID 0)",
+			"t", only(MySQL80)},
+		// Spatial column WITH a SPATIAL index + SRID (SRID is meaningful for SPATIAL indexes,
+		// which require a NOT NULL, SRID-constrained column). Must still round-trip.
+		{"srid-zero-spatial-index",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 0, SPATIAL INDEX sp_g (g))",
+			"t", only(MySQL80)},
+		{"srid-4326-spatial-index",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 4326, SPATIAL INDEX sp_g (g))",
+			"t", only(MySQL80)},
+		// Mixed table: a no-SRID spatial column alongside an explicit SRID 0 one — the two must
+		// not smear into each other (one stays absent, one stays present-0).
+		{"srid-mixed-none-and-zero",
+			"CREATE TABLE t (id INT PRIMARY KEY, a GEOMETRY, b GEOMETRY NOT NULL SRID 0)",
+			"t", only(MySQL80)},
+	}
+}
+
+// TestOracle_SRIDPresenceIdempotence proves gate 1 for every SRID form: user DDL vs its
+// engine readback diffs EMPTY, and the stored form self-diffs empty and self-plans empty,
+// on MySQL 8.0.
+func TestOracle_SRIDPresenceIdempotence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range only(MySQL80) {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, probe := range sridIdempotenceProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				db := "srid_" + strings.ReplaceAll(probe.id, "-", "_")
+				// Gate 1a + 2 (canonicalization): user form vs stored readback empty, both directions.
+				assertDiffEmptyAgainstReadback(t, o, db, probe.create, probe.table)
+
+				// Gate 1b (the spine, plan level): the stored form's self-plan is EMPTY, and the
+				// user-form-vs-stored round-trip plan is EMPTY (no phantom MODIFY re-rendering the
+				// column without SRID).
+				cat, _, rb, ok := o.catalogFromReadback(t, db+"_idem", probe.create, probe.table)
+				if !ok {
+					t.Skipf("[%s] could not obtain readback for %s", o.name, probe.id)
+				}
+				if plan := GenerateMigrationWithNormalizer(cat, cat, DiffWithNormalizer(cat, cat, n), n); plan.SQL() != "" {
+					t.Errorf("[%s] NON-EMPTY NO-OP PLAN for %s (SRID presence normalization bug):\n  stored: %s\n  plan:\n%s",
+						o.name, probe.id, strings.TrimSpace(rb), plan.SQL())
+				}
+				userCat, _ := loadOneTable(t, serverCharsetFor(o.version), probe.create, probe.table)
+				if rtPlan := GenerateMigrationWithNormalizer(userCat, cat, DiffWithNormalizer(userCat, cat, n), n); rtPlan.SQL() != "" {
+					t.Errorf("[%s] NON-EMPTY ROUND-TRIP PLAN (user vs stored) for %s:\n  user:   %s\n  stored: %s\n  plan:\n%s",
+						o.name, probe.id, strings.TrimSpace(probe.create), strings.TrimSpace(rb), rtPlan.SQL())
+				}
+			})
+		}
+	}
+}
+
+// TestOracle_SRIDPresenceDistinctness is the dual of idempotence: SRID 0, no-SRID, and a
+// nonzero SRID are three genuinely different MySQL schemas and MUST produce three distinct
+// canonical keys — otherwise add/remove/change of an explicit SRID 0 is an invisible no-op.
+// Each pair is loaded from the real engine's SHOW CREATE so the stored forms are authentic.
+func TestOracle_SRIDPresenceDistinctness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range only(MySQL80) {
+		o := connectOracle(t, version)
+		sc := serverCharsetFor(o.version)
+		n := NormalizerFor(o.version)
+
+		// Apply all three forms in one database and read them back, so each column's stored
+		// form is authentic and comparable (same table charset, same engine).
+		ddl := "CREATE TABLE t (id INT PRIMARY KEY, gz GEOMETRY NOT NULL SRID 0, gn GEOMETRY NOT NULL, gf GEOMETRY NOT NULL SRID 4326)"
+		rb, ok := o.showCreate(t, "srid_distinct", ddl, "t")
+		if !ok {
+			t.Skipf("[%s] could not obtain readback", o.name)
+		}
+		tbl, zCol := loadColumn(t, sc, rb, "t", "gz")
+		_, nCol := loadColumn(t, sc, rb, "t", "gn")
+		_, fCol := loadColumn(t, sc, rb, "t", "gf")
+		if zCol == nil || nCol == nil || fCol == nil {
+			t.Fatalf("[%s] missing columns (z=%v n=%v f=%v)", o.name, zCol != nil, nCol != nil, fCol != nil)
+		}
+
+		kz := n.CanonicalColumn(tbl, zCol)
+		kn := n.CanonicalColumn(tbl, nCol)
+		kf := n.CanonicalColumn(tbl, fCol)
+
+		t.Run(o.name+"/srid-zero-vs-none", func(t *testing.T) {
+			// The headline distinctness: SRID 0 (present, value 0) must differ from no-SRID.
+			if kz == kn {
+				t.Errorf("[%s] SRID 0 and no-SRID must produce DIFFERENT keys (else add/remove SRID 0 is a no-op):\n  srid0: %s\n  none:  %s",
+					o.name, kz, kn)
+			}
+		})
+		t.Run(o.name+"/srid-zero-vs-4326", func(t *testing.T) {
+			if kz == kf {
+				t.Errorf("[%s] SRID 0 and SRID 4326 must produce DIFFERENT keys:\n  srid0:    %s\n  srid4326: %s", o.name, kz, kf)
+			}
+		})
+		t.Run(o.name+"/srid-none-vs-4326", func(t *testing.T) {
+			if kn == kf {
+				t.Errorf("[%s] no-SRID and SRID 4326 must produce DIFFERENT keys:\n  none:     %s\n  srid4326: %s", o.name, kn, kf)
+			}
+		})
+	}
+}
+
+// sridMigrationProbes enumerates the add / remove / change transitions of the SRID clause,
+// each of which must generate a MODIFY that applies to a real from-state database and yields
+// a to-equal table. 8.0-only. These reuse the generate-core apply-correctness harness
+// (assertApplyCorrect), which loads from/to from the engine's own readbacks, generates the
+// plan, applies it, and diffs the result against `to` in both directions.
+func sridMigrationProbes() []migrationProbe {
+	return []migrationProbe{
+		// ---- ADD SRID (none -> value) ----
+		{"add-srid-none-to-zero", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL)",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 0)", only(MySQL80)},
+		{"add-srid-none-to-4326", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL)",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 4326)", only(MySQL80)},
+		// ---- REMOVE SRID (value -> none) ----
+		{"remove-srid-zero-to-none", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 0)",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL)", only(MySQL80)},
+		{"remove-srid-4326-to-none", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 4326)",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL)", only(MySQL80)},
+		// ---- CHANGE SRID (value -> different value, incl. to/from 0) ----
+		{"change-srid-4326-to-zero", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 4326)",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 0)", only(MySQL80)},
+		{"change-srid-zero-to-4326", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 0)",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 4326)", only(MySQL80)},
+		// ---- ADD spatial column carrying SRID 0 (from empty table) ----
+		{"add-column-with-srid-zero", "t",
+			"CREATE TABLE t (id INT PRIMARY KEY)",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 0)", only(MySQL80)},
+		// ---- CREATE table with a SRID-0 column + spatial index (from empty) ----
+		{"create-srid-zero-spatial-index", "t", "",
+			"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 0, SPATIAL INDEX sp_g (g))", only(MySQL80)},
+	}
+}
+
+// TestOracle_SRIDPresenceApplyCorrectness proves gate 2 (apply-correctness) for every SRID
+// add/remove/change: the generated DDL transforms a real from-state database into a to-equal
+// one, on MySQL 8.0. A non-empty result diff (or a failed apply) is a bug.
+func TestOracle_SRIDPresenceApplyCorrectness(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range only(MySQL80) {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		for _, probe := range sridMigrationProbes() {
+			if !containsVersion(probe.versions, version) {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/%s", o.name, probe.id), func(t *testing.T) {
+				assertApplyCorrect(t, o, n, probe)
+			})
+		}
+	}
+}
+
+// TestOracle_SRIDPresenceEmitsClause is the dedicated readback proof: for an add/change TO a
+// specific SRID, the generated plan text carries the exact `SRID <n>` clause (including
+// `SRID 0`), and for a remove the plan drops it. This complements apply-correctness (which
+// could in principle be satisfied by two equally-wrong sides) by asserting the emitted DDL
+// itself, and directly pins the "MODIFY re-renders WITHOUT SRID 0" regression: a remove must
+// emit no SRID clause, an add of SRID 0 must emit `SRID 0`.
+func TestOracle_SRIDPresenceEmitsClause(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	for _, version := range only(MySQL80) {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		sc := serverCharsetFor(o.version)
+
+		cases := []struct {
+			id          string
+			fromDDL     string
+			toDDL       string
+			wantInPlan  string // substring the plan MUST contain ("" = skip)
+			wantNotPlan string // substring the plan MUST NOT contain ("" = skip)
+		}{
+			// none -> SRID 0 : the plan must render the explicit SRID 0 clause.
+			{"add-zero", "CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL)",
+				"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 0)", "SRID 0", ""},
+			// none -> SRID 4326.
+			{"add-4326", "CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL)",
+				"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 4326)", "SRID 4326", ""},
+			// SRID 0 -> none : the plan must NOT carry any SRID clause (the regression case).
+			{"remove-zero", "CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 0)",
+				"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL)", "", "SRID"},
+			// SRID 4326 -> SRID 0 : must emit SRID 0, not drop to no-clause.
+			{"change-to-zero", "CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 4326)",
+				"CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 0)", "SRID 0", ""},
+		}
+		for _, c := range cases {
+			t.Run(o.name+"/"+c.id, func(t *testing.T) {
+				// Load from/to from the engine's own readbacks so the catalog is authentic.
+				rbFrom, ok1 := o.showCreate(t, "srid_emit_f", c.fromDDL, "t")
+				rbTo, ok2 := o.showCreate(t, "srid_emit_t", c.toDDL, "t")
+				if !ok1 || !ok2 {
+					t.Skipf("[%s] could not obtain readbacks", o.name)
+				}
+				fromCat, _ := loadOneTable(t, sc, rbFrom, "t")
+				toCat, _ := loadOneTable(t, sc, rbTo, "t")
+				diff := DiffWithNormalizer(fromCat, toCat, n)
+				plan := GenerateMigrationWithNormalizer(fromCat, toCat, diff, n)
+				sql := plan.SQL()
+				if sql == "" {
+					t.Fatalf("[%s] expected a MODIFY plan for %s, got empty (SRID change went undetected)", o.name, c.id)
+				}
+				if c.wantInPlan != "" && !strings.Contains(sql, c.wantInPlan) {
+					t.Errorf("[%s] %s: plan must contain %q:\n%s", o.name, c.id, c.wantInPlan, sql)
+				}
+				if c.wantNotPlan != "" && strings.Contains(sql, c.wantNotPlan) {
+					t.Errorf("[%s] %s: plan must NOT contain %q (SRID leaked on a remove):\n%s", o.name, c.id, c.wantNotPlan, sql)
+				}
+			})
+		}
+	}
+}

--- a/mysql/catalog/srid_presence_oracle_test.go
+++ b/mysql/catalog/srid_presence_oracle_test.go
@@ -67,6 +67,88 @@ func sridIdempotenceProbes() []diffProbe {
 	}
 }
 
+// TestOracle_SRIDPresenceCreateTableLike proves the CREATE TABLE ... LIKE clone path copies
+// the source column's SRID presence. MySQL's LIKE preserves the SRID clause (verified live:
+// a clone of a `SRID 0` column keeps `/*!80003 SRID 0 */`), so the omni loader's
+// createTableLike must copy SRID + HasSRID onto the cloned column — otherwise the clone loads
+// as no-SRID and its canonical form disagrees with the engine's readback of the clone.
+//
+// This uses a focused assertion (not the shared assertDiffEmptyAgainstReadback) because the
+// user-form SDL declares TWO tables (the source + the LIKE clone) while the readback is of
+// the clone alone; comparing the clone's column `g` canonical key against the engine's
+// readback of `g` isolates the SRID-copy behavior without a spurious whole-table diff on the
+// source table.
+func TestOracle_SRIDPresenceCreateTableLike(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	cases := []struct {
+		id     string
+		src    string // the source-table DDL (defines column g)
+		srsID  string // information_schema SRS_ID we expect on the clone's g ("" = NULL/absent)
+		expSQL string // substring the clone's g must render as ("" = no SRID clause)
+	}{
+		{"clone-srid-zero", "CREATE TABLE src (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 0)", "0", "/*!80003 SRID 0 */"},
+		{"clone-srid-4326", "CREATE TABLE src (id INT PRIMARY KEY, g GEOMETRY NOT NULL SRID 4326)", "4326", "/*!80003 SRID 4326 */"},
+		{"clone-srid-none", "CREATE TABLE src (id INT PRIMARY KEY, g GEOMETRY NOT NULL)", "", ""},
+	}
+	for _, version := range only(MySQL80) {
+		o := connectOracle(t, version)
+		sc := serverCharsetFor(o.version)
+		n := NormalizerFor(o.version)
+		for _, c := range cases {
+			t.Run(o.name+"/"+c.id, func(t *testing.T) {
+				// Apply source + LIKE clone on the engine, read back the CLONE.
+				createBoth := c.src + ";\nCREATE TABLE clone LIKE src"
+				rbClone, ok := o.showCreate(t, "srid_like_"+strings.ReplaceAll(c.id, "-", "_"), createBoth, "clone")
+				if !ok {
+					t.Skipf("[%s] could not obtain clone readback", o.name)
+				}
+				// User side: load the two-statement SDL and pull the clone's column g (this
+				// exercises the omni loader's createTableLike). Stored side: load the engine's
+				// readback of the clone.
+				wrappedUser := fmt.Sprintf("CREATE DATABASE ld DEFAULT CHARSET=%s;\nUSE ld;\n%s", sc, createBoth)
+				userCat, err := LoadSQL(wrappedUser)
+				if err != nil {
+					t.Fatalf("[%s] LoadSQL of source+LIKE failed: %v", o.name, err)
+				}
+				var userTbl *Table
+				for _, db := range userCat.Databases() {
+					if tt := db.GetTable("clone"); tt != nil {
+						userTbl = tt
+						break
+					}
+				}
+				if userTbl == nil {
+					t.Fatalf("[%s] clone table not found after LoadSQL", o.name)
+				}
+				userCol := userTbl.GetColumn("g")
+				storTbl, storCol := loadColumn(t, sc, rbClone, "clone", "g")
+				if userCol == nil || storCol == nil {
+					t.Fatalf("[%s] column g missing (user=%v stored=%v)", o.name, userCol != nil, storCol != nil)
+				}
+
+				// The clone's g must carry the same SRID presence as the engine stores.
+				if userCol.HasSRID != (c.srsID != "") {
+					t.Errorf("[%s] %s: clone g HasSRID=%v, want %v (engine SRS_ID=%q)", o.name, c.id, userCol.HasSRID, c.srsID != "", c.srsID)
+				}
+				// Canonical keys of the user-loaded clone column and the engine readback must match.
+				if uk, sk := n.CanonicalColumn(userTbl, userCol), n.CanonicalColumn(storTbl, storCol); uk != sk {
+					t.Errorf("[%s] %s: clone g phantom-diffs vs engine readback:\n  user:  %s\n  store: %s", o.name, c.id, uk, sk)
+				}
+				// The rendered column definition must (or must not) carry the SRID clause.
+				got := showColumnWithTable(userCol, userTbl)
+				if c.expSQL != "" && !strings.Contains(got, c.expSQL) {
+					t.Errorf("[%s] %s: clone g render %q must contain %q", o.name, c.id, got, c.expSQL)
+				}
+				if c.expSQL == "" && strings.Contains(got, "SRID") {
+					t.Errorf("[%s] %s: clone g render %q must NOT contain a SRID clause", o.name, c.id, got)
+				}
+			})
+		}
+	}
+}
+
 // TestOracle_SRIDPresenceIdempotence proves gate 1 for every SRID form: user DDL vs its
 // engine readback diffs EMPTY, and the stored form self-diffs empty and self-plans empty,
 // on MySQL 8.0.

--- a/mysql/catalog/table.go
+++ b/mysql/catalog/table.go
@@ -107,9 +107,15 @@ type Column struct {
 	Invisible                    bool
 	GeneratedInvisiblePrimaryKey bool // true for MySQL-generated my_row_id GIPK
 	Hidden                       ColumnHiddenKind
-	SRID                         int          // Spatial Reference ID (0 = not set)
-	DefaultAnalyzed              AnalyzedExpr // Phase 3: analyzed DEFAULT expression
-	GeneratedAnalyzed            AnalyzedExpr // Phase 3: analyzed GENERATED ALWAYS AS expression
+	SRID                         int // Spatial Reference ID (valid only when HasSRID)
+	// HasSRID records whether the column carries an explicit spatial SRID clause. MySQL
+	// treats `SRID 0` as present-and-distinct from a column with no SRID clause (SHOW
+	// CREATE echoes `/*!80003 SRID 0 */`; ST_GEOMETRY_COLUMNS.SRS_ID is 0 vs NULL), so
+	// presence cannot be derived from SRID != 0. Emit and diff gate on HasSRID; a
+	// non-spatial column leaves it false.
+	HasSRID           bool
+	DefaultAnalyzed   AnalyzedExpr // Phase 3: analyzed DEFAULT expression
+	GeneratedAnalyzed AnalyzedExpr // Phase 3: analyzed GENERATED ALWAYS AS expression
 }
 
 type ColumnDefaultKind int

--- a/mysql/catalog/tablecmds.go
+++ b/mysql/catalog/tablecmds.go
@@ -2406,6 +2406,11 @@ func (c *Catalog) createTableLike(db *Database, tableName, key string, stmt *nod
 			Invisible:                    srcCol.Invisible,
 			GeneratedInvisiblePrimaryKey: srcCol.GeneratedInvisiblePrimaryKey,
 			Hidden:                       srcCol.Hidden,
+			// SRID copied by presence: MySQL's CREATE TABLE ... LIKE preserves the source
+			// column's SRID clause (incl. an explicit `SRID 0`), so the cloned column must
+			// carry both the value and its presence flag, not silently drop to no-SRID.
+			SRID:    srcCol.SRID,
+			HasSRID: srcCol.HasSRID,
 		}
 		if srcCol.Default != nil {
 			def := *srcCol.Default

--- a/mysql/catalog/tablecmds.go
+++ b/mysql/catalog/tablecmds.go
@@ -236,9 +236,12 @@ func (c *Catalog) createTable(stmt *nodes.CreateTableStmt) error {
 			applyBinaryModifierCollation(col, colDef.TypeName)
 		}
 
-		// Top-level column properties.
-		if colDef.TypeName != nil && colDef.TypeName.SRID != 0 {
+		// Top-level column properties. Copy SRID by PRESENCE (HasSRID), not by a nonzero
+		// value: MySQL keeps `SRID 0` as a distinct, present clause, so a `SRID 0` column
+		// (SRID==0, HasSRID==true) must not be mistaken for a no-SRID column.
+		if colDef.TypeName != nil && colDef.TypeName.HasSRID {
 			col.SRID = colDef.TypeName.SRID
+			col.HasSRID = true
 		}
 		if colDef.AutoIncrement {
 			col.AutoIncrement = true

--- a/mysql/parser/create_table.go
+++ b/mysql/parser/create_table.go
@@ -592,13 +592,16 @@ func (p *Parser) parseColumnOption(col *nodes.ColumnDef) (bool, error) {
 		return true, nil
 	}
 
-	// SRID column option (now lexes as kwSRID keyword token)
+	// SRID column option (now lexes as kwSRID keyword token). Record presence even for
+	// `SRID 0`: MySQL keeps `SRID 0` as a distinct, present clause (SHOW CREATE echoes it),
+	// so HasSRID — not SRID != 0 — is what downstream emit/diff must gate on.
 	if p.cur.Type == kwSRID {
 		p.advance()
 		if p.cur.Type != tokICONST {
 			return false, nil
 		}
 		col.TypeName.SRID = int(p.cur.Ival)
+		col.TypeName.HasSRID = true
 		p.advance()
 		return true, nil
 	}


### PR DESCRIPTION
## Problem

The MySQL catalog modeled a spatial column's SRID as a plain `int` where `0` doubled as "not set", and every emit / parse / diff site gated on `SRID != 0`. But MySQL treats an explicit `SRID 0` as **present-and-distinct** from a column with no SRID clause:

- `SHOW CREATE TABLE` echoes `/*!80003 SRID 0 */` for a `SRID 0` column, and nothing for a no-SRID column.
- `information_schema.ST_GEOMETRY_COLUMNS.SRS_ID` is `0` for `SRID 0` vs `NULL` for no-SRID.

Both facts verified live on MySQL 8.0.32:

```
g GEOMETRY NOT NULL SRID 0     -> /*!80003 SRID 0 */    SRS_ID = 0
g GEOMETRY NOT NULL SRID 4326  -> /*!80003 SRID 4326 */ SRS_ID = 4326
g GEOMETRY NOT NULL            -> (no clause)            SRS_ID = NULL
```

Because the model collapsed `SRID 0` onto no-SRID, through `LoadSDL -> Diff -> GenerateMigration`:
- adding or removing an explicit `SRID 0` was a **silent no-op**, and
- a `MODIFY` generated for an unrelated change re-rendered the column **without** `SRID 0`, silently changing the spatial constraint.

## Fix — give SRID presence semantics

Add a `HasSRID bool` presence companion to the existing `SRID int` (mirroring the pre-existing `NullExplicit` / `CharsetExplicit` / `CollationExplicit` companion-bool pattern on the same `Column` — minimal churn, established convention), threaded through every layer:

1. **AST `TypeName`** (`mysql/ast/parsenodes.go`): `DataType.HasSRID`; the parser (`mysql/parser/create_table.go`) sets it whenever the `SRID` clause is present, **including `SRID 0`**; the AST dump (`mysql/ast/outfuncs.go` `writeDataType`) emits `:srid` on presence.
2. **Catalog `Column`** (`mysql/catalog/table.go`): `Column.HasSRID`; copied by presence in **all three** catalog-build paths — `createTable` (`tablecmds.go`, CREATE TABLE), `buildColumnFromDef` (`altercmds.go`, ALTER ADD/MODIFY/CHANGE COLUMN — previously dropped SRID entirely), and `createTableLike` (`tablecmds.go`, CREATE TABLE ... LIKE — previously dropped SRID on the clone).
3. **Emit** (`mysql/catalog/migration_column.go`, `mysql/catalog/show.go`): render `/*!80003 SRID %d */` on presence (including `SRID 0`); a no-SRID column emits nothing.
4. **Normalize** (`mysql/catalog/normalize.go`): the column canonical key now keys SRID by presence (`canonicalSRID`: present -> the value incl. `"0"`; absent -> sentinel `"-"`). The length-prefixed `encodeKeyFields` guarantees the sentinel can never collide with any present value. The column differ (`diff_column.go` `columnsChanged`) compares via this aggregate key, so add/remove/change of `SRID 0` now produces a `MODIFY`.

Existing behavior preserved: a no-SRID column stays no-SRID (no phantom `SRID 0`), a non-zero SRID is unchanged.

## Oracle matrix (live MySQL 8.0.32)

SRID is 8.0-only (5.7 has no column-level SRID clause), so every probe is gated to 8.0; 5.7 is skipped, not proven. All green:

- **Idempotence** (user form vs `SHOW CREATE` readback self-diff + self-plan EMPTY): `SRID 0`, `SRID 4326`, no-SRID, nullable-`SRID 0`, multi-type (POINT/LINESTRING/POLYGON) `SRID 0`, spatial-index + `SRID 0`, spatial-index + `SRID 4326`, mixed none+`SRID 0`.
- **Presence distinctness** (canonical keys differ): `SRID 0` != none, `SRID 0` != `SRID 4326`, none != `SRID 4326`.
- **Apply-correctness** (generated MODIFY applies to a real from-DB and converges): add (none->0, none->4326), remove (0->none, 4326->none), change (4326->0, 0->4326), add-column-with-`SRID 0`, create-with-spatial-index.
- **Emit clause** (pins the "MODIFY re-renders without SRID 0" regression): remove emits **no** SRID clause; add-0 / change-to-0 emit `SRID 0`.
- **CREATE TABLE ... LIKE** clone preserves SRID presence (clone of `SRID 0` / `4326` / none), proven to fail without the `createTableLike` fix.

## Testing

- New `mysql/catalog/srid_presence_oracle_test.go` (4 oracle test functions, 26 subtests) — all green on live 8.0.32.
- Full `go test ./mysql/...` green (both 5.7.25 + 8.0.32 engines), no regressions.
- `golangci-lint` stable (85 issues on origin/main baseline == 85 on this branch for the touched packages; 0 new), `gofmt` clean.

## Review

Cross-family review before opening (Codex `/codex:review` + two independent Claude `/code-review` finder passes, blind to each other). All three independently caught one real blocker — `createTableLike` omitted `SRID`/`HasSRID` from its column copy — fixed in the second commit and re-proven. Re-review converged clean (Codex: no introduced bug; Claude: exhaustive missed-site sweep clean, LIKE fix correct). The presence-keying normalization decision was audited and confirmed sound (collision-free sentinel, correct distinctness, version-independent).

## Tracking

Linear **BYT-9830** (the omni half). The bytebase half — re-pin + re-add store-proto / sync / dump / differ / generator + v1 converters — is handled separately.
