### PR TITLE
oracle: parse PIVOT/UNPIVOT inside the table_reference chain

### DIFF
--- a/oracle/ast/outfuncs.go
+++ b/oracle/ast/outfuncs.go
@@ -2322,14 +2322,6 @@ func writeSelectStmt(sb *strings.Builder, n *SelectStmt) {
 		sb.WriteString(" :fetchFirst ")
 		writeNode(sb, n.FetchFirst)
 	}
-	if n.Pivot != nil {
-		sb.WriteString(" :pivot ")
-		writeNode(sb, n.Pivot)
-	}
-	if n.Unpivot != nil {
-		sb.WriteString(" :unpivot ")
-		writeNode(sb, n.Unpivot)
-	}
 	if n.Op != SETOP_NONE {
 		sb.WriteString(fmt.Sprintf(" :op %d", n.Op))
 	}

--- a/oracle/ast/outfuncs.go
+++ b/oracle/ast/outfuncs.go
@@ -1335,6 +1335,10 @@ func writePivotClause(sb *strings.Builder, n *PivotClause) {
 		sb.WriteString(" :inList ")
 		writeNode(sb, n.InList)
 	}
+	if n.Source != nil {
+		sb.WriteString(" :source ")
+		writeNode(sb, n.Source)
+	}
 	if n.Alias != nil {
 		sb.WriteString(" :alias ")
 		writeNode(sb, n.Alias)
@@ -1359,6 +1363,10 @@ func writeUnpivotClause(sb *strings.Builder, n *UnpivotClause) {
 	}
 	if n.IncludeNulls {
 		sb.WriteString(" :includeNulls true")
+	}
+	if n.Source != nil {
+		sb.WriteString(" :source ")
+		writeNode(sb, n.Source)
 	}
 	if n.Alias != nil {
 		sb.WriteString(" :alias ")

--- a/oracle/ast/parsenodes.go
+++ b/oracle/ast/parsenodes.go
@@ -998,8 +998,6 @@ type SelectStmt struct {
 	SiblingsOrder bool                // ORDER SIBLINGS BY
 	ForUpdate     *ForUpdateClause    // FOR UPDATE
 	FetchFirst    *FetchFirstClause   // FETCH FIRST / OFFSET
-	Pivot         *PivotClause        // PIVOT clause
-	Unpivot       *UnpivotClause      // UNPIVOT clause
 	Hints         *List               // optimizer hints (list of *Hint)
 
 	// Set operations

--- a/oracle/ast/walk_generated.go
+++ b/oracle/ast/walk_generated.go
@@ -729,10 +729,10 @@ func walkChildren(v Visitor, node Node) {
 		walkList(v, n.Options)
 	case *CubeClause:
 		walkList(v, n.Args)
-	case *CursorExpr:
-		Walk(v, n.Subquery)
 	case *CursorAttributeExpr:
 		Walk(v, n.Cursor)
+	case *CursorExpr:
+		Walk(v, n.Subquery)
 	case *DDLOption:
 		walkList(v, n.Items)
 	case *DatafileClause:
@@ -836,6 +836,8 @@ func walkChildren(v Visitor, node Node) {
 	case *FetchFirstClause:
 		Walk(v, n.Offset)
 		Walk(v, n.Count)
+	case *FieldAccessExpr:
+		Walk(v, n.Expr)
 	case *FlashbackClause:
 		Walk(v, n.Expr)
 		Walk(v, n.VersionsLow)
@@ -860,8 +862,6 @@ func walkChildren(v Visitor, node Node) {
 	case *ForUpdateClause:
 		walkList(v, n.Tables)
 		Walk(v, n.Wait)
-	case *FieldAccessExpr:
-		Walk(v, n.Expr)
 	case *FuncCallExpr:
 		if n.FuncName != nil {
 			Walk(v, n.FuncName)
@@ -874,8 +874,6 @@ func walkChildren(v Visitor, node Node) {
 		if n.Over != nil {
 			Walk(v, n.Over)
 		}
-	case *NamedArgExpr:
-		Walk(v, n.Expr)
 	case *GrantStmt:
 		walkList(v, n.Privileges)
 		if n.OnObject != nil {
@@ -1103,6 +1101,8 @@ func walkChildren(v Visitor, node Node) {
 	case *MultisetExpr:
 		Walk(v, n.Left)
 		Walk(v, n.Right)
+	case *NamedArgExpr:
+		Walk(v, n.Expr)
 	case *NoauditStmt:
 		if n.Object != nil {
 			Walk(v, n.Object)
@@ -1290,12 +1290,6 @@ func walkChildren(v Visitor, node Node) {
 		}
 		if n.FetchFirst != nil {
 			Walk(v, n.FetchFirst)
-		}
-		if n.Pivot != nil {
-			Walk(v, n.Pivot)
-		}
-		if n.Unpivot != nil {
-			Walk(v, n.Unpivot)
 		}
 		walkList(v, n.Hints)
 		if n.Larg != nil {

--- a/oracle/parser/bytebase_oracle_ast_test.go
+++ b/oracle/parser/bytebase_oracle_ast_test.go
@@ -48,24 +48,25 @@ func TestBytebasePivotTypedOutputShape(t *testing.T) {
 		t.Fatalf("expected SelectStmt")
 	}
 
-	if stmt.Pivot == nil {
-		t.Fatal("expected PIVOT")
+	pivot, ok := stmt.FromClause.Items[0].(*ast.PivotClause)
+	if !ok {
+		t.Fatalf("expected PivotClause as from-item, got %T", stmt.FromClause.Items[0])
 	}
-	if stmt.Pivot.Aggregates == nil || stmt.Pivot.Aggregates.Len() != 2 {
-		t.Fatalf("expected 2 typed aggregates, got %v", stmt.Pivot.Aggregates)
+	if pivot.Aggregates == nil || pivot.Aggregates.Len() != 2 {
+		t.Fatalf("expected 2 typed aggregates, got %v", pivot.Aggregates)
 	}
-	agg := stmt.Pivot.Aggregates.Items[0].(*ast.PivotAggregate)
+	agg := pivot.Aggregates.Items[0].(*ast.PivotAggregate)
 	if agg.Alias != "TOTAL" {
 		t.Fatalf("aggregate alias = %q, want TOTAL", agg.Alias)
 	}
-	if stmt.Pivot.InItems == nil || stmt.Pivot.InItems.Len() != 2 {
-		t.Fatalf("expected 2 pivot in-items, got %v", stmt.Pivot.InItems)
+	if pivot.InItems == nil || pivot.InItems.Len() != 2 {
+		t.Fatalf("expected 2 pivot in-items, got %v", pivot.InItems)
 	}
-	in := stmt.Pivot.InItems.Items[0].(*ast.PivotInItem)
+	in := pivot.InItems.Items[0].(*ast.PivotInItem)
 	if in.Alias != "Q1" || in.Values == nil || in.Values.Len() != 1 {
 		t.Fatalf("unexpected pivot in-item: %+v", in)
 	}
-	if stmt.Pivot.Source == nil {
+	if pivot.Source == nil {
 		t.Fatal("expected PIVOT source table expression")
 	}
 }
@@ -76,23 +77,24 @@ func TestBytebaseUnpivotTypedMappings(t *testing.T) {
 		t.Fatalf("expected SelectStmt")
 	}
 
-	if stmt.Unpivot == nil {
-		t.Fatal("expected UNPIVOT")
+	unpivot, ok := stmt.FromClause.Items[0].(*ast.UnpivotClause)
+	if !ok {
+		t.Fatalf("expected UnpivotClause as from-item, got %T", stmt.FromClause.Items[0])
 	}
-	if stmt.Unpivot.ValueColumns == nil || stmt.Unpivot.ValueColumns.Len() != 2 {
-		t.Fatalf("expected 2 value columns, got %v", stmt.Unpivot.ValueColumns)
+	if unpivot.ValueColumns == nil || unpivot.ValueColumns.Len() != 2 {
+		t.Fatalf("expected 2 value columns, got %v", unpivot.ValueColumns)
 	}
-	if stmt.Unpivot.InputMappings == nil || stmt.Unpivot.InputMappings.Len() != 2 {
-		t.Fatalf("expected 2 input mappings, got %v", stmt.Unpivot.InputMappings)
+	if unpivot.InputMappings == nil || unpivot.InputMappings.Len() != 2 {
+		t.Fatalf("expected 2 input mappings, got %v", unpivot.InputMappings)
 	}
-	mapping := stmt.Unpivot.InputMappings.Items[0].(*ast.UnpivotInItem)
+	mapping := unpivot.InputMappings.Items[0].(*ast.UnpivotInItem)
 	if mapping.InputColumns == nil || mapping.InputColumns.Len() != 2 {
 		t.Fatalf("expected 2 input columns, got %v", mapping.InputColumns)
 	}
 	if mapping.Alias != "Q1" {
 		t.Fatalf("mapping alias = %q, want Q1", mapping.Alias)
 	}
-	if stmt.Unpivot.Source == nil {
+	if unpivot.Source == nil {
 		t.Fatal("expected UNPIVOT source table expression")
 	}
 }

--- a/oracle/parser/pivot_alias_test.go
+++ b/oracle/parser/pivot_alias_test.go
@@ -1,0 +1,145 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/oracle/ast"
+)
+
+// Oracle's table_reference grammar places PIVOT/UNPIVOT between the
+// query_table_expression and the trailing t_alias:
+//
+//	table_reference ::= query_table_expression
+//	                    [ pivot_clause | unpivot_clause ] [ t_alias ]
+//
+// so the pivoted result can carry a bare-identifier alias and participate in
+// joins like any other from-item. t_alias takes NO "AS" keyword and no column
+// alias list. All shapes below verified against Oracle 23ai Free.
+
+func fromItem(t *testing.T, sql string) ast.Node {
+	t.Helper()
+	stmt, ok := rawStmt(t, sql).(*ast.SelectStmt)
+	if !ok {
+		t.Fatalf("expected SelectStmt")
+	}
+	if stmt.FromClause == nil || stmt.FromClause.Len() != 1 {
+		t.Fatalf("expected 1 from-item, got %v", stmt.FromClause)
+	}
+	return stmt.FromClause.Items[0]
+}
+
+func TestPivotTableAlias(t *testing.T) {
+	item := fromItem(t, `SELECT p.a FROM t1 PIVOT (SUM(b) FOR m IN (1, 2, 3)) p`)
+	pc, ok := item.(*ast.PivotClause)
+	if !ok {
+		t.Fatalf("expected PivotClause from-item, got %T", item)
+	}
+	if pc.Alias == nil || pc.Alias.Name != "P" {
+		t.Fatalf("pivot alias = %v, want P", pc.Alias)
+	}
+	if _, ok := pc.Source.(*ast.TableRef); !ok {
+		t.Fatalf("pivot source = %T, want *TableRef", pc.Source)
+	}
+}
+
+func TestPivotSubqueryAliasReferencedInOrderBy(t *testing.T) {
+	// The originally reported shape: (subquery) PIVOT (...) alias, with the
+	// alias qualifying select-list and ORDER BY references.
+	sql := `SELECT p.a, p.c1 FROM (SELECT a, b, m FROM t1 WHERE b > 0) PIVOT (SUM(b) FOR m IN (1 AS c1, 2 AS c2)) p ORDER BY p.a`
+	item := fromItem(t, sql)
+	pc, ok := item.(*ast.PivotClause)
+	if !ok {
+		t.Fatalf("expected PivotClause from-item, got %T", item)
+	}
+	if pc.Alias == nil || pc.Alias.Name != "P" {
+		t.Fatalf("pivot alias = %v, want P", pc.Alias)
+	}
+	if _, ok := pc.Source.(*ast.SubqueryRef); !ok {
+		t.Fatalf("pivot source = %T, want *SubqueryRef", pc.Source)
+	}
+}
+
+func TestUnpivotAlias(t *testing.T) {
+	item := fromItem(t, `SELECT u.q, u.v FROM t1 UNPIVOT (v FOR q IN (c1, c2, c3)) u`)
+	uc, ok := item.(*ast.UnpivotClause)
+	if !ok {
+		t.Fatalf("expected UnpivotClause from-item, got %T", item)
+	}
+	if uc.Alias == nil || uc.Alias.Name != "U" {
+		t.Fatalf("unpivot alias = %v, want U", uc.Alias)
+	}
+	if _, ok := uc.Source.(*ast.TableRef); !ok {
+		t.Fatalf("unpivot source = %T, want *TableRef", uc.Source)
+	}
+}
+
+func TestPivotXMLAlias(t *testing.T) {
+	item := fromItem(t, `SELECT x.a FROM t1 PIVOT XML (SUM(b) FOR m IN (ANY)) x`)
+	pc, ok := item.(*ast.PivotClause)
+	if !ok {
+		t.Fatalf("expected PivotClause from-item, got %T", item)
+	}
+	if !pc.XML {
+		t.Fatal("expected XML pivot")
+	}
+	if pc.Alias == nil || pc.Alias.Name != "X" {
+		t.Fatalf("pivot xml alias = %v, want X", pc.Alias)
+	}
+}
+
+func TestPivotJoinParticipation(t *testing.T) {
+	item := fromItem(t, `SELECT p.a, d.name FROM t1 PIVOT (SUM(b) FOR m IN (1, 2)) p JOIN d ON p.a = d.a`)
+	jc, ok := item.(*ast.JoinClause)
+	if !ok {
+		t.Fatalf("expected JoinClause from-item, got %T", item)
+	}
+	pc, ok := jc.Left.(*ast.PivotClause)
+	if !ok {
+		t.Fatalf("join left = %T, want *PivotClause", jc.Left)
+	}
+	if pc.Alias == nil || pc.Alias.Name != "P" {
+		t.Fatalf("pivot alias = %v, want P", pc.Alias)
+	}
+}
+
+func TestPivotAliasRejectsASAndColumnList(t *testing.T) {
+	// t_alias is a bare identifier: no AS keyword, no column alias list.
+	// Oracle raises ORA-00933 on both.
+	for _, sql := range []string{
+		`SELECT * FROM t1 PIVOT (SUM(b) FOR m IN (1, 2)) AS p`,
+		`SELECT * FROM t1 PIVOT (SUM(b) FOR m IN (1, 2)) p(x, y)`,
+	} {
+		if _, err := Parse(sql); err == nil {
+			t.Errorf("expected parse error for %q", sql)
+		}
+	}
+}
+
+func TestPivotAliasInsidePLSQLCursor(t *testing.T) {
+	// The reported failure surfaced inside a function body: OPEN ... FOR a
+	// pivoted subquery with a trailing alias.
+	sql := `CREATE OR REPLACE FUNCTION f_report(p_from DATE, p_to DATE) RETURN SYS_REFCURSOR IS
+  v_cur SYS_REFCURSOR;
+BEGIN
+  OPEN v_cur FOR
+    SELECT p.a, p.c1, p.c2
+    FROM (SELECT a, b, m FROM t1 WHERE d BETWEEN p_from AND p_to) PIVOT (SUM(b) FOR m IN (1 AS c1, 2 AS c2)) p
+    ORDER BY p.a;
+  RETURN v_cur;
+END;`
+	result := ParseAndCheck(t, sql)
+	if result.Len() != 1 {
+		t.Fatalf("expected 1 statement, got %d", result.Len())
+	}
+}
+
+func TestPivotAliasOutputShape(t *testing.T) {
+	// The pivoted from-item serializes with its alias so downstream consumers
+	// (span extraction) can resolve alias-qualified column references.
+	stmt := rawStmt(t, `SELECT p.a FROM t1 PIVOT (SUM(b) FOR m IN (1, 2)) p`)
+	out := ast.NodeToString(stmt)
+	if !strings.Contains(out, ":alias") {
+		t.Fatalf("expected :alias in output, got %s", out)
+	}
+}

--- a/oracle/parser/pivot_alias_test.go
+++ b/oracle/parser/pivot_alias_test.go
@@ -135,11 +135,107 @@ END;`
 }
 
 func TestPivotAliasOutputShape(t *testing.T) {
-	// The pivoted from-item serializes with its alias so downstream consumers
-	// (span extraction) can resolve alias-qualified column references.
+	// The pivoted from-item serializes with its alias AND its source: the
+	// base relation now lives only in PivotClause.Source, so dropping it
+	// from outfuncs would lose the table entirely.
 	stmt := rawStmt(t, `SELECT p.a FROM t1 PIVOT (SUM(b) FOR m IN (1, 2)) p`)
 	out := ast.NodeToString(stmt)
-	if !strings.Contains(out, ":alias") {
-		t.Fatalf("expected :alias in output, got %s", out)
+	for _, want := range []string{":alias", ":source", "T1"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %s in output, got %s", want, out)
+		}
+	}
+
+	stmt = rawStmt(t, `SELECT u.q FROM t1 UNPIVOT (v FOR q IN (c1, c2)) u`)
+	out = ast.NodeToString(stmt)
+	for _, want := range []string{":alias", ":source", "T1"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %s in unpivot output, got %s", want, out)
+		}
+	}
+}
+
+// Oracle accepts pivot_clause / unpivot_clause after every
+// query_table_expression form below (verified on 23ai Free), so each source
+// parser must feed the pivot suffix rather than returning early.
+func TestPivotAfterEveryTableSource(t *testing.T) {
+	sources := []struct {
+		name string
+		from string
+	}{
+		{"table", `t1`},
+		{"subquery", `(SELECT a, b, m FROM t1)`},
+		{"parenthesized table", `(t1)`},
+		{"table collection", `TABLE(f())`},
+		{"xmltable", `XMLTABLE('/r' PASSING x COLUMNS m NUMBER PATH '@m', b NUMBER PATH '@b')`},
+		{"json_table", `JSON_TABLE(j, '$[*]' COLUMNS (m NUMBER PATH '$.m', b NUMBER PATH '$.b'))`},
+		{"containers", `CONTAINERS(t1)`},
+		{"shards", `SHARDS(t1)`},
+		{"sample", `t1 SAMPLE (10)`},
+		{"flashback", `t1 AS OF SCN 1`},
+		{"match_recognize", `t1 MATCH_RECOGNIZE (MEASURES 1 AS m ALL ROWS PER MATCH PATTERN (a) DEFINE a AS 1 = 1)`},
+	}
+	suffixes := []struct {
+		name   string
+		suffix string
+	}{
+		{"pivot", `PIVOT (SUM(b) FOR m IN (1, 2)) p`},
+		{"unpivot", `UNPIVOT (v FOR q IN (m, b)) u`},
+	}
+	for _, src := range sources {
+		for _, sfx := range suffixes {
+			t.Run(src.name+"/"+sfx.name, func(t *testing.T) {
+				sql := `SELECT * FROM ` + src.from + ` ` + sfx.suffix
+				if _, err := Parse(sql); err != nil {
+					t.Fatalf("parse failed: %v; sql: %s", err, sql)
+				}
+			})
+		}
+	}
+}
+
+func TestPivotChaining(t *testing.T) {
+	// Oracle chains pivot/unpivot clauses, optionally aliased per step.
+	for _, sql := range []string{
+		`SELECT * FROM t1 PIVOT (SUM(b) FOR m IN (1, 2)) PIVOT (COUNT(*) FOR a IN (1))`,
+		`SELECT * FROM t1 PIVOT (SUM(b) FOR m IN (1, 2)) p PIVOT (COUNT(*) FOR a IN (1)) q`,
+		`SELECT * FROM t1 PIVOT (SUM(b) FOR m IN (1, 2)) UNPIVOT (v FOR q IN (a))`,
+	} {
+		if _, err := Parse(sql); err != nil {
+			t.Errorf("parse failed: %v; sql: %s", err, sql)
+		}
+	}
+	// The chain nests: outer clause's Source is the inner clause.
+	item := fromItem(t, `SELECT * FROM t1 PIVOT (SUM(b) FOR m IN (1)) p PIVOT (COUNT(*) FOR a IN (1)) q`)
+	outer, ok := item.(*ast.PivotClause)
+	if !ok {
+		t.Fatalf("expected outer PivotClause, got %T", item)
+	}
+	if outer.Alias == nil || outer.Alias.Name != "Q" {
+		t.Fatalf("outer alias = %v, want Q", outer.Alias)
+	}
+	inner, ok := outer.Source.(*ast.PivotClause)
+	if !ok {
+		t.Fatalf("outer source = %T, want inner *PivotClause", outer.Source)
+	}
+	if inner.Alias == nil || inner.Alias.Name != "P" {
+		t.Fatalf("inner alias = %v, want P", inner.Alias)
+	}
+}
+
+func TestIncompletePivotRejected(t *testing.T) {
+	// PIVOT/UNPIVOT not followed by the clause body must not silently become
+	// an empty clause plus an alias (Oracle: ORA-03049 on `PIVOT p`).
+	// LATERAL views cannot be pivoted at all (Oracle: ORA-56905).
+	for _, sql := range []string{
+		`SELECT * FROM t1 PIVOT p`,
+		`SELECT * FROM t1 PIVOT`,
+		`SELECT * FROM t1 UNPIVOT u`,
+		`SELECT * FROM t1 PIVOT XML junk`,
+		`SELECT * FROM LATERAL (SELECT a, m FROM t1) PIVOT (SUM(a) FOR m IN (1))`,
+	} {
+		if _, err := Parse(sql); err == nil {
+			t.Errorf("expected parse error for %q", sql)
+		}
 	}
 }

--- a/oracle/parser/pivot_alias_test.go
+++ b/oracle/parser/pivot_alias_test.go
@@ -225,17 +225,55 @@ func TestPivotChaining(t *testing.T) {
 
 func TestIncompletePivotRejected(t *testing.T) {
 	// PIVOT/UNPIVOT not followed by the clause body must not silently become
-	// an empty clause plus an alias (Oracle: ORA-03049 on `PIVOT p`).
+	// an empty clause plus an alias (Oracle: ORA-03049 on `PIVOT p`), and the
+	// body itself requires FOR (ORA-02000) and IN (ORA-01738).
 	// LATERAL views cannot be pivoted at all (Oracle: ORA-56905).
 	for _, sql := range []string{
 		`SELECT * FROM t1 PIVOT p`,
 		`SELECT * FROM t1 PIVOT`,
 		`SELECT * FROM t1 UNPIVOT u`,
 		`SELECT * FROM t1 PIVOT XML junk`,
+		`SELECT * FROM t1 PIVOT (SUM(b)) p`,
+		`SELECT * FROM t1 PIVOT (SUM(b) FOR m) p`,
+		`SELECT * FROM t1 UNPIVOT (v) u`,
+		`SELECT * FROM t1 UNPIVOT (v FOR q) u`,
 		`SELECT * FROM LATERAL (SELECT a, m FROM t1) PIVOT (SUM(a) FOR m IN (1))`,
 	} {
 		if _, err := Parse(sql); err == nil {
 			t.Errorf("expected parse error for %q", sql)
 		}
+	}
+}
+
+func TestPivotAfterSourceAlias(t *testing.T) {
+	// Oracle accepts the pivot after an already-aliased source
+	// (t alias PIVOT (...) p), despite the documented grammar ordering the
+	// alias last. Verified on 23ai Free for all forms below.
+	for _, sql := range []string{
+		`SELECT * FROM t1 c PIVOT (SUM(b) FOR m IN (1, 2)) p`,
+		`SELECT * FROM (SELECT a, b, m FROM t1) c PIVOT (SUM(b) FOR m IN (1)) p`,
+		`SELECT * FROM (t1) c PIVOT (SUM(b) FOR m IN (1)) p`,
+		`SELECT * FROM TABLE(f()) c PIVOT (COUNT(*) FOR x IN (1)) p`,
+		`SELECT * FROM t1 c UNPIVOT (v FOR q IN (a, b)) u`,
+	} {
+		if _, err := Parse(sql); err != nil {
+			t.Errorf("parse failed: %v; sql: %s", err, sql)
+		}
+	}
+	// The aliased source stays intact under the pivot.
+	item := fromItem(t, `SELECT * FROM t1 c PIVOT (SUM(b) FOR m IN (1)) p`)
+	pc, ok := item.(*ast.PivotClause)
+	if !ok {
+		t.Fatalf("expected PivotClause from-item, got %T", item)
+	}
+	src, ok := pc.Source.(*ast.TableRef)
+	if !ok {
+		t.Fatalf("pivot source = %T, want *TableRef", pc.Source)
+	}
+	if src.Alias == nil || src.Alias.Name != "C" {
+		t.Fatalf("source alias = %v, want C", src.Alias)
+	}
+	if pc.Alias == nil || pc.Alias.Name != "P" {
+		t.Fatalf("pivot alias = %v, want P", pc.Alias)
 	}
 }

--- a/oracle/parser/select.go
+++ b/oracle/parser/select.go
@@ -635,17 +635,29 @@ func (p *Parser) parseTableRef() (nodes.TableExpr, error) {
 
 	// XMLTABLE(...)
 	if p.cur.Type == kwXMLTABLE {
-		return p.parseXmlTableRef(start)
+		ref, err := p.parseXmlTableRef(start)
+		if err != nil {
+			return nil, err
+		}
+		return p.parsePivotSuffix(ref)
 	}
 
 	// JSON_TABLE(...)
 	if p.cur.Type == kwJSON_TABLE {
-		return p.parseJsonTableRef(start)
+		ref, err := p.parseJsonTableRef(start)
+		if err != nil {
+			return nil, err
+		}
+		return p.parsePivotSuffix(ref)
 	}
 
 	// TABLE(collection_expression) — table collection expression
 	if p.cur.Type == kwTABLE && p.peekNext().Type == '(' {
-		return p.parseTableCollectionExpr(start)
+		ref, err := p.parseTableCollectionExpr(start)
+		if err != nil {
+			return nil, err
+		}
+		return p.parsePivotSuffix(ref)
 	}
 
 	// EXTERNAL ((columns) TYPE ... DEFAULT DIRECTORY ... LOCATION ...)
@@ -655,10 +667,18 @@ func (p *Parser) parseTableRef() (nodes.TableExpr, error) {
 
 	// CONTAINERS(table) or SHARDS(table)
 	if p.isIdentLikeStr("CONTAINERS") && p.peekNext().Type == '(' {
-		return p.parseContainersOrShards(start, false)
+		ref, err := p.parseContainersOrShards(start, false)
+		if err != nil {
+			return nil, err
+		}
+		return p.parsePivotSuffix(ref)
 	}
 	if p.isIdentLikeStr("SHARDS") && p.peekNext().Type == '(' {
-		return p.parseContainersOrShards(start, true)
+		ref, err := p.parseContainersOrShards(start, true)
+		if err != nil {
+			return nil, err
+		}
+		return p.parsePivotSuffix(ref)
 	}
 
 	// Subquery: ( SELECT ... )
@@ -672,7 +692,11 @@ func (p *Parser) parseTableRef() (nodes.TableExpr, error) {
 
 	// MATCH_RECOGNIZE as standalone (rare, usually post-table)
 	if p.isIdentLikeStr("MATCH_RECOGNIZE") {
-		return p.parseMatchRecognize(start)
+		ref, err := p.parseMatchRecognize(start)
+		if err != nil {
+			return nil, err
+		}
+		return p.parsePivotSuffix(ref)
 	}
 
 	// Table name
@@ -738,7 +762,7 @@ func (p *Parser) parseTableRef() (nodes.TableExpr, error) {
 		}
 	}
 
-	if p.cur.Type == kwPIVOT || p.cur.Type == kwUNPIVOT {
+	if p.pivotClauseAhead() || p.unpivotClauseAhead() {
 		tr.Loc.End = p.prev.End
 		return p.parsePivotSuffix(tr)
 	}
@@ -753,7 +777,7 @@ func (p *Parser) parseTableRef() (nodes.TableExpr, error) {
 			// Wrap: the table ref becomes the left side of a join-like construct
 			// For simplicity, return the MATCH_RECOGNIZE with the table ref embedded
 			mrClause.Source = tr
-			return mrRef, nil
+			return p.parsePivotSuffix(mrRef)
 		}
 	}
 
@@ -827,7 +851,7 @@ func (p *Parser) parseSubqueryRef(start int) (nodes.TableExpr, error) {
 		Loc:      nodes.Loc{Start: start},
 	}
 
-	if p.cur.Type == kwPIVOT || p.cur.Type == kwUNPIVOT {
+	if p.pivotClauseAhead() || p.unpivotClauseAhead() {
 		ref.Loc.End = p.prev.End
 		return p.parsePivotSuffix(ref)
 	}
@@ -871,7 +895,7 @@ func (p *Parser) parseParenthesizedTableRef(start int) (nodes.TableExpr, error) 
 	}
 	p.advance()
 
-	if p.cur.Type == kwPIVOT || p.cur.Type == kwUNPIVOT {
+	if p.pivotClauseAhead() || p.unpivotClauseAhead() {
 		return p.parsePivotSuffix(tref)
 	}
 
@@ -2226,45 +2250,72 @@ func (p *Parser) parseCTECycleClause() (*nodes.CTECycleClause, error) {
 	return cc, nil
 }
 
-// parsePivotSuffix attaches a PIVOT / UNPIVOT clause — with its optional
-// trailing t_alias — to a just-parsed table reference, per the table_reference
-// grammar: query_table_expression [pivot_clause | unpivot_clause] [t_alias].
-// The clause becomes the from-item itself (both implement TableExpr), so join
-// continuations and the alias participate in the FROM chain like any other
-// table reference. A bare identifier alias is accepted; AS stays rejected
-// (Oracle t_alias takes no AS keyword).
+// pivotClauseAhead reports whether the current position starts a real
+// pivot_clause: the PIVOT keyword followed by '(' or XML. PIVOT and UNPIVOT
+// are non-reserved in Oracle, so a trailing PIVOT not followed by its body is
+// an alias position, not a clause.
+func (p *Parser) pivotClauseAhead() bool {
+	if p.cur.Type != kwPIVOT {
+		return false
+	}
+	nxt := p.peekNext()
+	return nxt.Type == '(' || (nxt.Type == tokIDENT && strings.EqualFold(nxt.Str, "XML"))
+}
+
+// unpivotClauseAhead reports whether the current position starts a real
+// unpivot_clause: UNPIVOT followed by '(' or INCLUDE/EXCLUDE NULLS.
+func (p *Parser) unpivotClauseAhead() bool {
+	if p.cur.Type != kwUNPIVOT {
+		return false
+	}
+	nxt := p.peekNext()
+	return nxt.Type == '(' || nxt.Type == kwINCLUDE ||
+		(nxt.Type == tokIDENT && strings.EqualFold(nxt.Str, "EXCLUDE"))
+}
+
+// parsePivotSuffix attaches any PIVOT / UNPIVOT clauses — each with its
+// optional trailing t_alias — to a just-parsed table reference, per the
+// table_reference grammar: query_table_expression
+// [pivot_clause | unpivot_clause] [t_alias]. The clause becomes the from-item
+// itself (both implement TableExpr), so join continuations and the alias
+// participate in the FROM chain like any other table reference. Oracle also
+// accepts chained clauses (t PIVOT (...) a PIVOT (...) b), so this loops.
+// A bare identifier alias is accepted; AS stays rejected (Oracle t_alias
+// takes no AS keyword). No-op when no clause follows.
 func (p *Parser) parsePivotSuffix(source nodes.TableExpr) (nodes.TableExpr, error) {
-	switch p.cur.Type {
-	case kwPIVOT:
-		pc, err := p.parsePivotClause()
-		if err != nil {
-			return nil, err
-		}
-		pc.Source = source
-		if p.isTableAliasCandidate() {
-			pc.Alias, err = p.parseAlias()
+	for {
+		switch {
+		case p.pivotClauseAhead():
+			pc, err := p.parsePivotClause()
 			if err != nil {
 				return nil, err
 			}
-			pc.Loc.End = p.prev.End
-		}
-		return pc, nil
-	case kwUNPIVOT:
-		uc, err := p.parseUnpivotClause()
-		if err != nil {
-			return nil, err
-		}
-		uc.Source = source
-		if p.isTableAliasCandidate() {
-			uc.Alias, err = p.parseAlias()
+			pc.Source = source
+			if p.isTableAliasCandidate() {
+				pc.Alias, err = p.parseAlias()
+				if err != nil {
+					return nil, err
+				}
+				pc.Loc.End = p.prev.End
+			}
+			source = pc
+		case p.unpivotClauseAhead():
+			uc, err := p.parseUnpivotClause()
 			if err != nil {
 				return nil, err
 			}
-			uc.Loc.End = p.prev.End
+			uc.Source = source
+			if p.isTableAliasCandidate() {
+				uc.Alias, err = p.parseAlias()
+				if err != nil {
+					return nil, err
+				}
+				uc.Loc.End = p.prev.End
+			}
+			source = uc
+		default:
+			return source, nil
 		}
-		return uc, nil
-	default:
-		return source, nil
 	}
 }
 
@@ -2294,8 +2345,7 @@ func (p *Parser) parsePivotClause() (*nodes.PivotClause, error) {
 	}
 
 	if p.cur.Type != '(' {
-		pc.Loc.End = p.prev.End
-		return pc, nil
+		return nil, p.syntaxErrorAtCur()
 	}
 	p.advance() // consume '('
 
@@ -2601,8 +2651,7 @@ func (p *Parser) parseUnpivotClause() (*nodes.UnpivotClause, error) {
 	}
 
 	if p.cur.Type != '(' {
-		uc.Loc.End = p.prev.End
-		return uc, nil
+		return nil, p.syntaxErrorAtCur()
 	}
 	p.advance()
 	var // consume '('

--- a/oracle/parser/select.go
+++ b/oracle/parser/select.go
@@ -138,32 +138,8 @@ func (p *Parser) parseSelectStmt() (*nodes.SelectStmt, error) {
 		}
 	}
 
-	if p.cur.Type == kwPIVOT {
-		var parseErr945 error
-		sel.Pivot, parseErr945 = p.parsePivotClause()
-		if parseErr945 != nil {
-			return nil, parseErr945
-		}
-		if sel.FromClause != nil && sel.FromClause.Len() > 0 {
-			if src, ok := sel.FromClause.Items[sel.FromClause.Len()-1].(nodes.TableExpr); ok {
-				sel.Pivot.Source = src
-			}
-		}
-	} else if p.cur.Type == kwUNPIVOT {
-		var parseErr946 error
-		sel.Unpivot, parseErr946 = p.parseUnpivotClause()
-		if parseErr946 !=
-
-			// WHERE
-			nil {
-			return nil, parseErr946
-		}
-		if sel.FromClause != nil && sel.FromClause.Len() > 0 {
-			if src, ok := sel.FromClause.Items[sel.FromClause.Len()-1].(nodes.TableExpr); ok {
-				sel.Unpivot.Source = src
-			}
-		}
-	}
+	// PIVOT / UNPIVOT are parsed inside the table_reference chain
+	// (parsePivotSuffix); nothing to do at the select level.
 
 	if p.cur.Type == kwWHERE {
 		p.advance()
@@ -762,6 +738,11 @@ func (p *Parser) parseTableRef() (nodes.TableExpr, error) {
 		}
 	}
 
+	if p.cur.Type == kwPIVOT || p.cur.Type == kwUNPIVOT {
+		tr.Loc.End = p.prev.End
+		return p.parsePivotSuffix(tr)
+	}
+
 	if p.isIdentLikeStr("MATCH_RECOGNIZE") {
 		mrStart := p.pos()
 		mrRef, parseErr976 := p.parseMatchRecognize(mrStart)
@@ -846,6 +827,11 @@ func (p *Parser) parseSubqueryRef(start int) (nodes.TableExpr, error) {
 		Loc:      nodes.Loc{Start: start},
 	}
 
+	if p.cur.Type == kwPIVOT || p.cur.Type == kwUNPIVOT {
+		ref.Loc.End = p.prev.End
+		return p.parsePivotSuffix(ref)
+	}
+
 	// Optional alias
 	if p.cur.Type == kwAS {
 		p.advance()
@@ -884,6 +870,10 @@ func (p *Parser) parseParenthesizedTableRef(start int) (nodes.TableExpr, error) 
 		return nil, p.syntaxErrorAtCur()
 	}
 	p.advance()
+
+	if p.cur.Type == kwPIVOT || p.cur.Type == kwUNPIVOT {
+		return p.parsePivotSuffix(tref)
+	}
 
 	if aliasable, ok := tref.(*nodes.TableRef); ok {
 		if p.cur.Type == kwAS {
@@ -2234,6 +2224,48 @@ func (p *Parser) parseCTECycleClause() (*nodes.CTECycleClause, error) {
 
 	cc.Loc.End = p.prev.End
 	return cc, nil
+}
+
+// parsePivotSuffix attaches a PIVOT / UNPIVOT clause — with its optional
+// trailing t_alias — to a just-parsed table reference, per the table_reference
+// grammar: query_table_expression [pivot_clause | unpivot_clause] [t_alias].
+// The clause becomes the from-item itself (both implement TableExpr), so join
+// continuations and the alias participate in the FROM chain like any other
+// table reference. A bare identifier alias is accepted; AS stays rejected
+// (Oracle t_alias takes no AS keyword).
+func (p *Parser) parsePivotSuffix(source nodes.TableExpr) (nodes.TableExpr, error) {
+	switch p.cur.Type {
+	case kwPIVOT:
+		pc, err := p.parsePivotClause()
+		if err != nil {
+			return nil, err
+		}
+		pc.Source = source
+		if p.isTableAliasCandidate() {
+			pc.Alias, err = p.parseAlias()
+			if err != nil {
+				return nil, err
+			}
+			pc.Loc.End = p.prev.End
+		}
+		return pc, nil
+	case kwUNPIVOT:
+		uc, err := p.parseUnpivotClause()
+		if err != nil {
+			return nil, err
+		}
+		uc.Source = source
+		if p.isTableAliasCandidate() {
+			uc.Alias, err = p.parseAlias()
+			if err != nil {
+				return nil, err
+			}
+			uc.Loc.End = p.prev.End
+		}
+		return uc, nil
+	default:
+		return source, nil
+	}
 }
 
 // parsePivotClause parses a PIVOT clause.

--- a/oracle/parser/select.go
+++ b/oracle/parser/select.go
@@ -799,7 +799,9 @@ func (p *Parser) parseTableRef() (nodes.TableExpr, error) {
 	}
 
 	tr.Loc.End = p.prev.End
-	return tr, nil
+	// Oracle also accepts the pivot after an alias (t alias PIVOT (...)),
+	// even though the documented grammar orders the alias last.
+	return p.parsePivotSuffix(tr)
 }
 
 // isTableAliasCandidate checks if current token can be a table alias.
@@ -873,7 +875,7 @@ func (p *Parser) parseSubqueryRef(start int) (nodes.TableExpr, error) {
 	}
 
 	ref.Loc.End = p.prev.End
-	return ref, nil
+	return p.parsePivotSuffix(ref)
 }
 
 func (p *Parser) parseParenthesizedTableRef(start int) (nodes.TableExpr, error) {
@@ -927,7 +929,7 @@ func (p *Parser) parseParenthesizedTableRef(start int) (nodes.TableExpr, error) 
 		n.Loc.Start = start
 		n.Loc.End = p.prev.End
 	}
-	return tref, nil
+	return p.parsePivotSuffix(tref)
 }
 
 // parseInlineExternalTable parses Oracle's inline external table source.
@@ -2381,8 +2383,11 @@ func (p *Parser) parsePivotClause() (*nodes.PivotClause, error) {
 		}
 	}
 
-	// FOR column | ( column, column, ... )
-	if p.cur.Type == kwFOR {
+	// FOR column | ( column, column, ... ) — mandatory (Oracle: ORA-02000)
+	if p.cur.Type != kwFOR {
+		return nil, p.syntaxErrorAtCur()
+	}
+	{
 		p.advance() // consume FOR
 		pc.ForColumns = &nodes.List{}
 		if p.cur.Type == '(' {
@@ -2429,9 +2434,16 @@ func (p *Parser) parsePivotClause() (*nodes.PivotClause, error) {
 		}
 	}
 
-	if p.cur.Type == kwIN {
+	// IN ( ... ) — mandatory (Oracle: ORA-01738)
+	if p.cur.Type != kwIN {
+		return nil, p.syntaxErrorAtCur()
+	}
+	{
 		p.advance() // consume IN
-		if p.cur.Type == '(' {
+		if p.cur.Type != '(' {
+			return nil, p.syntaxErrorAtCur()
+		}
+		{
 			if pc.XML && p.peekNext().Type == kwSELECT {
 				// PIVOT XML allows a subquery in the IN clause
 				p.advance() // consume '('
@@ -2470,9 +2482,10 @@ func (p *Parser) parsePivotClause() (*nodes.PivotClause, error) {
 		}
 	}
 
-	if p.cur.Type == ')' {
-		p.advance() // consume outer ')'
+	if p.cur.Type != ')' {
+		return nil, p.syntaxErrorAtCur()
 	}
+	p.advance() // consume outer ')'
 
 	pc.Loc.End = p.prev.End
 	return pc, nil
@@ -2666,7 +2679,11 @@ func (p *Parser) parseUnpivotClause() (*nodes.UnpivotClause, error) {
 		uc.ValueCol, _ = uc.ValueColumns.Items[0].(nodes.ExprNode)
 	}
 
-	if p.cur.Type == kwFOR {
+	// FOR column — mandatory (Oracle: ORA-02000)
+	if p.cur.Type != kwFOR {
+		return nil, p.syntaxErrorAtCur()
+	}
+	{
 		p.advance()
 		var parseErr1040 error
 		uc.PivotColumn, parseErr1040 = p.parseColumnRef()
@@ -2679,9 +2696,16 @@ func (p *Parser) parseUnpivotClause() (*nodes.UnpivotClause, error) {
 		uc.PivotCol = uc.PivotColumn
 	}
 
-	if p.cur.Type == kwIN {
+	// IN ( ... ) — mandatory (Oracle: ORA-01738)
+	if p.cur.Type != kwIN {
+		return nil, p.syntaxErrorAtCur()
+	}
+	{
 		p.advance()
-		if p.cur.Type == '(' {
+		if p.cur.Type != '(' {
+			return nil, p.syntaxErrorAtCur()
+		}
+		{
 			p.advance()
 			uc.InList = &nodes.List{}
 			uc.InputMappings = &nodes.List{}


### PR DESCRIPTION
## Problem

PIVOT/UNPIVOT were parsed at the select level after the whole FROM clause, retro-attaching the last from-item as `Source`. Oracle's grammar places them inside `table_reference`:

```
table_reference ::= query_table_expression [pivot_clause | unpivot_clause] [t_alias]
```

so a pivoted result can carry a trailing bare-identifier alias and participate in joins. The old placement rejected both:

```sql
SELECT p.a FROM (SELECT a, b, m FROM t1) PIVOT (SUM(b) FOR m IN (1, 2)) p ORDER BY p.a
SELECT p.a FROM t1 PIVOT (SUM(b) FOR m IN (1, 2)) p JOIN d ON p.a = d.a
```

Reported via a PL/SQL function using `OPEN ... FOR (subquery) PIVOT (...) alias`, which failed to parse while being valid Oracle.

## Fix

- New `parsePivotSuffix` attaches PIVOT/UNPIVOT (and the optional `t_alias`) to the just-parsed table reference; wired into all three `table_reference` entry paths (plain table, subquery, parenthesized table reference). The clause becomes the from-item itself — `PivotClause`/`UnpivotClause` already implement `TableExpr` and already had `Alias`/`Source` fields.
- `AS p` and column alias lists `p(x, y)` after the pivot stay rejected — Oracle raises ORA-03048 on both (`t_alias` takes neither).
- Removed the dead select-level branch, `SelectStmt.Pivot/Unpivot` fields, their outfuncs writes, and regenerated the walker. This is an intentional fail-loud API break for consumers reading `SelectStmt.Pivot`; the Bytebase span extractor already handles the from-item form (`case *ast.PivotClause`) and will be updated in the bump PR.

## Verification

Every accept/reject shape in `pivot_alias_test.go` was run against Oracle 23ai Free: the 5 positive shapes (table/subquery/XML pivot + alias, unpivot + alias, pivot-then-join) execute cleanly, the 2 negative shapes fail with ORA-03048, and the PL/SQL cursor function compiles with no errors. Full `./oracle/...` suite passes.