### PR TITLE
mysql: model + preserve routine/trigger/event session context on recreate

### DIFF
--- a/mysql/catalog/migration_event.go
+++ b/mysql/catalog/migration_event.go
@@ -42,6 +42,8 @@ func generateEventDDL(_, _ *Catalog, diff *SchemaDiff, _ *Normalizer) []Migratio
 		e := &diff.Events[i]
 		switch e.Action {
 		case DiffAdd:
+			// A brand-new event emits a BARE CREATE (→ server-default session): no original
+			// context to preserve.
 			ops = append(ops, MigrationOp{
 				Type:       OpCreateEvent,
 				Database:   e.Database,
@@ -57,7 +59,8 @@ func generateEventDDL(_, _ *Catalog, diff *SchemaDiff, _ *Normalizer) []Migratio
 				// case: 5.7's ALTER EVENT … ON SCHEDULE does NOT clear an existing ENDS — verified
 				// on live 5.7.25, where the old ENDS survives; 8.0.32 clears it). Fall back to
 				// DROP + CREATE, which is always correct: a PhasePre DROP removes the old event
-				// before the PhaseMain CREATE re-establishes the target with no ENDS.
+				// before the PhaseMain CREATE re-establishes the target with no ENDS. The recreate
+				// runs under the OLD event's session context (e.From), including its time_zone.
 				ops = append(ops,
 					MigrationOp{
 						Type:       OpDropEvent,
@@ -72,7 +75,7 @@ func generateEventDDL(_, _ *Catalog, diff *SchemaDiff, _ *Normalizer) []Migratio
 						Type:       OpCreateEvent,
 						Database:   e.Database,
 						ObjectName: e.Name,
-						SQL:        renderCreateEvent(e.To),
+						SQL:        renderCreateEventWithContext(e.To, e.From),
 						Phase:      PhaseMain,
 						Priority:   priorityEvent,
 						sortName:   eventSortName(e.Database, e.Name),
@@ -80,11 +83,15 @@ func generateEventDDL(_, _ *Catalog, diff *SchemaDiff, _ *Normalizer) []Migratio
 				)
 				continue
 			}
+			// ALTER EVENT … DO <body> RE-STAMPS the event's sql_mode / character_set_client /
+			// collation_connection from the executing session (verified on live 8.0.32 — a bare
+			// ALTER EVENT DO under a different session flips ROUTINES/EVENTS.SQL_MODE), so the
+			// ALTER must run under the OLD event's context too, not just the DROP+CREATE path.
 			ops = append(ops, MigrationOp{
 				Type:       OpCreateEvent, // forward (PhaseMain) op; SQL is ALTER EVENT (see file doc)
 				Database:   e.Database,
 				ObjectName: e.Name,
-				SQL:        renderAlterEvent(e.To),
+				SQL:        renderAlterEventWithContext(e.To, e.From),
 				Phase:      PhaseMain,
 				Priority:   priorityEvent,
 				sortName:   eventSortName(e.Database, e.Name),
@@ -149,6 +156,46 @@ func renderCreateEvent(e *Event) string {
 	b.WriteString(quoteIdent(e.Name))
 	writeEventBodyClauses(&b, e)
 	return b.String()
+}
+
+// renderCreateEventWithContext renders the target event's CREATE and, when the OLD event
+// (`from`) carries synced session context, wraps it in a save/restore of that context —
+// sql_mode, character_set_client, collation_connection, AND the session time_zone — so an
+// event re-created via DROP+CREATE keeps the schedule/behavior it had under its original
+// session (a non-UTC time_zone in particular changes how a literal schedule is
+// interpreted). Without synced context (`from` nil / unset) it is a bare CREATE.
+func renderCreateEventWithContext(to, from *Event) string {
+	return frameEventWithContext(renderCreateEvent(to), from)
+}
+
+// renderAlterEventWithContext renders the target event's ALTER and, when the OLD event
+// (`from`) carries synced session context, wraps it in the same save/restore. This is
+// REQUIRED, not cosmetic: ALTER EVENT … DO <body> re-stamps sql_mode/charset/collation from
+// the executing session (verified on live 8.0.32), so a bare ALTER under the deploy session
+// would rewrite the event's stored modes. time_zone is not re-stamped by ALTER, but framing
+// it is harmless and keeps the CREATE and ALTER paths uniform.
+func renderAlterEventWithContext(to, from *Event) string {
+	return frameEventWithContext(renderAlterEvent(to), from)
+}
+
+// frameEventWithContext wraps an event CREATE/ALTER statement in a save/restore of the OLD
+// event's session context when that context is present; otherwise returns the bare statement.
+func frameEventWithContext(stmtSQL string, from *Event) string {
+	if from != nil && from.HasSessionContext {
+		return renderWithSessionContext(stmtSQL, eventSessionContext(from), true)
+	}
+	return stmtSQL
+}
+
+// eventSessionContext bundles an event's captured session context for the framing, including
+// the event-only time_zone axis.
+func eventSessionContext(e *Event) SessionContext {
+	return SessionContext{
+		SQLMode:             e.SQLMode,
+		CharacterSetClient:  e.CharacterSetClient,
+		CollationConnection: e.CollationConnection,
+		TimeZone:            e.TimeZone,
+	}
 }
 
 // renderAlterEvent renders an ALTER EVENT that re-establishes every mutable aspect of the target

--- a/mysql/catalog/migration_routine.go
+++ b/mysql/catalog/migration_routine.go
@@ -76,7 +76,9 @@ func routineOps(e *RoutineDiffEntry, n *Normalizer) []MigrationOp {
 		if e.To == nil {
 			return nil
 		}
-		return []MigrationOp{createRoutineOp(e, e.To, n)}
+		// A brand-new routine emits a BARE CREATE (→ server-default session): there is no
+		// original context to preserve (nil framing source).
+		return []MigrationOp{createRoutineOp(e, e.To, nil, n)}
 	case DiffDrop:
 		if e.From == nil {
 			return nil
@@ -90,22 +92,41 @@ func routineOps(e *RoutineDiffEntry, n *Normalizer) []MigrationOp {
 			return []MigrationOp{alterRoutineOp(e, e.To)}
 		}
 		// Body/params/RETURNS/DETERMINISTIC changed → DROP (PhasePre) then CREATE (PhaseMain).
-		return []MigrationOp{dropRoutineOp(e, e.From), createRoutineOp(e, e.To, n)}
+		// The recreate runs under the OLD routine's session context (e.From), so a routine
+		// authored under a non-default sql_mode/charset/collation is re-created identically.
+		return []MigrationOp{dropRoutineOp(e, e.From), createRoutineOp(e, e.To, e.From, n)}
 	}
 	return nil
 }
 
 // createRoutineOp builds a CREATE FUNCTION/PROCEDURE op (PhaseMain, priorityRoutine — before
-// view creates; see the file doc). The SQL is the DEFINER-less stored form.
-func createRoutineOp(e *RoutineDiffEntry, r *Routine, n *Normalizer) MigrationOp {
+// view creates; see the file doc). The SQL is the DEFINER-less stored form. When `from` is
+// non-nil AND carries synced session context, the emitted CREATE is wrapped in a save/restore
+// of that OLD context (renderWithSessionContext) so a recreate preserves the routine's
+// original sql_mode/charset/collation; on a first-time create `from` is nil → bare CREATE.
+func createRoutineOp(e *RoutineDiffEntry, r, from *Routine, n *Normalizer) MigrationOp {
+	sql := renderCreateRoutine(e.Database, r, n)
+	if from != nil && from.HasSessionContext {
+		sql = renderWithSessionContext(sql, routineSessionContext(from), false)
+	}
 	return MigrationOp{
 		Type:       createRoutineOpType(e.IsProcedure),
 		Database:   e.Database,
 		ObjectName: e.Name,
-		SQL:        renderCreateRoutine(e.Database, r, n),
+		SQL:        sql,
 		Phase:      PhaseMain,
 		Priority:   priorityRoutine,
 		sortName:   routineSortName(e.Database, e.Name),
+	}
+}
+
+// routineSessionContext bundles a routine's captured session context for the recreate
+// framing (routines have no time_zone axis).
+func routineSessionContext(r *Routine) SessionContext {
+	return SessionContext{
+		SQLMode:             r.SQLMode,
+		CharacterSetClient:  r.CharacterSetClient,
+		CollationConnection: r.CollationConnection,
 	}
 }
 

--- a/mysql/catalog/migration_trigger.go
+++ b/mysql/catalog/migration_trigger.go
@@ -47,7 +47,9 @@ func generateTriggerDDL(_, to *Catalog, diff *SchemaDiff, _ *Normalizer) []Migra
 			if te.To == nil {
 				continue
 			}
-			ops = append(ops, buildCreateTriggerOp(te.Database, te.To))
+			// A brand-new trigger emits a BARE CREATE (→ server-default session): no original
+			// context to preserve (nil framing source).
+			ops = append(ops, buildCreateTriggerOp(te.Database, te.To, nil))
 		case DiffDrop:
 			if te.From == nil || dropTriggerSuppressed(to, te.From) {
 				continue
@@ -65,7 +67,10 @@ func generateTriggerDDL(_, to *Catalog, diff *SchemaDiff, _ *Normalizer) []Migra
 				ops = append(ops, buildDropTriggerOp(te.Database, te.From))
 			}
 			if te.To != nil {
-				ops = append(ops, buildCreateTriggerOp(te.Database, te.To))
+				// The recreate runs under the OLD trigger's session context (te.From), so a
+				// trigger authored under a non-default sql_mode/charset/collation is re-created
+				// identically.
+				ops = append(ops, buildCreateTriggerOp(te.Database, te.To, te.From))
 			}
 		}
 	}
@@ -108,7 +113,11 @@ func dropTriggerSuppressed(to *Catalog, trig *Trigger) bool {
 // default) the stored object name is case-significant, so the DDL must reproduce the declared
 // casing, the same rationale as tableIdent in migration_table.go. `database` (the lower-cased diff
 // key) is retained only for the Database/sortName ordering metadata.
-func buildCreateTriggerOp(database string, trig *Trigger) MigrationOp {
+// When `from` is non-nil AND carries synced session context, the emitted CREATE is wrapped
+// in a save/restore of that OLD context (renderWithSessionContext) so a recreate preserves
+// the trigger's original sql_mode/charset/collation; on a first-time create `from` is nil →
+// bare CREATE. Triggers have no time_zone axis.
+func buildCreateTriggerOp(database string, trig, from *Trigger) MigrationOp {
 	dbName := triggerDatabaseName(trig)
 	trigIdent := qualifiedTriggerIdent(dbName, trig.Name)
 	onTableIdent := qualifiedTriggerIdent(dbName, trig.Table)
@@ -121,15 +130,30 @@ func buildCreateTriggerOp(database string, trig *Trigger) MigrationOp {
 		b.WriteString(body)
 	}
 
+	sql := b.String()
+	if from != nil && from.HasSessionContext {
+		sql = renderWithSessionContext(sql, triggerSessionContext(from), false)
+	}
+
 	return MigrationOp{
 		Type:         OpCreateTrigger,
 		Database:     database,
 		ObjectName:   trig.Name,
 		ParentObject: trig.Table,
-		SQL:          b.String(),
+		SQL:          sql,
 		Phase:        PhaseMain,
 		Priority:     priorityTrigger,
 		sortName:     triggerSortName(database, trig.Name),
+	}
+}
+
+// triggerSessionContext bundles a trigger's captured session context for the recreate
+// framing (triggers have no time_zone axis).
+func triggerSessionContext(t *Trigger) SessionContext {
+	return SessionContext{
+		SQLMode:             t.SQLMode,
+		CharacterSetClient:  t.CharacterSetClient,
+		CollationConnection: t.CollationConnection,
 	}
 }
 

--- a/mysql/catalog/session_context.go
+++ b/mysql/catalog/session_context.go
@@ -1,0 +1,224 @@
+package catalog
+
+import "strings"
+
+// MySQL SDL — object session context (sql_mode / charset / collation / time_zone).
+//
+// A routine, trigger, or event carries the session context it was created under:
+// sql_mode, character_set_client, collation_connection, and — for events — the session
+// time_zone. A declarative rollout must not silently drop that context when it re-emits the
+// object (e.g. a routine authored under PIPES_AS_CONCAT re-created under the server default
+// treats `||` as OR). Two emission paths must preserve it, both verified on live 8.0.32:
+//
+//   - DROP+CREATE recreate (routines/triggers always for a body/param change — MySQL has no
+//     CREATE OR REPLACE; events for the ENDS-removal case). The fresh CREATE adopts the
+//     SESSION context, so it must run under the OLD object's context.
+//   - ALTER EVENT … DO <body> (the common event body/schedule change). Empirically, ALTER
+//     EVENT RE-STAMPS sql_mode, character_set_client, and collation_connection from the
+//     session (it does NOT re-stamp time_zone), so a bare ALTER under the deploy session
+//     rewrites the event's stored modes. It too must run under the OLD event's context.
+//
+// NOT re-stamped, so left bare: ALTER FUNCTION / ALTER PROCEDURE (the characteristic-only
+// routine modify — COMMENT / SQL SECURITY / DATA ACCESS). Verified on live 8.0.32: an
+// ALTER FUNCTION COMMENT under a default-mode session leaves ROUTINES.SQL_MODE unchanged.
+//
+// The declarative SDL text is BARE (a clean export carries no `SET sql_mode` framing), so
+// omni cannot recover the old context from the source SDL. Instead the context enters
+// out-of-band as STRUCTURED data: bytebase passes the synced metadata's per-object context
+// (RoutineMetadata.SqlMode, TriggerMetadata.SqlMode, EventMetadata.TimeZone, …) via
+// ApplySessionContext, which stamps it onto the already-loaded catalog's objects. The SDL
+// text stays 100% bare; the context lives only on the in-memory objects.
+//
+// The context is deliberately NOT part of any object's declarative identity — the diff keys
+// (canonicalRoutine, triggersChanged, eventCanonicalKey) all exclude it, so a mode-only
+// difference never triggers a phantom recreate. It is consumed only by the generators, which
+// wrap the emitted CREATE/ALTER in a concat-safe save/restore sourced from the OLD (From)
+// object (renderWithSessionContext), matching mysqldump's framing, so one object's context
+// can never leak into the next statement of a multi-statement migration.
+
+// SessionContext is the session state captured when a routine/trigger/event was created.
+// Every field is the value as stored in the synced metadata; empty strings are legal and
+// are preserved verbatim (an authored empty sql_mode round-trips as SET sql_mode=”). A
+// PARTIAL context (some axes empty) preserves the populated axes and leaves the session
+// default for the rest — synced information_schema metadata always carries sql_mode /
+// charset / collation for a real object, so this only arises for a hand-built context.
+// TimeZone applies only to events and is ignored for routines and triggers.
+//
+// The database default collation is deliberately NOT modeled: it is a property of the SCHEMA
+// (CREATE DATABASE … DEFAULT COLLATE), not a session variable, so it is not preservable
+// per-object. Verified on live 8.0.32 — setting `SET collation_database = <x>` before a
+// CREATE leaves information_schema.ROUTINES.DATABASE_COLLATION at the schema default, not
+// <x>. A DEFAULT-COLLATE change is its own database-level schema diff.
+type SessionContext struct {
+	SQLMode             string
+	CharacterSetClient  string
+	CollationConnection string
+	TimeZone            string // events only
+}
+
+// SessionContextMap carries the per-object session context for a whole schema, keyed by
+// LOWER-CASED object name within each object kind (matching the catalog's identity
+// folding). It is the structured out-of-band input bytebase hands to ApplySessionContext;
+// the SDL text itself never carries session context. A nil or missing entry simply leaves
+// that object's context unset (a bare recreate).
+//
+// Name-only keying is sufficient because the MySQL declarative-rollout path is
+// SINGLE-DATABASE: bytebase loads both the source (dumped) and target (user) SDL under one
+// synthetic database (bbcatalog), so within a diff a name is unambiguous. ApplySessionContext
+// applies the map across every database in the catalog; a hypothetical multi-database catalog
+// with same-named objects in different databases is out of scope for this path.
+type SessionContextMap struct {
+	Functions  map[string]SessionContext
+	Procedures map[string]SessionContext
+	Triggers   map[string]SessionContext
+	Events     map[string]SessionContext
+}
+
+// ApplySessionContext stamps the supplied per-object session context onto every matching
+// object already loaded in the catalog, across all databases. It is called on the SOURCE
+// (from/current) catalog — the one whose objects supply the ORIGINAL context a recreate
+// must restore — after LoadSDL/LoadSQL and before Diff.
+//
+// Matching is by lower-cased object name within each kind; the MySQL release path is
+// single-database (see SessionContextMap), so the name alone is the identity. An object
+// present in the catalog but absent from the map is left with no context (HasSessionContext
+// stays false → bare recreate); a map entry with no matching object is ignored.
+//
+// Marking HasSessionContext lets the generator distinguish "context applied, sql_mode empty"
+// (emit SET sql_mode=”) from "no context" (bare CREATE), so an authored empty sql_mode
+// round-trips.
+func (c *Catalog) ApplySessionContext(m SessionContextMap) {
+	if c == nil {
+		return
+	}
+	for _, db := range c.Databases() {
+		applyRoutineContext(db.Functions, m.Functions)
+		applyRoutineContext(db.Procedures, m.Procedures)
+		for key, tr := range db.Triggers {
+			if tr == nil {
+				continue
+			}
+			if ctx, ok := lookupContext(m.Triggers, key, tr.Name); ok {
+				tr.SQLMode = ctx.SQLMode
+				tr.CharacterSetClient = ctx.CharacterSetClient
+				tr.CollationConnection = ctx.CollationConnection
+				tr.HasSessionContext = true
+			}
+		}
+		for key, e := range db.Events {
+			if e == nil {
+				continue
+			}
+			if ctx, ok := lookupContext(m.Events, key, e.Name); ok {
+				e.SQLMode = ctx.SQLMode
+				e.CharacterSetClient = ctx.CharacterSetClient
+				e.CollationConnection = ctx.CollationConnection
+				e.TimeZone = ctx.TimeZone
+				e.HasSessionContext = true
+			}
+		}
+	}
+}
+
+// applyRoutineContext stamps context onto a function or procedure map (both are
+// map[string]*Routine keyed by lower-cased name).
+func applyRoutineContext(routines map[string]*Routine, ctxByName map[string]SessionContext) {
+	for key, r := range routines {
+		if r == nil {
+			continue
+		}
+		if ctx, ok := lookupContext(ctxByName, key, r.Name); ok {
+			r.SQLMode = ctx.SQLMode
+			r.CharacterSetClient = ctx.CharacterSetClient
+			r.CollationConnection = ctx.CollationConnection
+			r.HasSessionContext = true
+		}
+	}
+}
+
+// lookupContext finds an object's context by the catalog map key (already lower-cased) and
+// falls back to the lower-cased object name, so callers may key the input map either way.
+func lookupContext(m map[string]SessionContext, key, name string) (SessionContext, bool) {
+	if m == nil {
+		return SessionContext{}, false
+	}
+	if ctx, ok := m[key]; ok {
+		return ctx, true
+	}
+	if ctx, ok := m[toLower(name)]; ok {
+		return ctx, true
+	}
+	return SessionContext{}, false
+}
+
+// renderWithSessionContext wraps a single CREATE or ALTER statement in a concat-safe
+// save/restore of the object's original session context, mirroring mysqldump's framing:
+//
+//	SET @saved_sql_mode = @@sql_mode; SET sql_mode = '<mode>';
+//	SET @saved_cs_client = @@character_set_client; SET character_set_client = <cs>;
+//	SET @saved_coll_conn = @@collation_connection; SET collation_connection = <coll>;
+//	SET @saved_time_zone = @@time_zone; SET time_zone = '<tz>';   -- events only
+//	<CREATE|ALTER …>;
+//	SET time_zone = @saved_time_zone;
+//	SET collation_connection = @saved_coll_conn;
+//	SET character_set_client = @saved_cs_client;
+//	SET sql_mode = @saved_sql_mode;
+//
+// The restores run in reverse order and re-capture each live @@-value immediately before
+// overwriting it, so applying a multi-object migration never leaks one object's context into
+// the next statement even though the @saved_* names are fixed (each block fully saves →
+// sets → runs → restores before the next block runs; blocks never nest). Each clause is
+// joined with the same ";\n" separator MigrationPlan.SQL() uses to join ops, so the whole
+// framed block is a well-formed statement sequence inside one MigrationOp.SQL.
+//
+// sql_mode is emitted UNCONDITIONALLY when framing (even when empty) so an authored empty
+// sql_mode (”) forces empty modes rather than inheriting the server default — the framing
+// is only ever invoked with a known-present context. character_set_client,
+// collation_connection, and time_zone are emitted only when non-empty: their values are
+// bare identifiers / literals and an empty value would produce invalid SQL, and a synced
+// object without one of them simply keeps the session default for that axis.
+//
+// includeTimeZone gates the time_zone axis (events set it true; routines and triggers false
+// — time_zone has no effect on a routine or trigger body's stored form).
+func renderWithSessionContext(stmtSQL string, ctx SessionContext, includeTimeZone bool) string {
+	var pre, post []string
+
+	// sql_mode: always framed.
+	pre = append(pre, "SET @saved_sql_mode = @@sql_mode")
+	pre = append(pre, "SET sql_mode = "+quoteStringLiteral(ctx.SQLMode))
+	post = append(post, "SET sql_mode = @saved_sql_mode")
+
+	if cs := strings.TrimSpace(ctx.CharacterSetClient); cs != "" {
+		pre = append(pre, "SET @saved_cs_client = @@character_set_client")
+		pre = append(pre, "SET character_set_client = "+cs)
+		post = append(post, "SET character_set_client = @saved_cs_client")
+	}
+	if coll := strings.TrimSpace(ctx.CollationConnection); coll != "" {
+		pre = append(pre, "SET @saved_coll_conn = @@collation_connection")
+		pre = append(pre, "SET collation_connection = "+coll)
+		post = append(post, "SET collation_connection = @saved_coll_conn")
+	}
+	if includeTimeZone {
+		if tz := strings.TrimSpace(ctx.TimeZone); tz != "" {
+			pre = append(pre, "SET @saved_time_zone = @@time_zone")
+			pre = append(pre, "SET time_zone = "+quoteStringLiteral(tz))
+			post = append(post, "SET time_zone = @saved_time_zone")
+		}
+	}
+
+	// Restores run in reverse of the saves so nested contexts unwind cleanly.
+	reverse(post)
+
+	parts := make([]string, 0, len(pre)+1+len(post))
+	parts = append(parts, pre...)
+	parts = append(parts, stmtSQL)
+	parts = append(parts, post...)
+	return strings.Join(parts, ";\n")
+}
+
+// reverse reverses a string slice in place.
+func reverse(s []string) {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		s[i], s[j] = s[j], s[i]
+	}
+}

--- a/mysql/catalog/session_context_oracle_test.go
+++ b/mysql/catalog/session_context_oracle_test.go
@@ -1,0 +1,245 @@
+package catalog
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// End-to-end apply-correctness proof for BYT-9832 against the LIVE 8.0 engine (:13306): a
+// routine / event whose BODY changes must be re-emitted under its ORIGINAL session context.
+// Each case creates the object under a distinctive sql_mode (and, for events, time_zone),
+// syncs that context into the source catalog via ApplySessionContext exactly as bytebase
+// will, generates the plan, APPLIES it to the real server, and reads back
+// information_schema to prove the original context survived the recreate/ALTER. Without the
+// framing these assertions fail (the object comes back under the deploy session's mode) —
+// which is the whole point of the change.
+//
+// 5.7 is exercised too when reachable; connectOracle skips a version that is down.
+
+const scOracleDB = "byt9832_sc_apply"
+
+// applyUnderSession runs the setup DDL on a dedicated connection whose session is first set
+// to the given sql_mode / time_zone, so the created object captures that context — mirroring
+// how a real routine/event acquires its stored sql_mode.
+func execUnderSession(t *testing.T, conn *sql.Conn, ctx context.Context, sqlMode, timeZone string, stmts ...string) bool {
+	t.Helper()
+	pre := []string{"SET SESSION sql_mode = " + quoteStringLiteral(sqlMode)}
+	if timeZone != "" {
+		pre = append(pre, "SET SESSION time_zone = "+quoteStringLiteral(timeZone))
+	}
+	for _, s := range append(pre, stmts...) {
+		if _, err := conn.ExecContext(ctx, s); err != nil {
+			t.Logf("setup exec failed (may be version-specific): %q: %v", s, err)
+			return false
+		}
+	}
+	return true
+}
+
+// TestOracle_RoutineRecreatePreservesSQLMode proves the routine DROP+CREATE recreate framing
+// preserves sql_mode on the live engine.
+func TestOracle_RoutineRecreatePreservesSQLMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	const origMode = "PIPES_AS_CONCAT,NO_BACKSLASH_ESCAPES"
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		t.Run(o.name, func(t *testing.T) {
+			ctx := context.Background()
+			conn, err := o.db.Conn(ctx)
+			if err != nil {
+				t.Fatalf("grab conn: %v", err)
+			}
+			defer func() { _ = conn.Close() }()
+
+			db := scOracleDB + "_rtn"
+			// Deploy session runs under a DIFFERENT (default-ish) mode so a bare recreate would
+			// lose PIPES_AS_CONCAT.
+			deployMode := "STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"
+
+			setup := []string{
+				"DROP DATABASE IF EXISTS " + db,
+				fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", db, serverCharsetFor(version)),
+				"USE " + db,
+			}
+			for _, s := range setup {
+				if _, err := conn.ExecContext(ctx, s); err != nil {
+					t.Skipf("[%s] setup: %q: %v", o.name, s, err)
+				}
+			}
+			// Create the function under the ORIGINAL mode.
+			if !execUnderSession(t, conn, ctx, origMode, "",
+				"CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a + 1") {
+				t.Skipf("[%s] could not create seed routine", o.name)
+			}
+
+			// Build source (from) catalog = current state, and stamp the synced context onto it.
+			from := mustLoadUnderDB(t, db, "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a + 1", version)
+			from.ApplySessionContext(SessionContextMap{Functions: map[string]SessionContext{
+				"f": {SQLMode: origMode, CharacterSetClient: serverCharsetFor(version), CollationConnection: defaultCollationForServerCharset(version)},
+			}})
+			// Target (to) catalog = desired body change.
+			to := mustLoadUnderDB(t, db, "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a + 2", version)
+
+			plan := GenerateMigrationWithNormalizer(from, to, DiffWithNormalizer(from, to, n), n)
+			if plan == nil || len(plan.Ops) == 0 {
+				t.Fatalf("[%s] expected a non-empty recreate plan", o.name)
+			}
+
+			// Apply under the DEPLOY session mode; the framing must override it per-statement.
+			if _, err := conn.ExecContext(ctx, "SET SESSION sql_mode = "+quoteStringLiteral(deployMode)); err != nil {
+				t.Fatalf("[%s] set deploy mode: %v", o.name, err)
+			}
+			for _, op := range plan.Ops {
+				if _, err := conn.ExecContext(ctx, op.SQL); err != nil {
+					t.Fatalf("[%s] APPLY FAILED:\n  stmt: %s\n  err: %v\n  plan:\n%s", o.name, op.SQL, err, plan.SQL())
+				}
+			}
+
+			got := routineSQLMode(t, conn, ctx, db, "f")
+			if got != origMode {
+				t.Fatalf("[%s] routine sql_mode not preserved across recreate: got %q want %q\nplan:\n%s", o.name, got, origMode, plan.SQL())
+			}
+		})
+	}
+}
+
+// TestOracle_EventAlterPreservesSQLMode proves the ALTER EVENT framing preserves sql_mode on
+// the live engine — the case that a bare ALTER would silently re-stamp.
+func TestOracle_EventAlterPreservesSQLMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("oracle test skipped in short mode")
+	}
+	const origMode = "PIPES_AS_CONCAT"
+	const origTZ = "+08:00"
+	for _, version := range both() {
+		o := connectOracle(t, version)
+		n := NormalizerFor(version)
+		t.Run(o.name, func(t *testing.T) {
+			ctx := context.Background()
+			conn, err := o.db.Conn(ctx)
+			if err != nil {
+				t.Fatalf("grab conn: %v", err)
+			}
+			defer func() { _ = conn.Close() }()
+
+			db := scOracleDB + "_evt"
+			deployMode := "STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"
+
+			setup := []string{
+				"DROP DATABASE IF EXISTS " + db,
+				fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s", db, serverCharsetFor(version)),
+				"USE " + db,
+				"SET GLOBAL event_scheduler = OFF",
+			}
+			for _, s := range setup {
+				if _, err := conn.ExecContext(ctx, s); err != nil {
+					// event_scheduler toggle may lack privilege; ignore that one.
+					if !strings.Contains(strings.ToLower(s), "event_scheduler") {
+						t.Skipf("[%s] setup: %q: %v", o.name, s, err)
+					}
+				}
+			}
+			if !execUnderSession(t, conn, ctx, origMode, origTZ,
+				"CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DISABLE DO SET @x = 1") {
+				t.Skipf("[%s] could not create seed event", o.name)
+			}
+
+			from := mustLoadUnderDB(t, db, "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DISABLE DO SET @x = 1", version)
+			from.ApplySessionContext(SessionContextMap{Events: map[string]SessionContext{
+				"e": {SQLMode: origMode, CharacterSetClient: serverCharsetFor(version), CollationConnection: defaultCollationForServerCharset(version), TimeZone: origTZ},
+			}})
+			to := mustLoadUnderDB(t, db, "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DISABLE DO SET @x = 2", version)
+
+			d := DiffWithNormalizer(from, to, n)
+			if len(d.Events) != 1 || d.Events[0].Action != DiffModify {
+				t.Fatalf("[%s] want one event MODIFY, got %+v", o.name, d.Events)
+			}
+			// This is the ALTER path (body-only change), the case a bare ALTER would re-stamp.
+			if eventModifyNeedsRecreate(d.Events[0].From, d.Events[0].To) {
+				t.Fatalf("[%s] expected the ALTER path for a body-only change", o.name)
+			}
+			plan := GenerateMigrationWithNormalizer(from, to, d, n)
+
+			if _, err := conn.ExecContext(ctx, "SET SESSION sql_mode = "+quoteStringLiteral(deployMode)); err != nil {
+				t.Fatalf("[%s] set deploy mode: %v", o.name, err)
+			}
+			for _, op := range plan.Ops {
+				if _, err := conn.ExecContext(ctx, op.SQL); err != nil {
+					t.Fatalf("[%s] APPLY FAILED:\n  stmt: %s\n  err: %v\n  plan:\n%s", o.name, op.SQL, err, plan.SQL())
+				}
+			}
+
+			gotMode, gotTZ := eventSQLModeTZ(t, conn, ctx, db, "e")
+			if gotMode != origMode {
+				t.Fatalf("[%s] event sql_mode not preserved across ALTER: got %q want %q\nplan:\n%s", o.name, gotMode, origMode, plan.SQL())
+			}
+			// time_zone is captured at CREATE and not re-stamped by ALTER, so it should still be origTZ.
+			if gotTZ != origTZ {
+				t.Fatalf("[%s] event time_zone changed unexpectedly: got %q want %q", o.name, gotTZ, origTZ)
+			}
+		})
+	}
+}
+
+// mustLoadUnderDB loads a single bare CREATE under db name `db` via LoadSQL, matching the
+// identity keying the oracle uses; it fails the test on a load error.
+func mustLoadUnderDB(t *testing.T, db, ddl string, version Version) *Catalog {
+	t.Helper()
+	c, err := LoadSQLWithVersionHelper(fmt.Sprintf("CREATE DATABASE %s DEFAULT CHARSET=%s;\nUSE %s;\n%s", db, serverCharsetFor(version), db, ddl), version)
+	if err != nil {
+		t.Fatalf("load under db %s: %v", db, err)
+	}
+	return c
+}
+
+// LoadSQLWithVersionHelper loads imperative SQL and fixes the catalog version (LoadSQL has no
+// version-taking variant; the version only affects canonicalization, not loading).
+func LoadSQLWithVersionHelper(sqlText string, version Version) (*Catalog, error) {
+	c, err := LoadSQL(sqlText)
+	if err != nil {
+		return nil, err
+	}
+	c.SetVersion(version)
+	return c, nil
+}
+
+// routineSQLMode reads information_schema.ROUTINES.SQL_MODE for a routine.
+func routineSQLMode(t *testing.T, conn *sql.Conn, ctx context.Context, db, name string) string {
+	t.Helper()
+	var mode sql.NullString
+	row := conn.QueryRowContext(ctx,
+		"SELECT SQL_MODE FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA=? AND ROUTINE_NAME=?", db, name)
+	if err := row.Scan(&mode); err != nil {
+		t.Fatalf("read routine sql_mode: %v", err)
+	}
+	return mode.String
+}
+
+// eventSQLModeTZ reads information_schema.EVENTS.SQL_MODE and TIME_ZONE for an event.
+func eventSQLModeTZ(t *testing.T, conn *sql.Conn, ctx context.Context, db, name string) (string, string) {
+	t.Helper()
+	var mode, tz sql.NullString
+	row := conn.QueryRowContext(ctx,
+		"SELECT SQL_MODE, TIME_ZONE FROM information_schema.EVENTS WHERE EVENT_SCHEMA=? AND EVENT_NAME=?", db, name)
+	if err := row.Scan(&mode, &tz); err != nil {
+		t.Fatalf("read event sql_mode/time_zone: %v", err)
+	}
+	return mode.String, tz.String
+}
+
+// defaultCollationForServerCharset returns a plausible default collation for the server
+// charset of a version, used only to populate a realistic synced context in these tests.
+func defaultCollationForServerCharset(v Version) string {
+	if v == MySQL57 {
+		return "utf8mb4_general_ci"
+	}
+	return "utf8mb4_0900_ai_ci"
+}

--- a/mysql/catalog/session_context_test.go
+++ b/mysql/catalog/session_context_test.go
@@ -1,0 +1,355 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+)
+
+// Unit coverage for BYT-9832: on a MySQL declarative RECREATE (DROP+CREATE) of a
+// routine/trigger/event, the emitted CREATE must be wrapped in a save/restore of the OLD
+// object's session context (sql_mode / charset / collation / — for events — time_zone),
+// sourced out-of-band via ApplySessionContext. A brand-new object emits a bare CREATE, and
+// the session context is NOT part of the diff identity (a mode-only difference never
+// triggers a change).
+//
+// These tests build catalogs the same way the other unit tests do (LoadSQL under a fixed
+// database), stamp the source objects with ApplySessionContext, then assert the generated
+// plan's framing exactly.
+
+const scDB = "d"
+
+func loadSCCatalog(t *testing.T, ddl string) *Catalog {
+	t.Helper()
+	c, err := LoadSQL("CREATE DATABASE " + scDB + " DEFAULT CHARSET=utf8mb4;\nUSE " + scDB + ";\n" + ddl)
+	if err != nil {
+		t.Fatalf("load %q: %v", ddl, err)
+	}
+	return c
+}
+
+// planSQL diffs from→to and returns the full migration SQL.
+func planSQL(t *testing.T, from, to *Catalog, n *Normalizer) string {
+	t.Helper()
+	d := DiffWithNormalizer(from, to, n)
+	return GenerateMigrationWithNormalizer(from, to, d, n).SQL()
+}
+
+// TestRecreate_RoutineCarriesSQLMode covers requirement (1): a routine authored under a
+// non-default sql_mode whose body is edited is DROPped and re-CREATEd wrapped in an exact
+// SET sql_mode='<mode>' … restore.
+func TestRecreate_RoutineCarriesSQLMode(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	from := loadSCCatalog(t, "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a + 1")
+	to := loadSCCatalog(t, "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a + 2")
+
+	from.ApplySessionContext(SessionContextMap{
+		Functions: map[string]SessionContext{
+			"f": {
+				SQLMode:             "PIPES_AS_CONCAT,NO_BACKSLASH_ESCAPES",
+				CharacterSetClient:  "utf8mb4",
+				CollationConnection: "utf8mb4_0900_ai_ci",
+			},
+		},
+	})
+
+	sql := planSQL(t, from, to, n)
+
+	// It must be a DROP then a framed CREATE.
+	if !strings.Contains(sql, "DROP FUNCTION") {
+		t.Fatalf("expected DROP FUNCTION in plan:\n%s", sql)
+	}
+	// Exact save/restore framing around the CREATE.
+	mustContainInOrder(t, sql,
+		"SET @saved_sql_mode = @@sql_mode",
+		"SET sql_mode = 'PIPES_AS_CONCAT,NO_BACKSLASH_ESCAPES'",
+		"SET @saved_cs_client = @@character_set_client",
+		"SET character_set_client = utf8mb4",
+		"SET @saved_coll_conn = @@collation_connection",
+		"SET collation_connection = utf8mb4_0900_ai_ci",
+		"CREATE FUNCTION `d`.`f`",
+		"RETURN a + 2",
+		"SET collation_connection = @saved_coll_conn",
+		"SET character_set_client = @saved_cs_client",
+		"SET sql_mode = @saved_sql_mode",
+	)
+}
+
+// TestNewRoutine_BareCreate covers requirement (2): a brand-new routine (no From) emits a
+// bare CREATE with no session framing.
+func TestNewRoutine_BareCreate(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	from := loadSCCatalog(t, "CREATE FUNCTION other() RETURNS INT DETERMINISTIC RETURN 1")
+	to := loadSCCatalog(t, "CREATE FUNCTION other() RETURNS INT DETERMINISTIC RETURN 1;\nCREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a")
+
+	// Even if a stray context map is supplied, an ADD has no From, so no framing is emitted.
+	from.ApplySessionContext(SessionContextMap{
+		Functions: map[string]SessionContext{
+			"f": {SQLMode: "PIPES_AS_CONCAT", CharacterSetClient: "utf8mb4"},
+		},
+	})
+
+	sql := planSQL(t, from, to, n)
+	if !strings.Contains(sql, "CREATE FUNCTION `d`.`f`") {
+		t.Fatalf("expected CREATE FUNCTION f:\n%s", sql)
+	}
+	if strings.Contains(sql, "sql_mode") || strings.Contains(sql, "@saved_") {
+		t.Fatalf("brand-new routine must emit a BARE CREATE (no session framing):\n%s", sql)
+	}
+	if strings.Contains(sql, "DROP FUNCTION `f`") {
+		t.Fatalf("brand-new routine must not DROP:\n%s", sql)
+	}
+}
+
+// TestUnchangedRoutine_NoDiff covers requirement (3): an unchanged routine (same body, only
+// the carried session context differs) produces NO diff entry — the identity is
+// context-agnostic, so there is no phantom churn.
+func TestUnchangedRoutine_NoDiff(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	body := "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a"
+	from := loadSCCatalog(t, body)
+	to := loadSCCatalog(t, body)
+
+	// Only the source carries context; a mode difference alone must not trigger a change.
+	from.ApplySessionContext(SessionContextMap{
+		Functions: map[string]SessionContext{
+			"f": {SQLMode: "PIPES_AS_CONCAT,NO_BACKSLASH_ESCAPES", CharacterSetClient: "latin1", CollationConnection: "latin1_swedish_ci"},
+		},
+	})
+
+	d := DiffWithNormalizer(from, to, n)
+	if !d.IsEmpty() {
+		t.Fatalf("carried session context must not create a diff, got: %s", describeRoutineDiff(d))
+	}
+}
+
+// TestRecreate_RoutineCharsetCollationOnly covers requirement (4): charset/collation are
+// carried through a routine recreate even when sql_mode is empty. sql_mode is still framed
+// (empty modes are authored, not the server default).
+func TestRecreate_RoutineCharsetCollationOnly(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	from := loadSCCatalog(t, "CREATE PROCEDURE p(IN a INT) BEGIN SET @v = a; END")
+	to := loadSCCatalog(t, "CREATE PROCEDURE p(IN a INT) BEGIN SET @v = a + 1; END")
+
+	from.ApplySessionContext(SessionContextMap{
+		Procedures: map[string]SessionContext{
+			"p": {
+				SQLMode:             "", // authored empty modes must round-trip as SET sql_mode=''
+				CharacterSetClient:  "latin1",
+				CollationConnection: "latin1_swedish_ci",
+			},
+		},
+	})
+
+	sql := planSQL(t, from, to, n)
+	mustContainInOrder(t, sql,
+		"SET sql_mode = ''",
+		"SET character_set_client = latin1",
+		"SET collation_connection = latin1_swedish_ci",
+		"CREATE PROCEDURE `d`.`p`",
+		"SET collation_connection = @saved_coll_conn",
+		"SET character_set_client = @saved_cs_client",
+		"SET sql_mode = @saved_sql_mode",
+	)
+}
+
+// TestRecreate_EventCarriesTimeZoneAndSQLMode covers requirement (5): an event recreated via
+// DROP+CREATE (an ENDS-removal change, which forces the recreate path) carries BOTH its
+// non-UTC time_zone and its sql_mode.
+func TestRecreate_EventCarriesTimeZoneAndSQLMode(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	// From has an ENDS bound; To drops it → eventModifyNeedsRecreate → DROP+CREATE.
+	from := loadSCCatalog(t, "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR ENDS '2030-01-01 00:00:00' DO SET @x = 1")
+	to := loadSCCatalog(t, "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x = 1")
+
+	from.ApplySessionContext(SessionContextMap{
+		Events: map[string]SessionContext{
+			"e": {
+				SQLMode:             "STRICT_ALL_TABLES",
+				CharacterSetClient:  "utf8mb4",
+				CollationConnection: "utf8mb4_0900_ai_ci",
+				TimeZone:            "+08:00",
+			},
+		},
+	})
+
+	// Confirm this actually takes the recreate path.
+	d := DiffWithNormalizer(from, to, n)
+	if len(d.Events) != 1 || d.Events[0].Action != DiffModify {
+		t.Fatalf("want one event MODIFY, got %+v", d.Events)
+	}
+	if !eventModifyNeedsRecreate(d.Events[0].From, d.Events[0].To) {
+		t.Fatalf("ENDS removal should force DROP+CREATE recreate path")
+	}
+
+	sql := GenerateMigrationWithNormalizer(from, to, d, n).SQL()
+	if !strings.Contains(sql, "DROP EVENT IF EXISTS") {
+		t.Fatalf("expected DROP EVENT in recreate plan:\n%s", sql)
+	}
+	mustContainInOrder(t, sql,
+		"SET @saved_sql_mode = @@sql_mode",
+		"SET sql_mode = 'STRICT_ALL_TABLES'",
+		"SET @saved_time_zone = @@time_zone",
+		"SET time_zone = '+08:00'",
+		"CREATE EVENT `e`",
+		"SET time_zone = @saved_time_zone",
+		"SET sql_mode = @saved_sql_mode",
+	)
+}
+
+// TestAlterEvent_CarriesSQLMode covers the common event-modify path: a body change goes
+// through ALTER EVENT (NOT DROP+CREATE), and ALTER EVENT … DO re-stamps sql_mode/charset/
+// collation from the executing session (verified on live 8.0.32), so the ALTER must be
+// framed with the OLD event's context too.
+func TestAlterEvent_CarriesSQLMode(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	// Body-only change → ALTER path (no ENDS to remove).
+	from := loadSCCatalog(t, "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x = 1")
+	to := loadSCCatalog(t, "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x = 2")
+
+	from.ApplySessionContext(SessionContextMap{
+		Events: map[string]SessionContext{
+			"e": {
+				SQLMode:             "PIPES_AS_CONCAT",
+				CharacterSetClient:  "latin1",
+				CollationConnection: "latin1_swedish_ci",
+				TimeZone:            "+08:00",
+			},
+		},
+	})
+
+	d := DiffWithNormalizer(from, to, n)
+	if len(d.Events) != 1 || d.Events[0].Action != DiffModify {
+		t.Fatalf("want one event MODIFY, got %+v", d.Events)
+	}
+	// Confirm this takes the ALTER path (not DROP+CREATE).
+	if eventModifyNeedsRecreate(d.Events[0].From, d.Events[0].To) {
+		t.Fatalf("a body-only change should take the ALTER path, not DROP+CREATE")
+	}
+
+	sql := GenerateMigrationWithNormalizer(from, to, d, n).SQL()
+	if strings.Contains(sql, "DROP EVENT") {
+		t.Fatalf("body-only event change must not DROP:\n%s", sql)
+	}
+	mustContainInOrder(t, sql,
+		"SET @saved_sql_mode = @@sql_mode",
+		"SET sql_mode = 'PIPES_AS_CONCAT'",
+		"SET character_set_client = latin1",
+		"SET collation_connection = latin1_swedish_ci",
+		"ALTER EVENT `e`",
+		"SET collation_connection = @saved_coll_conn",
+		"SET character_set_client = @saved_cs_client",
+		"SET sql_mode = @saved_sql_mode",
+	)
+}
+
+// TestAlterEvent_NoContextIsBare confirms a body-only event change with NO applied context
+// stays a bare ALTER EVENT (framing is opt-in via ApplySessionContext).
+func TestAlterEvent_NoContextIsBare(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	from := loadSCCatalog(t, "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x = 1")
+	to := loadSCCatalog(t, "CREATE EVENT e ON SCHEDULE EVERY 1 HOUR DO SET @x = 2")
+	// No ApplySessionContext.
+
+	sql := planSQL(t, from, to, n)
+	if !strings.Contains(sql, "ALTER EVENT `e`") {
+		t.Fatalf("expected ALTER EVENT:\n%s", sql)
+	}
+	if strings.Contains(sql, "@saved_") || strings.Contains(sql, "sql_mode") {
+		t.Fatalf("without applied context the ALTER must be bare (no framing):\n%s", sql)
+	}
+}
+
+// TestAlterRoutine_NoFraming confirms a characteristic-only routine modify (ALTER FUNCTION/
+// PROCEDURE) is emitted BARE even with context applied: ALTER FUNCTION does NOT re-stamp
+// sql_mode (verified on live 8.0.32), so framing it is unnecessary and would be noise.
+func TestAlterRoutine_NoFraming(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	from := loadSCCatalog(t, "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC COMMENT 'old' RETURN a")
+	to := loadSCCatalog(t, "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC COMMENT 'new' RETURN a")
+
+	from.ApplySessionContext(SessionContextMap{
+		Functions: map[string]SessionContext{
+			"f": {SQLMode: "PIPES_AS_CONCAT", CharacterSetClient: "utf8mb4", CollationConnection: "utf8mb4_0900_ai_ci"},
+		},
+	})
+
+	d := DiffWithNormalizer(from, to, n)
+	if len(d.Functions) != 1 || d.Functions[0].Action != DiffModify {
+		t.Fatalf("want one function MODIFY, got %s", describeRoutineDiff(d))
+	}
+	if !routineAlterSuffices(d.Functions[0].From, d.Functions[0].To, n) {
+		t.Fatalf("comment-only change should be ALTER-able")
+	}
+	sql := GenerateMigrationWithNormalizer(from, to, d, n).SQL()
+	if !strings.HasPrefix(sql, "ALTER FUNCTION") {
+		t.Fatalf("want a single ALTER FUNCTION, got:\n%s", sql)
+	}
+	if strings.Contains(sql, "@saved_") || strings.Contains(sql, "sql_mode") {
+		t.Fatalf("characteristic-only ALTER FUNCTION must be bare (ALTER does not re-stamp sql_mode):\n%s", sql)
+	}
+}
+
+// TestRecreate_TriggerCarriesSQLMode exercises the trigger recreate path (a body change is a
+// DROP+CREATE — MySQL has no ALTER TRIGGER). Triggers already model charset/collation; this
+// adds sql_mode and asserts the full framing.
+func TestRecreate_TriggerCarriesSQLMode(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	from := loadSCCatalog(t, "CREATE TABLE t (id INT);\nCREATE TRIGGER trg BEFORE INSERT ON t FOR EACH ROW SET @x = 1")
+	to := loadSCCatalog(t, "CREATE TABLE t (id INT);\nCREATE TRIGGER trg BEFORE INSERT ON t FOR EACH ROW SET @x = 2")
+
+	from.ApplySessionContext(SessionContextMap{
+		Triggers: map[string]SessionContext{
+			"trg": {
+				SQLMode:             "NO_ENGINE_SUBSTITUTION",
+				CharacterSetClient:  "utf8mb4",
+				CollationConnection: "utf8mb4_0900_ai_ci",
+			},
+		},
+	})
+
+	sql := planSQL(t, from, to, n)
+	if !strings.Contains(sql, "DROP TRIGGER") {
+		t.Fatalf("expected DROP TRIGGER in recreate plan:\n%s", sql)
+	}
+	mustContainInOrder(t, sql,
+		"SET @saved_sql_mode = @@sql_mode",
+		"SET sql_mode = 'NO_ENGINE_SUBSTITUTION'",
+		"CREATE TRIGGER `d`.`trg`",
+		"SET @x = 2",
+		"SET sql_mode = @saved_sql_mode",
+	)
+	// A trigger has no time_zone axis.
+	if strings.Contains(sql, "time_zone") {
+		t.Fatalf("trigger framing must not touch time_zone:\n%s", sql)
+	}
+}
+
+// TestRecreate_NoContextIsBareRecreate confirms that a MODIFY whose From carries NO applied
+// session context stays a bare DROP+CREATE — the framing is opt-in via ApplySessionContext.
+func TestRecreate_NoContextIsBareRecreate(t *testing.T) {
+	n := NormalizerFor(MySQL80)
+	from := loadSCCatalog(t, "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a + 1")
+	to := loadSCCatalog(t, "CREATE FUNCTION f(a INT) RETURNS INT DETERMINISTIC RETURN a + 2")
+	// No ApplySessionContext.
+
+	sql := planSQL(t, from, to, n)
+	if !strings.Contains(sql, "DROP FUNCTION") || !strings.Contains(sql, "CREATE FUNCTION `d`.`f`") {
+		t.Fatalf("expected bare DROP+CREATE:\n%s", sql)
+	}
+	if strings.Contains(sql, "@saved_") || strings.Contains(sql, "sql_mode") {
+		t.Fatalf("without applied context the recreate must be bare (no framing):\n%s", sql)
+	}
+}
+
+// mustContainInOrder asserts each substring appears in s, and in the given relative order.
+func mustContainInOrder(t *testing.T, s string, subs ...string) {
+	t.Helper()
+	idx := 0
+	for _, sub := range subs {
+		pos := strings.Index(s[idx:], sub)
+		if pos < 0 {
+			t.Fatalf("missing or out-of-order substring %q\nfull SQL:\n%s", sub, s)
+		}
+		idx += pos + len(sub)
+	}
+}

--- a/mysql/catalog/table.go
+++ b/mysql/catalog/table.go
@@ -172,6 +172,26 @@ type Routine struct {
 	Returns         string // return type string for functions (empty for procedures)
 	Body            string
 	Characteristics map[string]string // name -> value (DETERMINISTIC, COMMENT, etc.)
+
+	// Session context captured when the routine was created: sql_mode,
+	// character_set_client, collation_connection. These are NOT part of the routine's
+	// declarative identity — canonicalRoutine excludes them, so a mode-only difference
+	// never triggers a diff — and the SDL text never carries them. They are populated
+	// out-of-band via Catalog.ApplySessionContext from the synced metadata. On a
+	// DROP+CREATE recreate the generator wraps the emitted CREATE in a save/restore of
+	// these values (sourced from the OLD object) so the routine is re-created under its
+	// original session, matching mysqldump's framing. The database default collation is
+	// deliberately not carried — it is a schema property, not session-settable per-object
+	// (see session_context.go).
+	SQLMode             string
+	CharacterSetClient  string
+	CollationConnection string
+	// HasSessionContext records whether the fields above were populated from the synced
+	// metadata (via ApplySessionContext). It gates the recreate framing: an authored empty
+	// sql_mode ('') round-trips only when the context is known to be present, so the
+	// generator distinguishes "context applied, modes empty" (emit SET sql_mode='') from
+	// "no context" (bare CREATE).
+	HasSessionContext bool
 }
 
 // RoutineParam represents a parameter of a stored routine.
@@ -183,17 +203,31 @@ type RoutineParam struct {
 
 // Trigger represents a trigger in the catalog.
 type Trigger struct {
-	Name                string
-	Database            *Database
-	Table               string // table name the trigger is on
-	Timing              string // BEFORE, AFTER
-	Event               string // INSERT, UPDATE, DELETE
-	Definer             string
-	Body                string
+	Name     string
+	Database *Database
+	Table    string // table name the trigger is on
+	Timing   string // BEFORE, AFTER
+	Event    string // INSERT, UPDATE, DELETE
+	Definer  string
+	Body     string
+	// Session context. DatabaseCollation is snapshotted by createTrigger from the loading
+	// session's database (pre-existing; the database default collation is a schema property,
+	// not part of the recreate framing). SQLMode / CharacterSetClient / CollationConnection
+	// are populated out-of-band via Catalog.ApplySessionContext from the synced metadata (the
+	// SDL text carries no session context). None are part of the trigger's declarative
+	// identity — triggersChanged excludes them — but on a DROP+CREATE recreate the generator
+	// wraps the emitted CREATE in a save/restore of sql_mode/charset/collation sourced from
+	// the OLD trigger. See session_context.go.
+	SQLMode             string
 	CharacterSetClient  string
 	CollationConnection string
 	DatabaseCollation   string
-	Order               *TriggerOrderInfo
+	// HasSessionContext records whether the synced session context was populated (via
+	// ApplySessionContext); it gates the recreate framing. Note createTrigger always snapshots
+	// CharacterSetClient/CollationConnection at load, so the gate is on HasSessionContext, not
+	// on those fields being non-empty, to keep a trigger loaded without synced context bare.
+	HasSessionContext bool
+	Order             *TriggerOrderInfo
 }
 
 // TriggerOrderInfo represents FOLLOWS/PRECEDES ordering.
@@ -212,6 +246,25 @@ type Event struct {
 	Enable       string // ENABLE, DISABLE, DISABLE ON SLAVE, or "" (default ENABLE)
 	Comment      string
 	Body         string
+
+	// Session context captured when the event was created: sql_mode, character_set_client,
+	// collation_connection, and the session time_zone (events only). These are NOT part of
+	// the event's declarative identity — eventCanonicalKey excludes them — and the SDL text
+	// never carries them; they are populated out-of-band via Catalog.ApplySessionContext
+	// from the synced metadata. Both event emission paths preserve them: a DROP+CREATE
+	// recreate AND an ALTER EVENT … DO (which empirically re-stamps sql_mode/charset/
+	// collation) are wrapped in a save/restore sourced from the OLD event. time_zone is
+	// framed too (harmless on the ALTER path, which does not re-stamp it). The database
+	// default collation is deliberately not carried — it is a schema property, not
+	// session-settable per-object (see session_context.go).
+	SQLMode             string
+	CharacterSetClient  string
+	CollationConnection string
+	TimeZone            string
+	// HasSessionContext records whether the session context (including time_zone) was
+	// populated from the synced metadata (via ApplySessionContext); it gates the recreate/
+	// ALTER framing so an authored empty sql_mode ('') round-trips.
+	HasSessionContext bool
 }
 
 // cloneTable returns a deep copy of the table's mutable state.


### PR DESCRIPTION
## What

STAGE 1 (omni-only) of BYT-9832 — preserve a routine / trigger / event's session context across a declarative recreate. The bytebase wiring is a separate later stage.

MySQL has no `CREATE OR REPLACE` for routines, triggers, or events, so a declarative rollout that changes a body / param / schedule recreates the object as `DROP` + `CREATE`. Until now the emitted DDL was **bare**, silently dropping the object's original session context — `sql_mode`, `character_set_client`, `collation_connection`, and (for events) the session `time_zone`. A routine authored under `PIPES_AS_CONCAT` would come back treating `||` as boolean OR.

## How

**Model the context** on `Routine` and `Event` (new fields) and `Trigger` (adds `SQLMode`; it already carried charset / collation). Populate it **out-of-band** via the new `Catalog.ApplySessionContext(SessionContextMap)` — the SDL text stays 100% bare (the source dump is a clean export with no `SET sql_mode` framing). bytebase will pass the synced metadata's per-object context (`RoutineMetadata.SqlMode`, `TriggerMetadata.SqlMode`, `EventMetadata.TimeZone`, ...).

**Design choice — structured out-of-band input (option B), not SET-framing in the source SDL (option A).** The SDL producer (`getSDLFormat` in bytebase) is confirmed bare and is the *same* function used for the source dump, so option A would fork a "special source-dump SDL form" and diverge the two producers. The data is already structured on the bytebase side, and LoadSDL topologically reorders statements (breaking any "SET immediately preceding a CREATE" association). Option B sidesteps both.

**Keep it out of diff identity.** `canonicalRoutine`, `triggersChanged`, and `eventCanonicalKey` all continue to exclude the context, so a mode-only difference never triggers a phantom recreate.

### Which emission paths re-stamp the context (verified empirically on live 8.0.32 + 5.7)

| Path | sql_mode re-stamped? | Action |
|---|---|---|
| `DROP`+`CREATE` recreate (routines/triggers: any body/param change; events: ENDS removal) | yes — fresh `CREATE` adopts the session | **frame it** |
| `ALTER EVENT … DO <body>` (the common event body change) | **yes** — re-stamps sql_mode/charset/collation (not time_zone) | **frame it** |
| `ALTER FUNCTION` / `ALTER PROCEDURE` (characteristic-only) | no | left bare |

Framing wraps the `CREATE`/`ALTER` in a concat-safe save/restore sourced from the **OLD** (`From`) object, mirroring mysqldump:

```sql
DROP FUNCTION `f`;
SET @saved_sql_mode = @@sql_mode;
SET sql_mode = 'PIPES_AS_CONCAT,NO_BACKSLASH_ESCAPES';
SET @saved_cs_client = @@character_set_client;
SET character_set_client = utf8mb4;
SET @saved_coll_conn = @@collation_connection;
SET collation_connection = utf8mb4_0900_ai_ci;
CREATE FUNCTION `f`(`a` INT) RETURNS int
    DETERMINISTIC
RETURN a + 2;
SET collation_connection = @saved_coll_conn;
SET character_set_client = @saved_cs_client;
SET sql_mode = @saved_sql_mode
```

Per-object saved vars + reverse-order restores mean one object's context can never leak into the next statement of a multi-statement migration. Events additionally frame `time_zone`. A brand-**new** object (no `From`) emits a bare `CREATE`. An authored empty `sql_mode` (`''`) round-trips — `HasSessionContext` gates "context applied, modes empty" (emit `SET sql_mode=''`) vs "no context" (bare `CREATE`).

**`DatabaseCollation` is intentionally NOT modeled** in `SessionContext`: it is a schema property (`CREATE DATABASE … DEFAULT COLLATE`), not session-settable per-object — verified on live 8.0.32 (`SET collation_database` before a `CREATE` leaves `ROUTINES.DATABASE_COLLATION` at the schema default). A `DEFAULT COLLATE` change is its own database-level diff. Name-only keying in `SessionContextMap` is sufficient because the declarative-rollout path is single-database.

## New public API (for the bytebase wiring stage)

```go
type SessionContext struct {
    SQLMode             string
    CharacterSetClient  string
    CollationConnection string
    TimeZone            string // events only
}

type SessionContextMap struct {
    Functions  map[string]SessionContext // key: lower(name)
    Procedures map[string]SessionContext
    Triggers   map[string]SessionContext
    Events     map[string]SessionContext
}

func (c *Catalog) ApplySessionContext(m SessionContextMap)
```

Call `ApplySessionContext` on the **source** (from / current) catalog after `LoadSDL` / `LoadSQL` and before `Diff`. `Diff` / `GenerateMigration` signatures are unchanged.

## Tests

`mysql/catalog/session_context_test.go` (10 unit cases): routine recreate carries sql_mode with exact framing; new routine → bare CREATE; unchanged routine → no diff; charset/collation-only recreate (empty sql_mode round-trips); event recreate carries time_zone + sql_mode; **event ALTER carries sql_mode**; event-ALTER / routine-ALTER-only stay bare where appropriate; trigger recreate carries sql_mode; no-context recreate stays bare.

`mysql/catalog/session_context_oracle_test.go` proves end-to-end on the **live** engine (8.0 + 5.7) that a routine recreate and an event ALTER applied under a *different deploy sql_mode* preserve the original mode in `information_schema`.

`go build ./...`, `go test ./... -short`, existing routine/trigger/event oracle apply-correctness + idempotence suites (no regression), `gofmt`, `go vet`, `golangci-lint --new-from-rev=origin/main` — all clean.

## Testing

- `go test ./mysql/... -short` — pass.
- Live-engine oracle: new framing tests pass on 8.0 + 5.7; existing routine/trigger/event oracle suites pass unchanged (161s).
- Empirical `information_schema` probes on 8.0.32 grounded the ALTER-re-stamp and DatabaseCollation decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
