### PR TITLE
pg: handle backslash escapes in E'...' strings during split

### DIFF
--- a/pg/split.go
+++ b/pg/split.go
@@ -72,9 +72,15 @@ func Split(sql string) []Segment {
 		b := sql[i]
 
 		switch {
-		// Single-quoted string.
+		// Single-quoted string. E'...' (escape string) processes
+		// backslash escapes; plain '...' does not (PG default
+		// standard_conforming_strings=on).
 		case b == '\'':
-			i = skipSingleQuote(sql, i)
+			if isEscapeStringQuote(sql, i) {
+				i = skipEscapeString(sql, i)
+			} else {
+				i = skipSingleQuote(sql, i)
+			}
 
 		// Double-quoted identifier.
 		case b == '"':
@@ -156,7 +162,7 @@ func matchKeyword(sql string, i int, kw string) bool {
 }
 
 // skipSingleQuote skips a single-quoted string starting at position i.
-// Handles '' escape. Returns position after the closing quote (or end of input).
+// Handles ” escape. Returns position after the closing quote (or end of input).
 func skipSingleQuote(sql string, i int) int {
 	i++ // skip opening '
 	for i < len(sql) {
@@ -169,6 +175,59 @@ func skipSingleQuote(sql string, i int) int {
 			return i
 		}
 		i++
+	}
+	return i // unterminated
+}
+
+// isEscapeStringQuote reports whether the quote at position i opens an
+// E'...' escape string: the quote is directly preceded by a lone E/e
+// that is not the tail of an identifier (scan.l: {xestart} = [eE]{quote},
+// only recognized when E starts a token).
+func isEscapeStringQuote(sql string, i int) bool {
+	if i == 0 {
+		return false
+	}
+	prev := sql[i-1]
+	if prev != 'e' && prev != 'E' {
+		return false
+	}
+	if i >= 2 && isIdentByte(sql[i-2]) {
+		return false // E is the tail of an identifier like abcE'...'
+	}
+	return true
+}
+
+// isIdentByte reports whether b can appear in a PG identifier
+// (letters, digits, underscore, dollar, or any multibyte byte).
+func isIdentByte(b byte) bool {
+	return b == '_' || b == '$' ||
+		(b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9') || b >= 0x80
+}
+
+// skipEscapeString skips an E'...' string body starting at the opening
+// quote. Unlike plain strings, backslash escapes the next character
+// (including \' and \\); ” doubling is also honored. Returns the
+// position after the closing quote, or len(sql) if unterminated.
+func skipEscapeString(sql string, i int) int {
+	i++ // skip opening '
+	for i < len(sql) {
+		switch sql[i] {
+		case '\\':
+			if i+1 >= len(sql) {
+				return len(sql) // trailing backslash at EOF
+			}
+			i += 2
+		case '\'':
+			i++
+			if i < len(sql) && sql[i] == '\'' {
+				i++ // escaped ''
+				continue
+			}
+			return i
+		default:
+			i++
+		}
 	}
 	return i // unterminated
 }
@@ -309,7 +368,11 @@ func skipBeginAtomic(sql string, i int) int {
 
 		switch {
 		case b == '\'':
-			i = skipSingleQuote(sql, i)
+			if isEscapeStringQuote(sql, i) {
+				i = skipEscapeString(sql, i)
+			} else {
+				i = skipSingleQuote(sql, i)
+			}
 		case b == '"':
 			i = skipDoubleQuote(sql, i)
 		case b == '$' && isDollarQuoteStart(sql, i):

--- a/pg/split_estring_test.go
+++ b/pg/split_estring_test.go
@@ -45,6 +45,11 @@ func TestSplitEscapeString(t *testing.T) {
 			want: []string{`SELECT 'a\';`, ` SELECT 2;`},
 		},
 		{
+			name: "E-string at input start (lookback boundary)",
+			sql:  `E'a\';b'; SELECT 2;`,
+			want: []string{`E'a\';b';`, ` SELECT 2;`},
+		},
+		{
 			name: "E as identifier tail is not an escape prefix",
 			sql:  `SELECT abcE'x\'; SELECT 2;`,
 			want: []string{`SELECT abcE'x\';`, ` SELECT 2;`},

--- a/pg/split_estring_test.go
+++ b/pg/split_estring_test.go
@@ -1,0 +1,96 @@
+package pg
+
+import "testing"
+
+// TestSplitEscapeString covers E'...' escape-string handling in the
+// splitter (audit defect D1): backslash escapes the next character
+// inside E-strings, so a \' does not close the string. Plain '...'
+// strings keep standard_conforming_strings=on semantics where
+// backslash is a literal character.
+func TestSplitEscapeString(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+		want []string
+	}{
+		{
+			name: "escaped quote does not close E-string",
+			sql:  `SELECT E'a\';b';`,
+			want: []string{`SELECT E'a\';b';`},
+		},
+		{
+			name: "E-string followed by second statement",
+			sql:  `SELECT E'a\';b'; SELECT 2;`,
+			want: []string{`SELECT E'a\';b';`, ` SELECT 2;`},
+		},
+		{
+			name: "lowercase e prefix",
+			sql:  `SELECT e'a\';b';`,
+			want: []string{`SELECT e'a\';b';`},
+		},
+		{
+			name: "even backslashes close normally",
+			sql:  `SELECT E'a\\'; SELECT 2;`,
+			want: []string{`SELECT E'a\\';`, ` SELECT 2;`},
+		},
+		{
+			name: "doubled quote inside E-string",
+			sql:  `SELECT E'it''s \' ok';`,
+			want: []string{`SELECT E'it''s \' ok';`},
+		},
+		// Negative fences: these must NOT get escape-aware scanning.
+		{
+			name: "plain string backslash is literal (conforming on)",
+			sql:  `SELECT 'a\'; SELECT 2;`,
+			want: []string{`SELECT 'a\';`, ` SELECT 2;`},
+		},
+		{
+			name: "E as identifier tail is not an escape prefix",
+			sql:  `SELECT abcE'x\'; SELECT 2;`,
+			want: []string{`SELECT abcE'x\';`, ` SELECT 2;`},
+		},
+		{
+			name: "U& string is not escape-aware",
+			sql:  `SELECT U&'d\0061t;a'; SELECT 2;`,
+			want: []string{`SELECT U&'d\0061t;a';`, ` SELECT 2;`},
+		},
+		// BEGIN ATOMIC body path (second dispatch site).
+		{
+			name: "E-string inside BEGIN ATOMIC body",
+			sql:  "CREATE FUNCTION f() RETURNS text LANGUAGE sql BEGIN ATOMIC SELECT E'a\\';b'; END; SELECT 2;",
+			want: []string{"CREATE FUNCTION f() RETURNS text LANGUAGE sql BEGIN ATOMIC SELECT E'a\\';b'; END;", " SELECT 2;"},
+		},
+		// Resilience: unterminated constructs must not panic or hang.
+		{
+			name: "unterminated E-string at EOF",
+			sql:  `SELECT E'abc\'`,
+			want: []string{`SELECT E'abc\'`},
+		},
+		{
+			name: "trailing backslash at EOF",
+			sql:  `SELECT E'abc\`,
+			want: []string{`SELECT E'abc\`},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			segs := Split(c.sql)
+			if len(segs) != len(c.want) {
+				t.Fatalf("got %d segments, want %d: %#v", len(segs), len(c.want), segs)
+			}
+			joined := ""
+			for i, s := range segs {
+				if s.Text != c.want[i] {
+					t.Errorf("segment %d = %q, want %q", i, s.Text, c.want[i])
+				}
+				if s.Text != c.sql[s.ByteStart:s.ByteEnd] {
+					t.Errorf("segment %d Range mismatch: Text=%q, sql[%d:%d]=%q", i, s.Text, s.ByteStart, s.ByteEnd, c.sql[s.ByteStart:s.ByteEnd])
+				}
+				joined += s.Text
+			}
+			if joined != c.sql {
+				t.Errorf("lossless invariant violated: concat=%q, input=%q", joined, c.sql)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Audit defect **D1 (P0, silent mis-split)** from the PG splitter failure audit: `skipSingleQuote` only handled `''` doubling, so `E'a\';b'` split mid-string at the semicolon — `\'` does not close an escape string per PG's scan.l.

The quote dispatch now routes to an escape-aware scanner when the quote is opened by a lone `E`/`e` that is not the tail of an identifier. Plain `'...'` strings keep `standard_conforming_strings=on` semantics (backslash literal), enforced by negative fences.

## Why P0

Both halves of the mis-split can happen to parse individually, silently producing wrong execution units — the most dangerous splitter failure direction per the reliability plan.

## Testing

- 11-case fence matrix: positive (escaped quote, lowercase `e`, even backslashes, `''` doubling inside E-string, BEGIN ATOMIC body path), negative (plain-string backslash literal, `abcE'...'` identifier-tail, `U&'...'`), resilience (unterminated at EOF, trailing backslash)
- Every case asserts exact segment boundaries + byte-range consistency + lossless concat invariant (not just segment counts, per audit methodology)
- Engine ground truth: PG 17 verified by two independent runs (audit + cross-validation)
- Full `./pg/...` suite passes

Part of the PG splitter audit fix series (D1 of D1-D5); D2-D5 follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)