### PR TITLE
tidb: match TiDB v8.5.5 block-comment lexing

### DIFF
--- a/harness/conformance/scoreboards/tidb.md
+++ b/harness/conformance/scoreboards/tidb.md
@@ -3,7 +3,7 @@
 | meta | value |
 |---|---|
 | engine_version | v8.5.5 |
-| omni_sha | f7991e553a27d880dcd70b6d5bcfb007981f3be8 |
+| omni_sha | 3a141ab933b7b2614fc98c12c443384b49586b9f |
 | corpus_tag | v8.5.5 |
 | container_digest | pingcap/tidb@sha256:f2178ff6cd26f190c64a92cf867148ec6ee6fa31e214cc402bfbbb6bf5f70f26 |
 | classifier_version | 1 |
@@ -12,10 +12,10 @@
 
 | class | statements |
 |---|---|
-| AGREE_ACCEPT | 2004 |
-| AGREE_REJECT | 479 |
-| GAP | 1093 |
-| OVER | 160 |
+| AGREE_ACCEPT | 2000 |
+| AGREE_REJECT | 482 |
+| GAP | 1097 |
+| OVER | 157 |
 | INDETERMINATE | 49 |
 | SKIP | 13 |
 | duplicates_dropped | 58 |
@@ -26,7 +26,7 @@ Unexpanded generator sites (runtime-built srcs, each representing multiple upstr
 
 GAP clusters: 71
 
-OVER clusters: 46
+OVER clusters: 44
 
 Clusters are the work unit; statement counts are coverage context.
 
@@ -38,17 +38,17 @@ Clusters are the work unit; statement counts are coverage context.
 | 2 | SELECT | 112 | syntax error at or near ? (line N, column N) | `SELECT SCHEMA();` | corpus/tidb/pkg/parser/parser_test.go:1678 |
 | 3 | ADMIN | 76 | syntax error at or near ? (line N, column N) | `admin show ddl;` | corpus/tidb/pkg/parser/parser_test.go:489 |
 | 4 | CREATE OTHER | 73 | unexpected token after CREATE (line N, column N) | `create sequence seq` | corpus/tidb/pkg/parser/parser_test.go:3762 |
-| 5 | ALTER TABLE | 68 | syntax error at or near ? (line N, column N) | `ALTER TABLE db.t RENAME db1.t1` | corpus/tidb/pkg/parser/parser_test.go:3144 |
+| 5 | ALTER TABLE | 70 | syntax error at or near ? (line N, column N) | `ALTER TABLE db.t RENAME db1.t1` | corpus/tidb/pkg/parser/parser_test.go:3144 |
 | 6 | SHOW | 66 | syntax error at or near ? (line N, column N) | `show config` | corpus/tidb/pkg/parser/parser_test.go:1429 |
 | 7 | DROP | 49 | unexpected token after DROP (line N, column N) | `drop stats t` | corpus/tidb/pkg/parser/parser_test.go:2836 |
 | 8 | CREATE TABLE | 46 | unexpected token (line N, column N) | `create table t (a text byte)` | corpus/tidb/pkg/parser/parser_test.go:3735 |
 | 9 | ALTER TABLE | 33 | expected identifier (line N, column N) | `ALTER TABLE t RENAME = t1` | corpus/tidb/pkg/parser/parser_test.go:3149 |
 | 10 | CREATE OTHER | 33 | syntax error at or near ? (line N, column N) | `create resource group x ru_per_sec=2000` | corpus/tidb/pkg/parser/parser_test.go:3936 |
-| 11 | ALTER TABLE | 30 | expected ALTER TABLE operation (line N, column N) | `ALTER TABLE tmp CACHE` | corpus/tidb/pkg/parser/parser_test.go:2546 |
+| 11 | ALTER TABLE | 31 | expected ALTER TABLE operation (line N, column N) | `ALTER TABLE tmp CACHE` | corpus/tidb/pkg/parser/parser_test.go:2546 |
 | 12 | ALTER TABLE | 27 | unexpected token (line N, column N) | `ALTER TABLE d_n.t_n ADD PARTITION LOCAL` | corpus/tidb/pkg/parser/parser_test.go:3332 |
 | 13 | SELECT | 27 | expected SELECT or ? (line N, column N) | `(TABLE t)` | corpus/tidb/pkg/parser/parser_test.go:650 |
 | 14 | STATS | 22 | syntax error at or near ? (line N, column N) | `analyze table t1 index` | corpus/tidb/pkg/parser/parser_test.go:6087 |
-| 15 | CREATE TABLE | 20 | syntax error at or near ? (line N, column N) | `CREATE TABLE t (a int) STATS_TOPN=1` | corpus/tidb/pkg/parser/parser_test.go:4057 |
+| 15 | CREATE TABLE | 21 | syntax error at or near ? (line N, column N) | `CREATE TABLE t (a int) STATS_TOPN=1` | corpus/tidb/pkg/parser/parser_test.go:4057 |
 | 16 | CREATE TABLE | 19 | expected data type (line N, column N) | `CREATE TABLE t (a VECTOR)` | corpus/tidb/pkg/parser/parser_test.go:7688 |
 | 17 | LOAD | 17 | syntax error at or near ? (line N, column N) | `import into t from '/file.csv'` | corpus/tidb/pkg/parser/parser_test.go:781 |
 | 18 | EXPLAIN | 16 | expected identifier or keyword (line N, column N) | `EXPLAIN FORMAT = 'ROW' SELECT 1` | corpus/tidb/pkg/parser/parser_test.go:5603 |
@@ -124,35 +124,33 @@ Clusters are the work unit; statement counts are coverage context.
 | 12 | CREATE TABLE | 2 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `create table t (created_at datetime) TTL_ENABLE = 'test_case'` | corpus/tidb/pkg/parser/parser_test.go:7619 |
 | 13 | CREATE TABLE | 2 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `create table t (created_at datetime) TTL_JOB_INTERVAL = '10hourxx'` | corpus/tidb/pkg/parser/parser_test.go:7625 |
 | 14 | CREATE TABLE | 2 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `create table t (a int) stats_auto_recalc 2;` | corpus/tidb/pkg/parser/parser_test.go:3636 |
-| 15 | DELETE | 2 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `delete from t where a = 7 or 1=1/*' and b = 'p'` | corpus/tidb/pkg/parser/parser_test.go:5161 |
-| 16 | DROP | 2 | Unknown ALGORITHM ? | `drop index idx on t algorithm algorithm_type` | corpus/tidb/pkg/parser/parser_test.go:3453 |
-| 17 | DROP | 2 | Unknown LOCK type ? | `drop index idx on t lock lock_type` | corpus/tidb/pkg/parser/parser_test.go:3455 |
-| 18 | LOAD | 2 | Field separator argument is not what is expected; check the manual | `load data infile '/tmp/t.csv' into table t fields escaped by 'aa'` | corpus/tidb/pkg/parser/parser_test.go:756 |
-| 19 | SELECT | 2 | Incorrect usage of ALL and DISTINCT | `SELECT DISTINCT ALL * FROM t` | corpus/tidb/pkg/parser/parser_test.go:587 |
-| 20 | SELECT | 2 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `select date_add("2011-11-11 10:10:10.123456", "11,11")` | corpus/tidb/pkg/parser/parser_test.go:2068 |
-| 21 | TXN | 2 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `COMMIT AND CHAIN RELEASE` | corpus/tidb/pkg/parser/parser_test.go:626 |
-| 22 | UPDATE | 2 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `UPDATE items,month SET items.price=month.price WHERE items.id=month.id LIMIT 10;` | corpus/tidb/pkg/parser/parser_test.go:933 |
-| 23 | ALTER TABLE | 1 | For RANGE partitions each partition must be defined | `alter table t partition by range(a)` | corpus/tidb/pkg/parser/parser_test.go:3309 |
-| 24 | ALTER TABLE | 1 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `alter table t /*T![ttl] TTL_ENABLE = 'test_case' */` | corpus/tidb/pkg/parser/parser_test.go:7621 |
-| 25 | CREATE INDEX | 1 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `CREATE UNIQUE INDEX ident USING HNSW ON d_n.t_n ( ident , ident ASC )` | corpus/tidb/pkg/parser/parser_test.go:3417 |
-| 26 | CREATE OTHER | 1 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `CREATE ROLE RESOURCE` | corpus/tidb/pkg/parser/parser_test.go:4050 |
-| 27 | CREATE TABLE | 1 | Cannot have more than one value for this type of RANGE partitioning | `create table t1 (a int, b int) partition by range (a) (partition x values less than (10, 20))` | corpus/tidb/pkg/parser/parser_test.go:6404 |
-| 28 | CREATE TABLE | 1 | For LIST partitions each partition must be defined | `create table t1 (a int) partition by list (a)` | corpus/tidb/pkg/parser/parser_test.go:6397 |
-| 29 | CREATE TABLE | 1 | For RANGE partitions each partition must be defined | `create table t1 (a int) partition by range (a)` | corpus/tidb/pkg/parser/parser_test.go:6396 |
-| 30 | CREATE TABLE | 1 | Incorrect usage of AUTO_INCREMENT and generated column | `create table t (a bigint, b bigint as (a) primary key auto_increment);` | corpus/tidb/pkg/parser/parser_test.go:3500 |
-| 31 | CREATE TABLE | 1 | Incorrect usage of DEFAULT and generated column | `create table t (a bigint, b bigint as (a) not null default 10);` | corpus/tidb/pkg/parser/parser_test.go:3501 |
-| 32 | CREATE TABLE | 1 | Incorrect usage of ON UPDATE and generated column | `create table t (a timestamp, b timestamp as (a) not null on update current_timestamp);` | corpus/tidb/pkg/parser/parser_test.go:3499 |
-| 33 | CREATE TABLE | 1 | It is only possible to mix RANGE/LIST partitioning with HASH/KEY partitioning fo... | `create table t1 (a int, b int) partition by range (a) (partition x values less than (10) (subpartiti...` | corpus/tidb/pkg/parser/parser_test.go:6441 |
-| 34 | CREATE TABLE | 1 | Number of partitions = N is not an allowed value | `create table t1 (a int) partition by hash (a) partitions 0` | corpus/tidb/pkg/parser/parser_test.go:6442 |
-| 35 | CREATE TABLE | 1 | Number of subpartitions = N is not an allowed value | `create table t1 (a int, b int) partition by range (a) subpartition by hash (b) subpartitions 0 (part...` | corpus/tidb/pkg/parser/parser_test.go:6443 |
-| 36 | CREATE TABLE | 1 | Row expressions in VALUES IN only allowed for multi-field column partitioning | `create table t1 (a int, b int) partition by list (a) (partition x values in ((10, 20)))` | corpus/tidb/pkg/parser/parser_test.go:6409 |
-| 37 | CREATE TABLE | 1 | Syntax : LIST PARTITIONING requires definition of VALUES IN for each partition | `create table t1 (a int) partition by list (a) (partition x, partition y)` | corpus/tidb/pkg/parser/parser_test.go:6366 |
-| 38 | CREATE TABLE | 1 | Syntax : RANGE PARTITIONING requires definition of VALUES LESS THAN for each par... | `create table t1 (a int) partition by range (a) (partition x, partition y)` | corpus/tidb/pkg/parser/parser_test.go:6365 |
-| 39 | CREATE TABLE | 1 | Wrong number of partitions defined, mismatch with previous setting | `create table t1 (a int) partition by hash (a) partitions 2 (partition x)` | corpus/tidb/pkg/parser/parser_test.go:6429 |
-| 40 | CREATE TABLE | 1 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `create table t (created_at datetime) TTL_JOB_INTERVAL = '10.10.255h'` | corpus/tidb/pkg/parser/parser_test.go:7626 |
-| 41 | INSERT | 1 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `INSERT INTO t (a) SET a=1` | corpus/tidb/pkg/parser/parser_test.go:918 |
-| 42 | SELECT | 1 | Incorrect arguments to ESCAPE | `select "abc_" like "abc\\_" escape '\|\|'` | corpus/tidb/pkg/parser/parser_test.go:5443 |
-| 43 | SELECT | 1 | Too-big precision N specified for ?. Maximum is N. | `select cast(1 as float(54));` | corpus/tidb/pkg/parser/parser_test.go:1753 |
-| 44 | SELECT | 1 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `select """;` | corpus/tidb/pkg/parser/parser_test.go:5571 |
-| 45 | SELECT | 1 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `select 0X11` | corpus/tidb/pkg/parser/parser_test.go:4968 |
-| 46 | SELECT | 1 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `select 1/*` | corpus/tidb/pkg/parser/parser_test.go:5188 |
+| 15 | DROP | 2 | Unknown ALGORITHM ? | `drop index idx on t algorithm algorithm_type` | corpus/tidb/pkg/parser/parser_test.go:3453 |
+| 16 | DROP | 2 | Unknown LOCK type ? | `drop index idx on t lock lock_type` | corpus/tidb/pkg/parser/parser_test.go:3455 |
+| 17 | LOAD | 2 | Field separator argument is not what is expected; check the manual | `load data infile '/tmp/t.csv' into table t fields escaped by 'aa'` | corpus/tidb/pkg/parser/parser_test.go:756 |
+| 18 | SELECT | 2 | Incorrect usage of ALL and DISTINCT | `SELECT DISTINCT ALL * FROM t` | corpus/tidb/pkg/parser/parser_test.go:587 |
+| 19 | SELECT | 2 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `select date_add("2011-11-11 10:10:10.123456", "11,11")` | corpus/tidb/pkg/parser/parser_test.go:2068 |
+| 20 | TXN | 2 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `COMMIT AND CHAIN RELEASE` | corpus/tidb/pkg/parser/parser_test.go:626 |
+| 21 | UPDATE | 2 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `UPDATE items,month SET items.price=month.price WHERE items.id=month.id LIMIT 10;` | corpus/tidb/pkg/parser/parser_test.go:933 |
+| 22 | ALTER TABLE | 1 | For RANGE partitions each partition must be defined | `alter table t partition by range(a)` | corpus/tidb/pkg/parser/parser_test.go:3309 |
+| 23 | ALTER TABLE | 1 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `alter table t /*T![ttl] TTL_ENABLE = 'test_case' */` | corpus/tidb/pkg/parser/parser_test.go:7621 |
+| 24 | CREATE INDEX | 1 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `CREATE UNIQUE INDEX ident USING HNSW ON d_n.t_n ( ident , ident ASC )` | corpus/tidb/pkg/parser/parser_test.go:3417 |
+| 25 | CREATE OTHER | 1 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `CREATE ROLE RESOURCE` | corpus/tidb/pkg/parser/parser_test.go:4050 |
+| 26 | CREATE TABLE | 1 | Cannot have more than one value for this type of RANGE partitioning | `create table t1 (a int, b int) partition by range (a) (partition x values less than (10, 20))` | corpus/tidb/pkg/parser/parser_test.go:6404 |
+| 27 | CREATE TABLE | 1 | For LIST partitions each partition must be defined | `create table t1 (a int) partition by list (a)` | corpus/tidb/pkg/parser/parser_test.go:6397 |
+| 28 | CREATE TABLE | 1 | For RANGE partitions each partition must be defined | `create table t1 (a int) partition by range (a)` | corpus/tidb/pkg/parser/parser_test.go:6396 |
+| 29 | CREATE TABLE | 1 | Incorrect usage of AUTO_INCREMENT and generated column | `create table t (a bigint, b bigint as (a) primary key auto_increment);` | corpus/tidb/pkg/parser/parser_test.go:3500 |
+| 30 | CREATE TABLE | 1 | Incorrect usage of DEFAULT and generated column | `create table t (a bigint, b bigint as (a) not null default 10);` | corpus/tidb/pkg/parser/parser_test.go:3501 |
+| 31 | CREATE TABLE | 1 | Incorrect usage of ON UPDATE and generated column | `create table t (a timestamp, b timestamp as (a) not null on update current_timestamp);` | corpus/tidb/pkg/parser/parser_test.go:3499 |
+| 32 | CREATE TABLE | 1 | It is only possible to mix RANGE/LIST partitioning with HASH/KEY partitioning fo... | `create table t1 (a int, b int) partition by range (a) (partition x values less than (10) (subpartiti...` | corpus/tidb/pkg/parser/parser_test.go:6441 |
+| 33 | CREATE TABLE | 1 | Number of partitions = N is not an allowed value | `create table t1 (a int) partition by hash (a) partitions 0` | corpus/tidb/pkg/parser/parser_test.go:6442 |
+| 34 | CREATE TABLE | 1 | Number of subpartitions = N is not an allowed value | `create table t1 (a int, b int) partition by range (a) subpartition by hash (b) subpartitions 0 (part...` | corpus/tidb/pkg/parser/parser_test.go:6443 |
+| 35 | CREATE TABLE | 1 | Row expressions in VALUES IN only allowed for multi-field column partitioning | `create table t1 (a int, b int) partition by list (a) (partition x values in ((10, 20)))` | corpus/tidb/pkg/parser/parser_test.go:6409 |
+| 36 | CREATE TABLE | 1 | Syntax : LIST PARTITIONING requires definition of VALUES IN for each partition | `create table t1 (a int) partition by list (a) (partition x, partition y)` | corpus/tidb/pkg/parser/parser_test.go:6366 |
+| 37 | CREATE TABLE | 1 | Syntax : RANGE PARTITIONING requires definition of VALUES LESS THAN for each par... | `create table t1 (a int) partition by range (a) (partition x, partition y)` | corpus/tidb/pkg/parser/parser_test.go:6365 |
+| 38 | CREATE TABLE | 1 | Wrong number of partitions defined, mismatch with previous setting | `create table t1 (a int) partition by hash (a) partitions 2 (partition x)` | corpus/tidb/pkg/parser/parser_test.go:6429 |
+| 39 | CREATE TABLE | 1 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `create table t (created_at datetime) TTL_JOB_INTERVAL = '10.10.255h'` | corpus/tidb/pkg/parser/parser_test.go:7626 |
+| 40 | INSERT | 1 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `INSERT INTO t (a) SET a=1` | corpus/tidb/pkg/parser/parser_test.go:918 |
+| 41 | SELECT | 1 | Incorrect arguments to ESCAPE | `select "abc_" like "abc\\_" escape '\|\|'` | corpus/tidb/pkg/parser/parser_test.go:5443 |
+| 42 | SELECT | 1 | Too-big precision N specified for ?. Maximum is N. | `select cast(1 as float(54));` | corpus/tidb/pkg/parser/parser_test.go:1753 |
+| 43 | SELECT | 1 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `select """;` | corpus/tidb/pkg/parser/parser_test.go:5571 |
+| 44 | SELECT | 1 | You have an error in your SQL syntax; check the manual that corresponds to your ... | `select 0X11` | corpus/tidb/pkg/parser/parser_test.go:4968 |

--- a/tidb/parser/compare_test.go
+++ b/tidb/parser/compare_test.go
@@ -171,7 +171,10 @@ func TestLexerComments(t *testing.T) {
 		{"SELECT -- comment\n1", []int{kwSELECT, tokICONST}},
 		{"SELECT # comment\n1", []int{kwSELECT, tokICONST}},
 		{"SELECT /* comment */ 1", []int{kwSELECT, tokICONST}},
-		{"SELECT /* nested /* comment */ */ 1", []int{kwSELECT, tokICONST}},
+		// Block comments do not nest: the first */ closes, so the trailing
+		// */ lexes as '*' and '/' operator tokens (TiDB v8.5.5 rejects this
+		// statement for exactly that reason).
+		{"SELECT /* nested /* comment */ */ 1", []int{kwSELECT, '*', '/', tokICONST}},
 	}
 
 	for _, tt := range tests {

--- a/tidb/parser/lexer.go
+++ b/tidb/parser/lexer.go
@@ -9,27 +9,17 @@ import (
 )
 
 // tidbSupportedFeatures lists TiDB v8.5 feature IDs recognized in /*T![feature] */ comments.
+// Mirrors pkg/parser/tidb/features.go featureIDs at v8.5.5.
 var tidbSupportedFeatures = map[string]bool{
 	"auto_rand":       true,
 	"auto_id_cache":   true,
 	"auto_rand_base":  true,
 	"clustered_index": true,
+	"force_inc":       true,
 	"placement":       true,
 	"ttl":             true,
-}
-
-// allTiDBFeaturesSupported checks if all comma-separated feature IDs are supported.
-func allTiDBFeaturesSupported(featureStr string) bool {
-	for _, f := range strings.Split(featureStr, ",") {
-		f = strings.TrimSpace(f)
-		if f == "" {
-			continue
-		}
-		if !tidbSupportedFeatures[f] {
-			return false
-		}
-	}
-	return true
+	"global_index":    true,
+	"affinity":        true,
 }
 
 // Token type constants for literals and operators.
@@ -56,6 +46,7 @@ const (
 	tokJsonExtract // ->
 	tokJsonUnquote // ->>
 	tokAt2         // @@ (system variable prefix)
+	tokInvalid     // lexically invalid input, e.g. an unclosed block comment
 )
 
 // Keyword token constants. Values start at 700.
@@ -1806,7 +1797,9 @@ func (l *Lexer) NextToken() Token {
 }
 
 func (l *Lexer) nextToken() Token {
-	l.skipWhitespaceAndComments()
+	if bad := l.skipWhitespaceAndComments(); bad != nil {
+		return *bad
+	}
 
 	if l.pos >= len(l.input) {
 		return Token{Type: tokEOF, Loc: l.pos}
@@ -1911,7 +1904,10 @@ func (l *Lexer) nextToken() Token {
 	return Token{Type: int(ch), Str: string(ch), Loc: l.start}
 }
 
-func (l *Lexer) skipWhitespaceAndComments() {
+// skipWhitespaceAndComments advances past whitespace and comments. It
+// returns a non-nil tokInvalid token when the input ends inside an unclosed
+// regular block comment (a parse error in TiDB).
+func (l *Lexer) skipWhitespaceAndComments() *Token {
 	for l.pos < len(l.input) {
 		ch := l.input[l.pos]
 
@@ -1946,141 +1942,268 @@ func (l *Lexer) skipWhitespaceAndComments() {
 
 		// Block comment: /* ... */
 		if ch == '/' && l.pos+1 < len(l.input) && l.input[l.pos+1] == '*' {
-			// TiDB comments: /*T! ... */ or /*T![feature] ... */
-			if l.pos+3 < len(l.input) && l.input[l.pos+2] == 'T' && l.input[l.pos+3] == '!' {
-				innerStart := l.pos + 4 // after /*T!
-
-				// Check for feature bracket: /*T![feature_id]
-				if innerStart < len(l.input) && l.input[innerStart] == '[' {
-					bracketEnd := innerStart + 1
-					for bracketEnd < len(l.input) && l.input[bracketEnd] != ']' {
-						bracketEnd++
-					}
-					if bracketEnd >= len(l.input) {
-						// Malformed: no closing bracket, skip as regular comment.
-						l.pos += 2
-						depth := 1
-						for l.pos < len(l.input) && depth > 0 {
-							if l.input[l.pos] == '*' && l.pos+1 < len(l.input) && l.input[l.pos+1] == '/' {
-								depth--
-								l.pos += 2
-							} else if l.input[l.pos] == '/' && l.pos+1 < len(l.input) && l.input[l.pos+1] == '*' {
-								depth++
-								l.pos += 2
-							} else {
-								l.pos++
-							}
-						}
-						continue
-					}
-					featureStr := l.input[innerStart+1 : bracketEnd]
-					if !allTiDBFeaturesSupported(featureStr) {
-						// Unsupported feature — skip entire comment.
-						l.pos += 2
-						depth := 1
-						for l.pos < len(l.input) && depth > 0 {
-							if l.input[l.pos] == '*' && l.pos+1 < len(l.input) && l.input[l.pos+1] == '/' {
-								depth--
-								l.pos += 2
-							} else if l.input[l.pos] == '/' && l.pos+1 < len(l.input) && l.input[l.pos+1] == '*' {
-								depth++
-								l.pos += 2
-							} else {
-								l.pos++
-							}
-						}
-						continue
-					}
-					innerStart = bracketEnd + 1 // SQL starts after ]
-				}
-
-				// Find matching */
-				end := innerStart
-				depth := 1
-				for end < len(l.input) && depth > 0 {
-					if l.input[end] == '*' && end+1 < len(l.input) && l.input[end+1] == '/' {
-						depth--
-						if depth == 0 {
-							break
-						}
-						end += 2
-					} else if l.input[end] == '/' && end+1 < len(l.input) && l.input[end+1] == '*' {
-						depth++
-						end += 2
-					} else {
-						end++
-					}
-				}
-				// If comment is unclosed (no matching */), treat as regular block comment.
-				if depth > 0 {
-					l.pos = len(l.input)
-					continue
-				}
-				// Splice inner SQL into the input buffer, replacing the comment construct.
-				// Note: this in-place mutation means Loc offsets on subsequent tokens are
-				// relative to the rewritten buffer, not the original source text. This matches
-				// the MySQL /*!*/ handling below and is an accepted invariant — no downstream
-				// code in the TiDB engine currently relies on byte-accurate Loc against the
-				// original input.
-				inner := l.input[innerStart:end]
-				l.input = l.input[:l.pos] + inner + l.input[end+2:]
-				continue
-			}
-
-			// MySQL conditional comments: /*!NNNNN ... */ or /*! ... */
-			// These should be parsed as SQL, not skipped.
-			if l.pos+2 < len(l.input) && l.input[l.pos+2] == '!' {
-				// Skip /*!
-				innerStart := l.pos + 3
-				// Skip optional version number (digits)
-				vpos := innerStart
-				for vpos < len(l.input) && l.input[vpos] >= '0' && l.input[vpos] <= '9' {
-					vpos++
-				}
-				// Find the matching */
-				end := vpos
-				depth := 1
-				for end < len(l.input) && depth > 0 {
-					if l.input[end] == '*' && end+1 < len(l.input) && l.input[end+1] == '/' {
-						depth--
-						if depth == 0 {
-							break
-						}
-						end += 2
-					} else if l.input[end] == '/' && end+1 < len(l.input) && l.input[end+1] == '*' {
-						depth++
-						end += 2
-					} else {
-						end++
-					}
-				}
-				// Extract the inner content and splice it into the input,
-				// replacing the conditional comment with its content.
-				inner := l.input[vpos:end]
-				l.input = l.input[:l.pos] + inner + l.input[end+2:]
-				// Don't advance l.pos — re-scan from the start of the inner content.
-				continue
-			}
-
-			l.pos += 2
-			// Regular block comment: skip everything.
-			depth := 1
-			for l.pos < len(l.input) && depth > 0 {
-				if l.input[l.pos] == '*' && l.pos+1 < len(l.input) && l.input[l.pos+1] == '/' {
-					depth--
-					l.pos += 2
-				} else if l.input[l.pos] == '/' && l.pos+1 < len(l.input) && l.input[l.pos+1] == '*' {
-					depth++
-					l.pos += 2
-				} else {
-					l.pos++
-				}
+			if bad := l.scanBlockComment(); bad != nil {
+				return bad
 			}
 			continue
 		}
 
 		break
 	}
+	return nil
+}
+
+// scanBlockComment handles a block-comment construct starting at l.pos
+// (guaranteed "/*"). Mirrors TiDB v8.5.5 pkg/parser/lexer.go
+// startWithSlash/startWithStar:
+//   - /*! with exactly five version digits (or none) and /*T! with a
+//     supported feature list are bang comments: their content is SQL and is
+//     spliced into the input buffer;
+//   - a well-formed /*T![...] list containing an unsupported ID makes the
+//     whole construct a regular comment; a malformed list resets, so the
+//     construct is a bang comment whose content starts at the '[';
+//   - everything else is a regular comment ending at the FIRST */ — block
+//     comments do not nest — and an unclosed regular comment is a parse
+//     error, surfaced as a tokInvalid token.
+func (l *Lexer) scanBlockComment() *Token {
+	start := l.pos
+	// TiDB comments: /*T! ... */ or /*T![feature,...] ... */
+	if l.pos+3 < len(l.input) && l.input[l.pos+2] == 'T' && l.input[l.pos+3] == '!' {
+		p := l.pos + 4
+		if p < len(l.input) && l.input[p] == '[' {
+			ids, after, wellFormed := scanTiDBFeatureIDs(l.input, p)
+			if !wellFormed {
+				l.spliceBangComment(p)
+				return nil
+			}
+			for _, id := range ids {
+				if !tidbSupportedFeatures[id] {
+					return l.skipRegularBlockComment(start)
+				}
+			}
+			l.spliceBangComment(after)
+			return nil
+		}
+		l.spliceBangComment(p)
+		return nil
+	}
+
+	// MySQL conditional comments: /*!NNNNN ... */ or /*! ... */
+	if l.pos+2 < len(l.input) && l.input[l.pos+2] == '!' {
+		inner := l.pos + 3
+		// Exactly five version digits or none (TiDB scanVersionDigits(5, 5));
+		// a shorter digit run and the sixth-and-later digits are SQL content.
+		d := inner
+		for d < len(l.input) && d-inner < 5 && l.input[d] >= '0' && l.input[d] <= '9' {
+			d++
+		}
+		if d-inner == 5 {
+			inner = d
+		}
+		l.spliceBangComment(inner)
+		return nil
+	}
+
+	return l.skipRegularBlockComment(start)
+}
+
+// skipRegularBlockComment skips a non-nesting block comment starting at
+// start ("/*"): the first */ closes it. An unclosed comment is a parse error
+// in TiDB; surface it as a tokInvalid token at the comment start and park
+// the lexer at end of input so the next token is EOF.
+func (l *Lexer) skipRegularBlockComment(start int) *Token {
+	for i := start + 2; i+1 < len(l.input); i++ {
+		if l.input[i] == '*' && l.input[i+1] == '/' {
+			l.pos = i + 2
+			return nil
+		}
+	}
+	l.pos = len(l.input)
+	return &Token{Type: tokInvalid, Str: "/*", Loc: start}
+}
+
+// spliceBangComment splices the content of a bang comment (/*! or supported
+// /*T!) into the input buffer, replacing the construct, and leaves l.pos at
+// the splice point for re-scanning. The construct closes at the first */
+// not consumed by a string literal, backtick identifier, line comment, or
+// inner regular block comment — TiDB lexes bang content as SQL, so those
+// constructs hide */. Inner bang markers are replaced with a single space:
+// TiDB's inBangComment is a bool, so nested markers do not stack and the
+// first unconsumed */ closes everything. An unclosed construct is tolerated
+// (TiDB reaches EOF in bang mode without error): the content simply runs to
+// end of input.
+// Note: this rewrites l.input in place like the previous implementation, so
+// Loc offsets on subsequent tokens are relative to the rewritten buffer, not
+// the original source text — an accepted invariant; no downstream code
+// relies on byte-accurate Loc against the original input.
+func (l *Lexer) spliceBangComment(innerStart int) {
+	var sb strings.Builder
+	i := innerStart
+	end := -1 // position of the closing */
+scan:
+	for i < len(l.input) {
+		ch := l.input[i]
+		switch {
+		case ch == '*' && i+1 < len(l.input) && l.input[i+1] == '/':
+			end = i
+			break scan
+		case ch == '\'' || ch == '"' || ch == '`':
+			i = appendQuoted(&sb, l.input, i)
+		case ch == '#':
+			i = appendLineComment(&sb, l.input, i)
+		case ch == '-' && i+1 < len(l.input) && l.input[i+1] == '-' &&
+			(i+2 >= len(l.input) || l.input[i+2] == ' ' || l.input[i+2] == '\t' || l.input[i+2] == '\n' || l.input[i+2] == '\r'):
+			i = appendLineComment(&sb, l.input, i)
+		case ch == '/' && i+1 < len(l.input) && l.input[i+1] == '*':
+			i = l.appendInnerComment(&sb, i)
+		default:
+			sb.WriteByte(ch)
+			i++
+		}
+	}
+	if end >= 0 {
+		// The closing */ is a token boundary in TiDB (its scanner emits the
+		// token before it, exits bang mode, and scans fresh after it), so
+		// replace it with one space: without it, content and suffix bytes
+		// would butt into a single token (x*/YZ must lex as x then YZ).
+		l.input = l.input[:l.pos] + sb.String() + " " + l.input[end+2:]
+	} else {
+		l.input = l.input[:l.pos] + sb.String()
+	}
+}
+
+// appendInnerComment handles a /* opener inside bang-comment content at
+// position i. Bang markers (/*!NNNNN, /*T!, and supported /*T![...]) are
+// replaced with a single space — TiDB's bool inBangComment means they do not
+// stack, and the marker is a token boundary, so deleting it outright would
+// butt adjacent content bytes into phantom tokens (2//*!50000*3 must lex as
+// 2 / * 3, not reconstruct a /* opener). Regular comments (including
+// well-formed unsupported-feature /*T![...]) are copied through to their
+// closing */ so they hide any */ inside.
+// Returns the position content scanning resumes at.
+func (l *Lexer) appendInnerComment(sb *strings.Builder, i int) int {
+	if i+3 < len(l.input) && l.input[i+2] == 'T' && l.input[i+3] == '!' {
+		p := i + 4
+		if p < len(l.input) && l.input[p] == '[' {
+			ids, after, wellFormed := scanTiDBFeatureIDs(l.input, p)
+			if !wellFormed {
+				sb.WriteByte(' ')
+				return p // strip marker; content resumes at '['
+			}
+			for _, id := range ids {
+				if !tidbSupportedFeatures[id] {
+					return appendRegularComment(sb, l.input, i)
+				}
+			}
+			sb.WriteByte(' ')
+			return after // strip marker including feature list
+		}
+		sb.WriteByte(' ')
+		return p
+	}
+	if i+2 < len(l.input) && l.input[i+2] == '!' {
+		p := i + 3
+		d := p
+		for d < len(l.input) && d-p < 5 && l.input[d] >= '0' && l.input[d] <= '9' {
+			d++
+		}
+		sb.WriteByte(' ')
+		if d-p == 5 {
+			return d
+		}
+		return p
+	}
+	return appendRegularComment(sb, l.input, i)
+}
+
+// appendRegularComment copies a regular block comment (non-nesting: the
+// first */ closes it) into sb, returning the position after the closing */
+// or end of input when unclosed.
+func appendRegularComment(sb *strings.Builder, input string, i int) int {
+	for j := i + 2; j+1 < len(input); j++ {
+		if input[j] == '*' && input[j+1] == '/' {
+			sb.WriteString(input[i : j+2])
+			return j + 2
+		}
+	}
+	sb.WriteString(input[i:])
+	return len(input)
+}
+
+// appendQuoted copies a quoted region (string literal or backtick
+// identifier) into sb, honoring backslash escapes (strings only) and
+// doubled-quote escapes, returning the position after the closing quote or
+// end of input when unclosed.
+func appendQuoted(sb *strings.Builder, input string, i int) int {
+	quote := input[i]
+	j := i + 1
+	for j < len(input) {
+		ch := input[j]
+		if ch == '\\' && quote != '`' && j+1 < len(input) {
+			j += 2
+			continue
+		}
+		if ch == quote {
+			if j+1 < len(input) && input[j+1] == quote {
+				j += 2
+				continue
+			}
+			j++
+			break
+		}
+		j++
+	}
+	sb.WriteString(input[i:j])
+	return j
+}
+
+// appendLineComment copies a # or -- line comment into sb up to (not
+// including) the terminating newline, returning the newline position (or end
+// of input).
+func appendLineComment(sb *strings.Builder, input string, i int) int {
+	j := i
+	for j < len(input) && input[j] != '\n' {
+		j++
+	}
+	sb.WriteString(input[i:j])
+	return j
+}
+
+// scanTiDBFeatureIDs parses the '[feature1,feature2,...]' list of a /*T!
+// comment starting at the '[' (mirrors TiDB pkg/parser scanFeatureIDs). It
+// returns the IDs, the position just after ']', and whether the list is
+// well-formed; a malformed list (empty segment, invalid character, or
+// missing ']') returns wellFormed=false and the caller lexes from '[' as
+// bang-comment content.
+func scanTiDBFeatureIDs(input string, p int) (ids []string, after int, wellFormed bool) {
+	i := p + 1 // after '['
+	var b strings.Builder
+	expectChar := true // each segment needs at least one identifier char
+	for i < len(input) {
+		ch := input[i]
+		switch {
+		case isTiDBFeatureIdentChar(ch):
+			b.WriteByte(ch)
+			expectChar = false
+		case ch == ',' && !expectChar:
+			ids = append(ids, b.String())
+			b.Reset()
+			expectChar = true
+		case ch == ']' && !expectChar:
+			ids = append(ids, b.String())
+			return ids, i + 1, true
+		default:
+			return nil, p, false
+		}
+		i++
+	}
+	return nil, p, false
+}
+
+// isTiDBFeatureIdentChar mirrors TiDB's isIdentChar for feature IDs.
+func isTiDBFeatureIdentChar(ch byte) bool {
+	return ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' ||
+		ch >= '0' && ch <= '9' || ch == '_' || ch == '$' || ch >= 0x80
 }
 
 func (l *Lexer) scanVariable() Token {

--- a/tidb/parser/split.go
+++ b/tidb/parser/split.go
@@ -1,5 +1,7 @@
 package parser
 
+import "strings"
+
 // Segment represents a portion of SQL text delimited by top-level semicolons.
 type Segment struct {
 	Text      string // the raw text of this segment (without trailing semicolon)
@@ -38,11 +40,12 @@ func (s Segment) Empty() bool {
 			if i+3 < len(t) && t[i+2] == 'T' && t[i+3] == '!' {
 				return false
 			}
-			prev := i
-			i = skipBlockCommentMySQL(t, i)
-			if i == prev {
+			// An unclosed comment is a parse error, not emptiness: the
+			// segment must reach the lexer so it can reject.
+			if !strings.Contains(t[i+2:], "*/") {
 				return false
 			}
+			i = skipBlockCommentMySQL(t, i)
 			continue
 		}
 		// Found a non-whitespace, non-comment character.
@@ -520,22 +523,15 @@ func skipHashComment(sql string, i int) int {
 }
 
 // skipBlockCommentMySQL skips a block comment starting at position i.
-// Supports nesting. Handles both regular /* ... */ and conditional /*!...*/
+// Block comments do NOT nest (TiDB/MySQL semantics): the first */ closes the
+// construct. Handles both regular /* ... */ and conditional /*!...*/
 // comments (for Split purposes, the entire construct is skipped).
-// Returns position after the closing */ (or end of input).
+// Returns position after the closing */ (or end of input when unclosed).
 func skipBlockCommentMySQL(sql string, i int) int {
-	i += 2 // skip /*
-	depth := 1
-	for i < len(sql) && depth > 0 {
-		if sql[i] == '/' && i+1 < len(sql) && sql[i+1] == '*' {
-			depth++
-			i += 2
-		} else if sql[i] == '*' && i+1 < len(sql) && sql[i+1] == '/' {
-			depth--
-			i += 2
-		} else {
-			i++
+	for i += 2; i+1 < len(sql); i++ {
+		if sql[i] == '*' && sql[i+1] == '/' {
+			return i + 2
 		}
 	}
-	return i
+	return len(sql)
 }

--- a/tidb/parser/split_test.go
+++ b/tidb/parser/split_test.go
@@ -176,9 +176,19 @@ func TestSplitQuotingAndComments(t *testing.T) {
 			want: []string{"SELECT 1 # ;\n", " SELECT 2"},
 		},
 		{
+			// Non-nesting: the first */ closes the comment; the ; inside the
+			// comment still doesn't split, the top-level one does.
 			name: "nested block comments",
 			sql:  "SELECT /* /* ; */ */ 1; SELECT 2;",
 			want: []string{"SELECT /* /* ; */ */ 1", " SELECT 2"},
+		},
+		{
+			// A pseudo-nested comment closes at the first */, so the ; after
+			// it is a real separator (nesting semantics used to swallow the
+			// rest of the input into one segment).
+			name: "pseudo-nested comment closes at first */",
+			sql:  "SELECT /* a /* b */ 1; SELECT 2;",
+			want: []string{"SELECT /* a /* b */ 1", " SELECT 2"},
 		},
 		{
 			name: "-- without space is not comment",

--- a/tidb/parser/tidb_comment_test.go
+++ b/tidb/parser/tidb_comment_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bytebase/omni/tidb/ast"
@@ -84,15 +85,17 @@ func TestTiDBCommentEmpty(t *testing.T) {
 }
 
 func TestTiDBCommentUnclosed(t *testing.T) {
-	// Unclosed TiDB comments must not panic.
+	// Unclosed TiDB comments must not panic. TiDB v8.5.5 tolerates EOF
+	// inside a bang comment: the content is already lexed as SQL, so these
+	// all parse (container-verified).
 	tests := []struct {
 		sql     string
 		wantErr bool
 	}{
-		{"SELECT /*T! 1", true},          // unclosed, incomplete SQL
-		{"SELECT /*T![ttl] 1", true},     // unclosed with feature gate
-		{"SELECT /*T![auto_rand] col", true}, // unclosed, dangling identifier
-		{"/*T! SELECT 1", false},         // unclosed but inner SQL is valid after injection
+		{"SELECT /*T! 1", false},              // SELECT 1
+		{"SELECT /*T![ttl] 1", false},         // SELECT 1
+		{"SELECT /*T![auto_rand] col", false}, // SELECT col
+		{"/*T! SELECT 1", false},              // SELECT 1
 	}
 	for _, tt := range tests {
 		t.Run(tt.sql, func(t *testing.T) {
@@ -112,28 +115,348 @@ func TestTiDBCommentUnclosed(t *testing.T) {
 	}
 }
 
-func TestAllTiDBFeaturesSupported(t *testing.T) {
+func TestScanTiDBFeatureIDs(t *testing.T) {
 	tests := []struct {
-		features string
-		want     bool
+		bracket    string
+		wantIDs    []string
+		wellFormed bool
 	}{
-		{"auto_rand", true},
-		{"auto_id_cache", true},
-		{"clustered_index", true},
-		{"placement", true},
-		{"ttl", true},
-		{"auto_rand_base", true},
-		{"unsupported_xyz", false},
-		{"auto_rand,clustered_index", true},
-		{"auto_rand,unsupported", false},
-		{"", true}, // empty = no features required
+		{"[auto_rand]", []string{"auto_rand"}, true},
+		{"[auto_rand,clustered_index]", []string{"auto_rand", "clustered_index"}, true},
+		{"[unsupported_xyz]", []string{"unsupported_xyz"}, true},
+		{"[]", nil, false},         // empty segment
+		{"[abc,]", nil, false},     // trailing empty segment
+		{"[abc", nil, false},       // missing ]
+		{"[a b]", nil, false},      // space is not an ident char
+		{"[auto_rand,]", nil, false},
 	}
 	for _, tt := range tests {
-		t.Run(tt.features, func(t *testing.T) {
-			got := allTiDBFeaturesSupported(tt.features)
-			if got != tt.want {
-				t.Errorf("allTiDBFeaturesSupported(%q) = %v, want %v", tt.features, got, tt.want)
+		t.Run(tt.bracket, func(t *testing.T) {
+			ids, after, wellFormed := scanTiDBFeatureIDs(tt.bracket, 0)
+			if wellFormed != tt.wellFormed {
+				t.Fatalf("wellFormed = %v, want %v", wellFormed, tt.wellFormed)
+			}
+			if !tt.wellFormed {
+				if after != 0 {
+					t.Fatalf("malformed list must reset: after = %d, want 0", after)
+				}
+				return
+			}
+			if after != len(tt.bracket) {
+				t.Fatalf("after = %d, want %d", after, len(tt.bracket))
+			}
+			if len(ids) != len(tt.wantIDs) {
+				t.Fatalf("ids = %v, want %v", ids, tt.wantIDs)
+			}
+			for i := range ids {
+				if ids[i] != tt.wantIDs[i] {
+					t.Fatalf("ids = %v, want %v", ids, tt.wantIDs)
+				}
 			}
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Comment-lexer conformance tests, container-verified against TiDB v8.5.5
+// (pingcap/tidb@sha256:f2178ff6cd26f190c64a92cf867148ec6ee6fa31e214cc402bfbbb6bf5f70f26).
+// TiDB semantics (pkg/parser/lexer.go startWithSlash/startWithStar):
+//   - block comments do NOT nest: the first */ closes the comment;
+//   - an unclosed regular block comment is a parse error;
+//   - /*! and supported /*T! comments lex their content as SQL; EOF inside
+//     one is tolerated (the construct just ends);
+//   - /*!NNNNN consumes exactly 5 version digits or none (scanVersionDigits(5,5));
+//   - /*T![...] feature IDs follow scanFeatureIDs: a malformed bracket list
+//     resets and the content (starting at '[') is lexed as SQL; a well-formed
+//     list with any unsupported ID makes the whole thing a regular comment.
+// ---------------------------------------------------------------------------
+
+func parseVerdict(t *testing.T, sql string) (nStmts int, err error) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("parser panicked on %q: %v", sql, r)
+		}
+	}()
+	list, perr := Parse(sql)
+	if perr != nil {
+		return 0, perr
+	}
+	return list.Len(), nil
+}
+
+func TestBlockCommentNonNesting(t *testing.T) {
+	tests := []struct {
+		sql      string
+		wantErr  bool
+		wantLen  int
+	}{
+		// TiDB v8.5.5: accept — comment ends at first */, "1" is the select item.
+		{"SELECT /* a /* b */ 1", false, 1},
+		// TiDB v8.5.5: accept, 1 row — the SELECT after the comment executes.
+		// omni used to swallow it (0 statements parsed = silent statement loss).
+		{"/* a /* b */ SELECT 1", false, 1},
+		{"/* a /* b */ SELECT 1; SELECT 2", false, 2},
+		{"SELECT /* a /* b */ 1; SELECT 2", false, 2},
+		{"SELECT /* a /* b */ /* c */ 1", false, 1},
+		// Unsupported-feature /*T! is a regular comment: also non-nesting.
+		{"SELECT /*T![unsupported_feature_xyz] a /* b */ 1", false, 1},
+		// TiDB v8.5.5: reject 1064 near "*/ SELECT 1".
+		{"/*T![unsupported_feature_xyz] a /* b */ */ SELECT 1", true, 0},
+		// Comment then empty statement then SELECT: TiDB executes SELECT 2.
+		{"/* a /* b */ ; SELECT 2", false, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.sql, func(t *testing.T) {
+			n, err := parseVerdict(t, tt.sql)
+			if tt.wantErr && err == nil {
+				t.Fatalf("want parse error, got %d stmts", n)
+			}
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("want %d stmts, got error: %v", tt.wantLen, err)
+				}
+				if n != tt.wantLen {
+					t.Fatalf("want %d stmts, got %d", tt.wantLen, n)
+				}
+			}
+		})
+	}
+}
+
+func TestBlockCommentUnterminated(t *testing.T) {
+	// TiDB v8.5.5 rejects all of these with 1064 (unclosed regular comment).
+	for _, sql := range []string{
+		"SELECT 1 /*",
+		"SELECT 1 /* unterminated",
+		"SELECT 1 /**",
+		"SELECT /** / 1",
+		"/* only a comment",
+		"SELECT 1 /*M! x",
+		"SELECT 1 /* x */; SELECT 2 /* unterminated",
+		// Well-formed but unsupported feature list downgrades to a regular
+		// comment, so unclosed is an error too.
+		"SELECT /*T![unsupported_xyz] 1",
+	} {
+		t.Run(sql, func(t *testing.T) {
+			if n, err := parseVerdict(t, sql); err == nil {
+				t.Fatalf("want parse error for unclosed comment, got %d stmts", n)
+			}
+		})
+	}
+}
+
+func TestBangCommentUnterminated(t *testing.T) {
+	// TiDB v8.5.5 ACCEPTS an unclosed /*! or supported /*T! construct: the
+	// content is already lexed as SQL, EOF just ends it. omni used to panic
+	// (slice out of range) on /*! and to swallow /*T! to end of input.
+	tests := []struct {
+		sql     string
+		wantLen int
+	}{
+		{"SELECT /*! 1", 1},
+		{"SELECT /*!50000 1", 1},
+		{"/*! SELECT 1", 1},
+		{"SELECT /*T! 1", 1},
+		{"SELECT /*T![auto_rand] 1", 1},
+		{"/*T! SELECT 1", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.sql, func(t *testing.T) {
+			n, err := parseVerdict(t, tt.sql)
+			if err != nil {
+				t.Fatalf("want accept (%d stmts), got error: %v", tt.wantLen, err)
+			}
+			if n != tt.wantLen {
+				t.Fatalf("want %d stmts, got %d", tt.wantLen, n)
+			}
+		})
+	}
+	// Unclosed bang construct whose content ends inside a regular comment:
+	// TiDB rejects (the inner /* c never closes).
+	if n, err := parseVerdict(t, "SELECT /*! 1 /* c"); err == nil {
+		t.Fatalf("want parse error (unclosed inner comment), got %d stmts", n)
+	}
+}
+
+func TestBangCommentVersionDigits(t *testing.T) {
+	// scanVersionDigits(5,5): exactly five digits are the version prefix;
+	// fewer-than-five or the sixth-and-later digits are SQL content.
+	tests := []struct {
+		sql     string
+		wantErr bool
+	}{
+		{"SELECT /*!123 */", false},     // content "123": SELECT 123
+		{"SELECT /*!1234567 */", false}, // "12345" version, content "67"
+		{"SELECT /*!523456 */", false},  // "52345" version, content "6"
+		{"SELECT /*!12345 6 */", false}, // classic versioned comment
+		{"SELECT /*!m 1 */", true},      // no digits: content "m 1" → SELECT m 1 rejects
+	}
+	for _, tt := range tests {
+		t.Run(tt.sql, func(t *testing.T) {
+			n, err := parseVerdict(t, tt.sql)
+			if tt.wantErr && err == nil {
+				t.Fatalf("want parse error, got %d stmts", n)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("want accept, got error: %v", err)
+			}
+		})
+	}
+}
+
+func TestBangCommentContentScanning(t *testing.T) {
+	tests := []struct {
+		sql     string
+		wantErr bool
+	}{
+		// */ hidden inside string literals, line comments, backtick idents,
+		// and inner regular comments does not close the construct.
+		{"SELECT /*! '*/' */", false},
+		{"SELECT /*!50000 1 # */\n */", false},
+		{"SELECT /*!50000 1 -- */\n */", false},
+		{"SELECT /*! 1 AS `*/` */ FROM (SELECT 1) t", false},
+		{"SELECT /*!50000 1 /* c */ + 1 */", false},
+		{"SELECT /*T! 1 /* c */ + 1 */", false},
+		// Nested bang markers do not stack: TiDB's inBangComment is a bool,
+		// so the first unconsumed */ closes everything and the trailing */
+		// is a syntax error. TiDB v8.5.5: reject 1064 near "/".
+		{"SELECT /*!50000 1 /*!50000 + 1 */ */", true},
+		{"SELECT /*T! 1 /*T! + 1 */ */", true},
+		// Multi-statement inside a versioned comment splits as SQL.
+		{"SELECT /*!50000 1; SELECT 2 */", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.sql, func(t *testing.T) {
+			n, err := parseVerdict(t, tt.sql)
+			if tt.wantErr && err == nil {
+				t.Fatalf("want parse error, got %d stmts", n)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("want accept, got error: %v", err)
+			}
+		})
+	}
+}
+
+func TestTiDBFeatureCommentFSM(t *testing.T) {
+	tests := []struct {
+		sql     string
+		wantErr bool
+	}{
+		// Malformed bracket lists reset: content starts at '[' and is lexed
+		// as SQL, which rejects. TiDB v8.5.5: 1064 near "[...".
+		{"SELECT /*T![] 1 */", true},
+		{"SELECT /*T![abc 1 */", true},
+		{"SELECT /*T![abc,] 1 */", true},
+		// No bracket at all: bang mode, content right after T!.
+		{"SELECT /*T! 1 */", false},
+		{"SELECT /*T!50000 1 */", true}, // content "50000 1" → SELECT 50000 1 rejects
+		// Well-formed, all-supported list (v8.5.5 has 9 feature IDs).
+		{"SELECT /*T![auto_rand,ttl] 1 + 1 */", false},
+		{"SELECT /*T![force_inc] 1 */", false},
+		{"SELECT /*T![affinity] 1 */", false},
+		{"SELECT /*T![global_index] 1 */", false},
+		// Lowercase /*t! is never special: regular comment, so the select
+		// list vanishes and the bare SELECT rejects (TiDB: 1064 near "").
+		{"SELECT /*t! 1 */", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.sql, func(t *testing.T) {
+			n, err := parseVerdict(t, tt.sql)
+			if tt.wantErr && err == nil {
+				t.Fatalf("want parse error, got %d stmts", n)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("want accept, got error: %v", err)
+			}
+		})
+	}
+}
+
+func TestGlobalIndexCommentPreserved(t *testing.T) {
+	// v8.5.5 supports global_index; with a stale feature list the comment
+	// body (NONCLUSTERED) was silently dropped from the AST.
+	sql := "CREATE TABLE tgi (a BIGINT PRIMARY KEY /*T![global_index] NONCLUSTERED */)"
+	list, err := Parse(sql)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if list.Len() != 1 {
+		t.Fatalf("want 1 stmt, got %d", list.Len())
+	}
+	// NONCLUSTERED sets the tri-state clustered flag to false; without the
+	// comment the outfunc omits the field entirely.
+	out := ast.NodeToString(list.Items[0])
+	if !strings.Contains(out, ":clustered f") {
+		t.Errorf("NONCLUSTERED from /*T![global_index] */ comment lost: %s", out)
+	}
+}
+
+// Known, deliberate divergences from TiDB v8.5.5 (parked leniencies, both
+// reject-only on the TiDB side — omni accepting is fail-safe because the
+// engine remains the final validity gate):
+//  1. TiDB's Scanner.Lex lookahead for AS OF / TO TIMESTAMP / MEMBER OF
+//     corrupts inBangComment when the token before the closing */ is
+//     AS/TO/MEMBER (getNextToken restores the reader but not the flag), so
+//     TiDB rejects e.g. `SELECT /*! 1 AS */ x`. omni closes the construct
+//     cleanly and accepts.
+//  2. omni tolerates unclosed string literals (`SELECT '1`), so bang content
+//     ending in an unclosed string (`SELECT /*! '1 */`) parses as a string
+//     where TiDB rejects. Pre-existing lexer-wide leniency, tracked
+//     separately from comment handling.
+//  3. omni accepts `SELECT * / 1` (raw input, container-verified TiDB 1064),
+//     so a trailing */ after a closed comment in select-item position
+//     (`SELECT /* a /* b */ */ 1`) parses even though the token stream now
+//     matches TiDB. Pre-existing select-grammar leniency.
+func TestBangCommentParkedLeniencies(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT /*! 1 AS */ x",      // TiDB: 1064 via lookahead state corruption
+		"SELECT /*! '1 */",          // TiDB: 1064 via unclosed-string detection
+		"SELECT /* a /* b */ */ 1",  // TiDB: 1064 near "/ 1" (SELECT * / 1 shape)
+	} {
+		t.Run(sql, func(t *testing.T) {
+			if _, err := parseVerdict(t, sql); err != nil {
+				t.Fatalf("parked leniency regressed to reject: %v", err)
+			}
+		})
+	}
+}
+
+func TestBangCommentSpliceTokenBoundaries(t *testing.T) {
+	// Stripped markers and the closing */ are token boundaries in TiDB, so
+	// the splice must not butt adjacent content bytes together
+	// (container-verified against TiDB v8.5.5).
+	t.Run("stripped marker cannot reconstruct a comment opener", func(t *testing.T) {
+		// TiDB lexes 2 / * 3 * / and rejects 1064; naive zero-byte marker
+		// stripping produced "2/ *3" -> phantom /* -> accepted as SELECT 2.
+		if n, err := parseVerdict(t, "SELECT /*! 2//*!50000*3*/ */"); err == nil {
+			t.Fatalf("want parse error, got %d stmts", n)
+		}
+	})
+	t.Run("closing */ separates content and suffix tokens", func(t *testing.T) {
+		// TiDB: x aliased YZ (two tokens). A seamless splice merged them
+		// into one column reference xYZ (silent wrong AST).
+		list, err := Parse("SELECT /*!50000 x*/YZ FROM (SELECT 1 AS x) t")
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		out := ast.NodeToString(list.Items[0])
+		if strings.Contains(out, "xYZ") {
+			t.Errorf("content and suffix merged into one token: %s", out)
+		}
+	})
+	t.Run("ident butted against closer stays separate", func(t *testing.T) {
+		// TiDB: SELECT SELE CT parses (SELE aliased CT, unknown column at
+		// exec is still a parse-accept).
+		if _, err := parseVerdict(t, "SELECT/*!50000 SELE*/CT"); err != nil {
+			t.Fatalf("want accept, got: %v", err)
+		}
+	})
+	t.Run("marker replacement does not join operators", func(t *testing.T) {
+		// TiDB: 1 - (-2) = 3; the two dashes must not become -- (comment).
+		if _, err := parseVerdict(t, "SELECT 1 -/*!50000- 2 */"); err != nil {
+			t.Fatalf("want accept, got: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
Wave 0 of the TiDB GAP burn-down (full-compat directive): container-verified rewrite of the block-comment lexer against the pinned `pingcap/tidb:v8.5.5` oracle.

## What was wrong

TiDB block comments do **not** nest — the first `*/` closes — and unclosed regular comments are parse errors. omni's nesting depth-scan diverged in both directions, plus a crash:

- **GAP / silent statement loss**: `/* a /* b */ SELECT 1` — TiDB executes the SELECT; omni swallowed it as comment (parsed to **0 statements**, invisible to every downstream consumer).
- **OVER**: `SELECT 1 /* unterminated` accepted; TiDB rejects 1064.
- **P1 panic on main**: `SELECT /*! 1` (unclosed `/*!`) → `slice bounds out of range` in the splice tail.
- **Wrong AST**: `/*T![global_index] GLOBAL */` and `/*T![affinity] ...` content silently dropped — the v8.5 feature list was missing `force_inc`, `global_index`, `affinity`.

## What changed

- Regular comments end at the first `*/`; unclosed → `tokInvalid` parse error (TiDB 1064 parity). Same non-nesting fix in `Split`'s `skipBlockCommentMySQL`, and a segment holding an unclosed comment now reaches the lexer instead of being dropped as empty.
- Bang comments (`/*!`, supported `/*T!`): content spliced as SQL. The closing `*/` is found with a string/backtick/line-comment/inner-comment-aware scan (those hide `*/` in TiDB since content is lexed as SQL); unclosed constructs are tolerated exactly like TiDB's EOF-in-bang-mode (fixes the panic). Inner bang markers and the closing `*/` splice to a single space so butted tokens stay separate (`x*/YZ` lexes as `x` then `YZ`; markers can't reconstruct phantom `/*` openers).
- `/*!NNNNN` consumes exactly five version digits or none (`scanVersionDigits(5,5)` parity).
- `/*T![...]` feature lists follow `scanFeatureIDs` byte-for-byte: malformed lists reset and lex from `[` as content; well-formed lists with an unsupported ID downgrade to a regular comment. Feature map synced to v8.5.5.

## Deliberate parked leniencies (documented in `TestBangCommentParkedLeniencies`, all reject-only on TiDB's side, fail-safe)

1. TiDB's `Scanner.Lex` lookahead for `AS OF`/`TO TIMESTAMP`/`MEMBER OF` corrupts `inBangComment` when `AS`/`TO`/`MEMBER` precedes the closing `*/` (`getNextToken` restores the reader but not the flag) — an upstream bug we don't emulate.
2. omni's lexer-wide unclosed-string tolerance (`SELECT '1` parses) — pre-existing, tracked separately.
3. `SELECT * / 1`-class select-grammar acceptance — pre-existing, surfaces as trailing `*/` after a closed comment.

## Verification

- Container-grounded TDD: 35 RED subtests written from live-probe ground truth, all GREEN after the fix.
- **520-probe generated reject-space sweep** + 57-probe hand battery vs the live oracle: zero non-parked parse-level divergences, zero panics.
- Adversarial splice audit: backtrack snapshots capture `l.input` (splices are restore-safe), all raw-text captures go through clamped `inputText`, splicing is idempotent; the audit's one real finding (zero-byte marker strip could reconstruct a phantom `/*`) is fixed by the space-padding and regression-tested.
- `go vet ./tidb/...` clean; `go test ./tidb/...` green except the **pre-existing** `tidb/catalog` non-short container tests (collation-rendering mismatch, fails identically on main; `-short` lane green).

## Scoreboard delta (adjudicated sweep, committed)

- AGREE_REJECT +3: both unterminated-comment OVER clusters now correctly reject.
- AGREE_ACCEPT −4 / GAP +4: the feature-list sync un-masks four wrong-AST acceptances (`GLOBAL` index option, `AFFINITY` table option previously dropped silently). Honest accounting — the grammar gaps are owned by wave-3 burn-down items (`index-global-local-options`, `tidb-table-options-parity`).
- OVER clusters 46 → 44.

Mirror-back note: omni/mysql shares the fork-parent nesting comment scanner and the missing `||`-era gaps do not apply here, but the non-nesting + unclosed-comment behavior is MySQL semantics too — candidate for the mysql lane (Jonathan), minus the TiDB-only `/*T!` machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)