### PR TITLE
pg: recognize dollar-quote delimiters only at token starts during split

### DIFF
--- a/pg/parse_test.go
+++ b/pg/parse_test.go
@@ -50,8 +50,8 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
-			name: "multiline",
-			sql:  "SELECT\n  1;\nSELECT\n  2;",
+			name:      "multiline",
+			sql:       "SELECT\n  1;\nSELECT\n  2;",
 			wantCount: 2,
 			checks: func(t *testing.T, stmts []Statement) {
 				if stmts[0].Start.Line != 1 {

--- a/pg/split.go
+++ b/pg/split.go
@@ -162,7 +162,7 @@ func matchKeyword(sql string, i int, kw string) bool {
 }
 
 // skipSingleQuote skips a single-quoted string starting at position i.
-// Handles ” escape. Returns position after the closing quote (or end of input).
+// Handles the doubled-quote escape. Returns position after the closing quote (or end of input).
 func skipSingleQuote(sql string, i int) int {
 	i++ // skip opening '
 	for i < len(sql) {
@@ -207,7 +207,7 @@ func isIdentByte(b byte) bool {
 
 // skipEscapeString skips an E'...' string body starting at the opening
 // quote. Unlike plain strings, backslash escapes the next character
-// (including \' and \\); ” doubling is also honored. Returns the
+// (including \' and \\); a doubled single quote is also honored. Returns the
 // position after the closing quote, or len(sql) if unterminated.
 func skipEscapeString(sql string, i int) int {
 	i++ // skip opening '
@@ -251,9 +251,20 @@ func skipDoubleQuote(sql string, i int) int {
 }
 
 // isDollarQuoteStart checks if position i starts a valid dollar-quote tag.
-// A dollar-quote is $$ or $tag$ where tag is [a-zA-Z_][a-zA-Z0-9_]*.
+// A dollar-quote is $$ or $tag$ where tag is [a-zA-Z_][a-zA-Z0-9_]*, and the
+// '$' must not continue a preceding identifier.
 func isDollarQuoteStart(sql string, i int) bool {
 	if i >= len(sql) || sql[i] != '$' {
+		return false
+	}
+	// scan.l: '$' is an identifier-continuation byte ({ident_cont} includes
+	// '$'), so abc$tag$y is a single identifier, not "abc" followed by a
+	// dollar-quote. An opening delimiter is only recognized when the '$'
+	// starts a new token. (Known documented divergence: PG lexes tokens, so
+	// 123$t$...$t$ is number+string there but stays unsplit here; adjacent
+	// number/param + string is never valid grammar, so the difference only
+	// moves the boundary of an error — accepted in the splitter audit.)
+	if i > 0 && isIdentByte(sql[i-1]) {
 		return false
 	}
 	j := i + 1

--- a/pg/split_test.go
+++ b/pg/split_test.go
@@ -6,10 +6,10 @@ import (
 
 func TestSplit(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		want     []Segment
-		empties  []bool // expected Empty() for each segment
+		name    string
+		input   string
+		want    []Segment
+		empties []bool // expected Empty() for each segment
 	}{
 		// Basic cases.
 		{
@@ -287,7 +287,7 @@ $$; SELECT 1;`,
 			empties: []bool{false, false},
 		},
 		{
-			name: "BEGIN TRANSACTION is normal split",
+			name:  "BEGIN TRANSACTION is normal split",
 			input: "BEGIN TRANSACTION; SELECT 1; COMMIT;",
 			want: []Segment{
 				{Text: "BEGIN TRANSACTION;", ByteStart: 0, ByteEnd: 18},
@@ -297,7 +297,7 @@ $$; SELECT 1;`,
 			empties: []bool{false, false, false},
 		},
 		{
-			name: "BEGIN WORK is normal split",
+			name:  "BEGIN WORK is normal split",
 			input: "BEGIN WORK; SELECT 1; END WORK;",
 			want: []Segment{
 				{Text: "BEGIN WORK;", ByteStart: 0, ByteEnd: 11},
@@ -410,6 +410,110 @@ $$; SELECT 1;`,
 					if g.Empty() != tt.empties[i] {
 						t.Errorf("segment[%d].Empty() = %v, want %v (text=%q)", i, g.Empty(), tt.empties[i], g.Text)
 					}
+				}
+			}
+		})
+	}
+}
+
+// TestSplitDollarIdentAdjacency pins the scan.l rule that '$' continues an
+// identifier: abc$x$y is one identifier, not "abc" + dollar-quote $x$. A
+// mis-lex here swallows all input from the false opening tag to EOF (or, in
+// the other direction, splits inside a real dollar-quote). Engine-verified
+// on PostgreSQL 17: SELECT 1 AS abc$x$y, 名$x$y, _a$t$b all parse as plain
+// aliases; $tag$ after a non-identifier byte opens a quote as usual.
+func TestSplitDollarIdentAdjacency(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string // exact non-empty segment texts
+	}{
+		{
+			name:  "identifier with dollar then real statement",
+			input: `SELECT 1 AS abc$x$y; SELECT 2;`,
+			want:  []string{`SELECT 1 AS abc$x$y;`, ` SELECT 2;`},
+		},
+		{
+			name:  "identifier with multiple dollars",
+			input: `SELECT 1 AS abc$x$y$z; SELECT 2;`,
+			want:  []string{`SELECT 1 AS abc$x$y$z;`, ` SELECT 2;`},
+		},
+		{
+			name:  "multibyte identifier tail dollar",
+			input: "SELECT 1 AS 名$x$y; SELECT 2;",
+			want:  []string{"SELECT 1 AS 名$x$y;", " SELECT 2;"},
+		},
+		{
+			name:  "underscore identifier tail dollar",
+			input: `SELECT 1 AS _a$t$b; SELECT 2;`,
+			want:  []string{`SELECT 1 AS _a$t$b;`, ` SELECT 2;`},
+		},
+		{
+			name:  "identifier absorbs double dollar (scan.l x$$a is one identifier)",
+			input: `SELECT 1 AS x$$a;b$$; SELECT 2;`,
+			want:  []string{`SELECT 1 AS x$$a;`, `b$$;`, ` SELECT 2;`},
+		},
+		{
+			name:  "dollar quote still opens after operator",
+			input: `SELECT $tag$a;b$tag$; SELECT 2;`,
+			want:  []string{`SELECT $tag$a;b$tag$;`, ` SELECT 2;`},
+		},
+		{
+			name:  "dollar quote at input start",
+			input: `$t$;$t$; SELECT 2;`,
+			want:  []string{`$t$;$t$;`, ` SELECT 2;`},
+		},
+		{
+			name:  "dollar quote after open paren",
+			input: `SELECT f($q$a;b$q$); SELECT 2;`,
+			want:  []string{`SELECT f($q$a;b$q$);`, ` SELECT 2;`},
+		},
+		{
+			// Documented divergence: PG lexes tokens, so 123$t$a;b$t$ is
+			// number + string there (single grammar-INVALID statement, since
+			// a literal cannot be adjacent to a number). The byte scanner
+			// keeps '$' after a digit as identifier continuation and splits
+			// at the inner semicolon. Both sides reject the input; only the
+			// error boundary differs. Accepted in the splitter audit.
+			name:  "digit-adjacent dollar stays byte-scanned (known divergence)",
+			input: `SELECT 123$t$a;b$t$`,
+			want:  []string{`SELECT 123$t$a;`, `b$t$`},
+		},
+		{
+			name:  "dollar quote inside BEGIN ATOMIC after identifier",
+			input: "CREATE FUNCTION f() RETURNS int BEGIN ATOMIC SELECT 1 AS a$x$b; END; SELECT 2;",
+			want:  []string{"CREATE FUNCTION f() RETURNS int BEGIN ATOMIC SELECT 1 AS a$x$b; END;", " SELECT 2;"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			segs := Split(tt.input)
+
+			// Lossless invariant: offsets must reconstruct the input.
+			var rebuilt []byte
+			for _, s := range segs {
+				if s.Text != tt.input[s.ByteStart:s.ByteEnd] {
+					t.Fatalf("segment text %q does not match input[%d:%d]", s.Text, s.ByteStart, s.ByteEnd)
+				}
+				rebuilt = append(rebuilt, s.Text...)
+			}
+			if string(rebuilt) != tt.input {
+				t.Fatalf("segments do not reconstruct input:\ngot  %q\nwant %q", rebuilt, tt.input)
+			}
+
+			var got []string
+			for _, s := range segs {
+				if !s.Empty() {
+					got = append(got, s.Text)
+				}
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d non-empty segments %q, want %d %q", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("segment[%d] = %q, want %q", i, got[i], tt.want[i])
 				}
 			}
 		})


### PR DESCRIPTION
Fixes D3 from the PG splitter failure audit.

## Problem

scan.l treats `$` as an identifier-continuation byte (`{ident_cont}` includes `$`), so `abc$x$y` is a single identifier — not `abc` followed by a dollar-quote `$x$`. The split scanner opened a quote at any `$` with a valid-looking tag, swallowing everything from the false delimiter to EOF.

Engine-verified on PostgreSQL 17: `SELECT 1 AS abc$x$y`, `名$x$y` (multibyte + `$`), and `_a$t$b` all parse as plain aliases; `$tag$` after an operator/paren/input-start opens a quote as usual.

## Fix

Gate the opening delimiter on the preceding byte not continuing an identifier (reuses `isIdentByte` from #374, which matches scan.l's `ident_cont` charset including multibyte bytes). Closing delimiters are exact-tag matches and stay position-insensitive, same as the `xdolq` state. Both dispatch sites (top-level scan and BEGIN ATOMIC body) go through the gated function.

Known documented divergence (per audit verdict): PG lexes tokens, so number-adjacent `123$t$...$t$` is number + string there. Adjacent literals are never valid grammar, so both sides reject such input and only the error boundary differs — pinned in the fence with that rationale.

## Tests

`TestSplitDollarIdentAdjacency`: 10 boundary-exact cases (identifier tails incl. multibyte/underscore/multiple-`$`, scan.l's `x$$a` identifier absorption, quote-opening positions after operator/paren/input-start, BEGIN ATOMIC body, and the documented divergence) + offset-lossless reconstruction assertions per case.

Also rephrases two doc comments to avoid the TeX `''` pattern that gofmt has canonicalized into a typographic quote since Go 1.19 — this is what has been flipping between `''` and `”` in recent diffs; prose avoids the pattern entirely so the file is stable under gofmt regardless of toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)