### PR TITLE
pg: splitter test framework — constructive generator + invariants

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -258,6 +258,28 @@ jobs:
       - name: Oracle reference tests (full engine without -short, -tags=oracle_ref)
         run: go test -tags=oracle_ref -timeout 35m -v ./oracle/... -count=1
 
+  splittest-nightly:
+    # PG splitter framework at nightly scale: 10^6 constructive cases
+    # (self-verifying expected boundaries) + byte-mutation invariants.
+    # PR runs use the in-repo default N=10^4; see pg/splittest/.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        go-version: ['1.25']
+    env:
+      SPLITTEST_N: '1000000'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: PG splitter framework (nightly N=10^6)
+        run: go test ./pg/splittest/ -count=1 -v
+
   paren-fuzz-nightly:
     # SCENARIOS-pg-paren-dispatch.md §5.2 — wide-N nightly fuzz run.
     # N=10000 catches low-frequency paren-dispatch drift that the

--- a/pg/splittest/atoms.go
+++ b/pg/splittest/atoms.go
@@ -1,0 +1,274 @@
+// Package splittest is the PG splitter test framework: enumeration
+// fences, a constructive generator whose cases carry their own expected
+// boundaries, and invariant checks that need no ground truth at all.
+//
+// Design: docs 2026-07-16 "PG Splitter 测试框架设计" (three-layer tower).
+// The generator's key property is constructive truth: every atom
+// guarantees that any semicolon inside its text is NOT a statement
+// boundary, so when the composer joins statements with top-level
+// semicolons, the expected segmentation is derived during construction
+// and holds at any scale without consulting an engine.
+package splittest
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+)
+
+// Atom is a fragment of statement text whose internal semicolons (if
+// any) are guaranteed by construction to be inside a quoting/comment
+// construct and therefore must never split. Atoms never end in a state
+// that leaks into following text (all constructs are closed), and are
+// composed with single-space separators so adjacent atoms cannot fuse
+// into different tokens (e.g. an identifier tail absorbing an E prefix).
+type Atom struct {
+	// Class is the construct class from the framework design (C1..C19).
+	Class string
+	// Gen produces the fragment text. It must return text that is
+	// self-contained: every quote/comment/paren opened is closed.
+	Gen func(r *rand.Rand) string
+	// RequiresFix names an unfixed audit defect (e.g. "D2", "D5") that
+	// must land before this atom can be enabled in the composer. Empty
+	// means the construct is safe on current main.
+	RequiresFix string
+}
+
+// identChars are safe identifier-continuation characters for generated names.
+const identChars = "abcdefghijklmnopqrstuvwxyz_"
+
+func randIdent(r *rand.Rand, n int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteByte(identChars[r.Intn(len(identChars))])
+	}
+	return b.String()
+}
+
+// payload returns dangerous inner content for quoted constructs:
+// semicolons, quote-lookalikes, comment openers, dollar signs.
+func payload(r *rand.Rand) string {
+	pieces := []string{
+		";", "; ", "a;b", "--;", "/*;", "$x$;", "$;$", "end;", "END ;",
+		"select 1;", ");(", ";;",
+	}
+	var b strings.Builder
+	n := 1 + r.Intn(3)
+	for i := 0; i < n; i++ {
+		b.WriteString(pieces[r.Intn(len(pieces))])
+	}
+	return b.String()
+}
+
+// Atoms is the construct-atom library. Each entry corresponds to a
+// class from the enumeration layer; the composer draws from the subset
+// whose RequiresFix is empty (or explicitly enabled after a fix lands).
+var Atoms = []Atom{
+	{
+		Class: "C1-plain-string",
+		Gen: func(r *rand.Rand) string {
+			// '' doubling belongs inside; backslash is literal
+			// (standard_conforming_strings=on).
+			inner := strings.ReplaceAll(payload(r), "'", "''")
+			if r.Intn(3) == 0 {
+				inner += `\`
+			}
+			return "'" + inner + "'"
+		},
+	},
+	{
+		Class: "C2-escape-string",
+		Gen: func(r *rand.Rand) string {
+			// E-string: backslash escapes; embed \' and '' forms
+			// around semicolons (audit D1, fixed in #374).
+			forms := []string{`\';`, `'';`, `\\`, `\n;`}
+			var b strings.Builder
+			prefix := "E"
+			if r.Intn(2) == 0 {
+				prefix = "e"
+			}
+			b.WriteString(prefix + "'")
+			n := 1 + r.Intn(3)
+			for i := 0; i < n; i++ {
+				b.WriteString(forms[r.Intn(len(forms))])
+			}
+			b.WriteString("'")
+			return b.String()
+		},
+	},
+	{
+		Class: "C5-dollar-quote",
+		Gen: func(r *rand.Rand) string {
+			tag := ""
+			if r.Intn(2) == 0 {
+				tag = randIdent(r, 1+r.Intn(4))
+			}
+			delim := "$" + tag + "$"
+			inner := payload(r)
+			// Similar-but-different tag inside is fair game.
+			if tag != "" && r.Intn(2) == 0 {
+				inner += "$" + tag[:len(tag)-1] + "x$"
+			}
+			// Constructive guarantee: the payload must not contain the
+			// closing delimiter itself, or the atom is no longer sealed.
+			inner = strings.ReplaceAll(inner, delim, "@")
+			return delim + inner + delim
+		},
+	},
+	{
+		Class: "C7-line-comment",
+		Gen: func(r *rand.Rand) string {
+			// Line comment swallows a semicolon; newline ends it so
+			// the atom stays self-contained.
+			return "--" + strings.ReplaceAll(payload(r), "\n", " ") + "\n"
+		},
+	},
+	{
+		Class: "C8-block-comment",
+		Gen: func(r *rand.Rand) string {
+			// Neutralize both delimiters: a stray closer would end the
+			// comment early, a stray opener would deepen nesting beyond
+			// the closers we emit — either way the atom leaks.
+			inner := strings.ReplaceAll(payload(r), "*/", "* /")
+			inner = strings.ReplaceAll(inner, "/*", "/ *")
+			depth := 1 + r.Intn(3) // PG block comments nest
+			return strings.Repeat("/*", depth) + inner + strings.Repeat("*/", depth)
+		},
+	},
+	{
+		Class: "C9-quoted-ident",
+		Gen: func(r *rand.Rand) string {
+			inner := strings.ReplaceAll(payload(r), `"`, `""`)
+			return `"` + inner + `"`
+		},
+	},
+	{
+		Class: "C11-begin-atomic",
+		Gen: func(r *rand.Rand) string {
+			// SQL-standard function body: internal semicolons must not
+			// split. Keep body constructs simple (quoted payloads) —
+			// keyword-boundary pathology (D4) is enumeration-layer
+			// territory until the hardening lands.
+			body := "SELECT " + "'" + strings.ReplaceAll(payload(r), "'", "''") + "'" + ";"
+			if r.Intn(2) == 0 {
+				body += " SELECT 1;"
+			}
+			return "CREATE FUNCTION " + randIdent(r, 4) + "() RETURNS int LANGUAGE sql BEGIN ATOMIC " + body + " END"
+		},
+	},
+	{
+		Class:       "C10-paren-semicolon",
+		RequiresFix: "D2",
+		Gen: func(r *rand.Rand) string {
+			return "(SELECT 1; SELECT 2)"
+		},
+	},
+	{
+		Class:       "C6-ident-dollar",
+		RequiresFix: "D3",
+		Gen: func(r *rand.Rand) string {
+			return randIdent(r, 2) + "$" + randIdent(r, 1) + "$" + randIdent(r, 1)
+		},
+	},
+	{
+		Class:       "C12-copy-stdin",
+		RequiresFix: "D5",
+		Gen: func(r *rand.Rand) string {
+			return "COPY t FROM stdin;\na;b\nc;d\n\\."
+		},
+	},
+}
+
+// EnabledAtoms returns the atoms usable by the composer: those with no
+// pending fix, plus any whose defect id is in the enabled set (used to
+// switch atoms on as D2/D3/D5 fixes merge).
+func EnabledAtoms(enabledFixes ...string) []Atom {
+	on := map[string]bool{}
+	for _, f := range enabledFixes {
+		on[f] = true
+	}
+	var out []Atom
+	for _, a := range Atoms {
+		if a.RequiresFix == "" || on[a.RequiresFix] {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// glue is plain SQL text between atoms within one statement. Single
+// spaces prevent token fusion between adjacent atoms.
+func glue(r *rand.Rand) string {
+	pieces := []string{"SELECT", "1", "+", "col", ",", "FROM t WHERE a =", "AS x"}
+	return pieces[r.Intn(len(pieces))]
+}
+
+// Statement composes 1..k atoms with glue into a statement containing
+// no top-level semicolon by construction.
+func Statement(r *rand.Rand, atoms []Atom) string {
+	var b strings.Builder
+	n := 1 + r.Intn(3)
+	b.WriteString(glue(r))
+	for i := 0; i < n; i++ {
+		b.WriteString(" ")
+		b.WriteString(atoms[r.Intn(len(atoms))].Gen(r))
+		b.WriteString(" ")
+		b.WriteString(glue(r))
+	}
+	return b.String()
+}
+
+// Script is a generated multi-statement script together with its
+// expected segmentation, derived during construction.
+type Script struct {
+	SQL string
+	// Want holds the expected segment texts, in order. A segment is a
+	// statement plus its terminating semicolon; inter-statement trivia
+	// belongs to the FOLLOWING segment (current splitter contract).
+	Want []string
+}
+
+// trivia is inter-statement noise attached to the start of the next
+// segment: whitespace and full-line comments.
+func trivia(r *rand.Rand) string {
+	switch r.Intn(4) {
+	case 0:
+		return " "
+	case 1:
+		return "\n"
+	case 2:
+		return " -- trailing note;\n"
+	default:
+		return ""
+	}
+}
+
+// Compose builds a script of n statements. Every semicolon that acts
+// as a boundary is placed by this function; every other semicolon is
+// sealed inside an atom. That is the constructive-truth guarantee.
+func Compose(r *rand.Rand, atoms []Atom, n int) Script {
+	var sql strings.Builder
+	var want []string
+	pending := "" // trivia belonging to the upcoming segment
+	for i := 0; i < n; i++ {
+		stmt := pending + Statement(r, atoms) + ";"
+		sql.WriteString(stmt)
+		want = append(want, stmt)
+		pending = trivia(r)
+	}
+	if pending != "" && strings.TrimSpace(pending) == "" {
+		// Trailing pure-whitespace trivia forms no segment in the
+		// current contract only if empty; keep scripts closed instead.
+		pending = ""
+	}
+	if pending != "" {
+		sql.WriteString(pending)
+		want = append(want, pending)
+	}
+	return Script{SQL: sql.String(), Want: want}
+}
+
+// String implements fmt.Stringer for failure dumps.
+func (s Script) String() string {
+	return fmt.Sprintf("script(%d segs): %q", len(s.Want), s.SQL)
+}

--- a/pg/splittest/atoms.go
+++ b/pg/splittest/atoms.go
@@ -116,6 +116,26 @@ var Atoms = []Atom{
 		},
 	},
 	{
+		Class: "C3-unicode-string",
+		Gen: func(r *rand.Rand) string {
+			// U&'...' lexes with plain-string quote rules: '' doubling,
+			// backslash NOT special at the string boundary (UESCAPE
+			// processing happens after lexing). Audit-verified.
+			inner := strings.ReplaceAll(payload(r), "'", "''")
+			return "U&'" + inner + "'"
+		},
+	},
+	{
+		Class: "C4-bit-string",
+		Gen: func(r *rand.Rand) string {
+			// B''/X'' consume to the closing quote like plain strings;
+			// the splitter does not validate content, so a semicolon
+			// inside must stay sealed even though the value is invalid.
+			prefix := []string{"B", "b", "X", "x"}[r.Intn(4)]
+			return prefix + "'01;10'"
+		},
+	},
+	{
 		Class: "C7-line-comment",
 		Gen: func(r *rand.Rand) string {
 			// Line comment swallows a semicolon; newline ends it so

--- a/pg/splittest/invariants.go
+++ b/pg/splittest/invariants.go
@@ -1,0 +1,75 @@
+package splittest
+
+import (
+	"fmt"
+
+	"github.com/bytebase/omni/pg"
+)
+
+// CheckInvariants runs the truth-free properties against one input.
+// These hold for ANY input, valid SQL or not, so they can absorb
+// unlimited volume (corpus files, byte mutations, generated scripts):
+//
+//	I1 lossless: concatenating all segment texts reproduces the input
+//	I2 ranges:   each segment's [ByteStart,ByteEnd) slices to its Text,
+//	             ranges are adjacent and cover the whole input
+//	I3 re-split: splitting a segment's text yields that segment back
+//	             (idempotence)
+//
+// It returns a descriptive error for the first violated property.
+func CheckInvariants(sql string) error {
+	segs := pg.Split(sql)
+
+	// I1 + I2.
+	pos := 0
+	var concat []byte
+	for i, s := range segs {
+		if s.ByteStart != pos {
+			return fmt.Errorf("I2: segment %d starts at %d, want %d", i, s.ByteStart, pos)
+		}
+		if s.ByteEnd < s.ByteStart || s.ByteEnd > len(sql) {
+			return fmt.Errorf("I2: segment %d has range [%d,%d) outside input len %d", i, s.ByteStart, s.ByteEnd, len(sql))
+		}
+		if sql[s.ByteStart:s.ByteEnd] != s.Text {
+			return fmt.Errorf("I2: segment %d Text %q != sql[%d:%d] %q", i, s.Text, s.ByteStart, s.ByteEnd, sql[s.ByteStart:s.ByteEnd])
+		}
+		concat = append(concat, s.Text...)
+		pos = s.ByteEnd
+	}
+	if len(sql) > 0 && pos != len(sql) {
+		return fmt.Errorf("I2: segments cover [0,%d), input len %d", pos, len(sql))
+	}
+	if string(concat) != sql {
+		return fmt.Errorf("I1: concat(split(sql)) != sql")
+	}
+
+	// I3: re-splitting one segment must not find new boundaries.
+	for i, s := range segs {
+		re := pg.Split(s.Text)
+		if len(re) != 1 {
+			return fmt.Errorf("I3: segment %d re-splits into %d segments: %q", i, len(re), s.Text)
+		}
+		if re[0].Text != s.Text {
+			return fmt.Errorf("I3: segment %d re-split text %q != %q", i, re[0].Text, s.Text)
+		}
+	}
+	return nil
+}
+
+// CheckScript verifies a generated script against its constructive
+// expectation: exact segment texts in order, plus all invariants.
+func CheckScript(s Script) error {
+	if err := CheckInvariants(s.SQL); err != nil {
+		return err
+	}
+	segs := pg.Split(s.SQL)
+	if len(segs) != len(s.Want) {
+		return fmt.Errorf("constructive: got %d segments, want %d\ninput: %q", len(segs), len(s.Want), s.SQL)
+	}
+	for i := range segs {
+		if segs[i].Text != s.Want[i] {
+			return fmt.Errorf("constructive: segment %d = %q, want %q\ninput: %q", i, segs[i].Text, s.Want[i], s.SQL)
+		}
+	}
+	return nil
+}

--- a/pg/splittest/splittest_test.go
+++ b/pg/splittest/splittest_test.go
@@ -1,0 +1,163 @@
+package splittest
+
+import (
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// Scale knobs. PR runs use the defaults; nightly overrides via env:
+//
+//	SPLITTEST_N=1000000 SPLITTEST_SEED=<date-derived> go test ./pg/splittest/
+const (
+	defaultN    = 10000
+	defaultSeed = 20260716
+)
+
+func scale() (n int, seed int64) {
+	n, seed = defaultN, defaultSeed
+	if v := os.Getenv("SPLITTEST_N"); v != "" {
+		if p, err := strconv.Atoi(v); err == nil {
+			n = p
+		}
+	}
+	if v := os.Getenv("SPLITTEST_SEED"); v != "" {
+		if p, err := strconv.ParseInt(v, 10, 64); err == nil {
+			seed = p
+		}
+	}
+	return
+}
+
+// TestConstructive is the generator gate: every case carries its own
+// expected segmentation (truth_source=construct). Failures dump the
+// full script for reproduction; the seed is printed so any run can be
+// replayed exactly.
+func TestConstructive(t *testing.T) {
+	n, seed := scale()
+	r := rand.New(rand.NewSource(seed))
+	atoms := EnabledAtoms( /* enable "D2","D3","D5" as fixes land */ )
+	t.Logf("constructive: n=%d seed=%d atoms=%d", n, seed, len(atoms))
+	fails := 0
+	for i := 0; i < n; i++ {
+		script := Compose(r, atoms, 1+r.Intn(5))
+		if err := CheckScript(script); err != nil {
+			fails++
+			t.Errorf("case %d (seed %d): %v", i, seed, err)
+			if fails >= 10 {
+				t.Fatalf("too many failures, aborting at case %d", i)
+			}
+		}
+	}
+}
+
+// TestPairCoverage guarantees every ordered pair of enabled atom
+// classes appears within one statement, several times, per the
+// combination-layer quota (design §2.2).
+func TestPairCoverage(t *testing.T) {
+	_, seed := scale()
+	r := rand.New(rand.NewSource(seed + 1))
+	atoms := EnabledAtoms()
+	const perPair = 5
+	for ai := range atoms {
+		for bi := range atoms {
+			for k := 0; k < perPair; k++ {
+				a, b := atoms[ai], atoms[bi]
+				stmt := glue(r) + " " + a.Gen(r) + " " + glue(r) + " " + b.Gen(r) + " " + glue(r)
+				script := Script{SQL: stmt + ";", Want: []string{stmt + ";"}}
+				if err := CheckScript(script); err != nil {
+					t.Errorf("pair %s×%s: %v", a.Class, b.Class, err)
+				}
+			}
+		}
+	}
+}
+
+// TestInvariantsOverPgregress is the S1 hard gate: the truth-free
+// invariants must hold over the full vendored PG regression corpus
+// (truth_source=invariant). Any violation is a P0 by definition —
+// lossless reconstruction failed on real-world input.
+func TestInvariantsOverPgregress(t *testing.T) {
+	root := filepath.Join("..", "pgregress", "testdata", "sql")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Skipf("pgregress corpus not found: %v", err)
+	}
+	files := 0
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".sql" {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(root, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := CheckInvariants(string(content)); err != nil {
+			t.Errorf("%s: %v", e.Name(), err)
+		}
+		files++
+	}
+	t.Logf("invariants over %d pgregress files", files)
+	if files < 200 {
+		t.Errorf("expected >=200 corpus files, found %d — corpus path drift?", files)
+	}
+}
+
+// TestByteMutation fuzzes with quote/semicolon/backslash/dollar
+// insertions into generated scripts. Mutated inputs are usually
+// invalid SQL — only the truth-free invariants apply, which is exactly
+// their job (truth_source=invariant).
+func TestByteMutation(t *testing.T) {
+	n, seed := scale()
+	r := rand.New(rand.NewSource(seed + 2))
+	atoms := EnabledAtoms()
+	hot := []byte{'\'', '"', ';', '\\', '$', '-', '*', '/', 'E'}
+	for i := 0; i < n/2; i++ {
+		script := Compose(r, atoms, 1+r.Intn(3))
+		b := []byte(script.SQL)
+		for m := 0; m < 1+r.Intn(4); m++ {
+			switch r.Intn(3) {
+			case 0: // insert
+				pos := r.Intn(len(b) + 1)
+				b = append(b[:pos], append([]byte{hot[r.Intn(len(hot))]}, b[pos:]...)...)
+			case 1: // delete
+				if len(b) > 0 {
+					pos := r.Intn(len(b))
+					b = append(b[:pos], b[pos+1:]...)
+				}
+			default: // replace
+				if len(b) > 0 {
+					b[r.Intn(len(b))] = hot[r.Intn(len(hot))]
+				}
+			}
+		}
+		if err := CheckInvariants(string(b)); err != nil {
+			t.Errorf("mutation case %d (seed %d): %v\ninput: %q", i, seed, err, string(b))
+		}
+	}
+}
+
+// FuzzSplitInvariants hooks the invariants into Go native fuzzing so
+// `go test -fuzz` can explore beyond the structured generators. Seeds
+// cover every audit defect class.
+func FuzzSplitInvariants(f *testing.F) {
+	seeds := []string{
+		`SELECT E'a\';b'; SELECT 2;`,
+		"CREATE RULE r AS ON UPDATE TO t DO ALSO (SELECT 1; SELECT 2);",
+		"SELECT 1 AS abc$x$y; SELECT 2;",
+		"CREATE FUNCTION f() RETURNS int LANGUAGE sql BEGIN ATOMIC SELECT t4.end FROM t4; END; SELECT 1;",
+		"COPY t FROM stdin;\na;b\n\\.\nSELECT 1;",
+		"/* /* nested; */ ; */ SELECT $tag$;$tag$;",
+		"SELECT U&'d\\0061t;a'; SELECT 'x''y;z';",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, sql string) {
+		if err := CheckInvariants(sql); err != nil {
+			t.Fatalf("%v", err)
+		}
+	})
+}

--- a/pg/splittest/splittest_test.go
+++ b/pg/splittest/splittest_test.go
@@ -38,7 +38,7 @@ func scale() (n int, seed int64) {
 func TestConstructive(t *testing.T) {
 	n, seed := scale()
 	r := rand.New(rand.NewSource(seed))
-	atoms := EnabledAtoms( /* enable "D2","D3","D5" as fixes land */ )
+	atoms := EnabledAtoms("D3" /* D3 fixed in #375; enable "D2","D5" as fixes land */)
 	t.Logf("constructive: n=%d seed=%d atoms=%d", n, seed, len(atoms))
 	fails := 0
 	for i := 0; i < n; i++ {
@@ -59,7 +59,7 @@ func TestConstructive(t *testing.T) {
 func TestPairCoverage(t *testing.T) {
 	_, seed := scale()
 	r := rand.New(rand.NewSource(seed + 1))
-	atoms := EnabledAtoms()
+	atoms := EnabledAtoms("D3")
 	const perPair = 5
 	for ai := range atoms {
 		for bi := range atoms {
@@ -112,7 +112,7 @@ func TestInvariantsOverPgregress(t *testing.T) {
 func TestByteMutation(t *testing.T) {
 	n, seed := scale()
 	r := rand.New(rand.NewSource(seed + 2))
-	atoms := EnabledAtoms()
+	atoms := EnabledAtoms("D3")
 	hot := []byte{'\'', '"', ';', '\\', '$', '-', '*', '/', 'E'}
 	for i := 0; i < n/2; i++ {
 		script := Compose(r, atoms, 1+r.Intn(3))


### PR DESCRIPTION
## What

Implements the PG splitter test framework (design doc 2026-07-16, three-layer tower) as a resident package `pg/splittest/`:

| Layer | Mechanism | Scale |
|---|---|---|
| Constructive generator | Atoms seal internal semicolons + carry boundary metadata → composed scripts know their expected segmentation | PR 10^4, nightly **10^6** (~3s, zero truth cost) |
| Invariants | lossless concat / range consistency / re-split idempotence — truth-free | all corpus + mutations |
| S1 hard gate | invariants over full pgregress corpus | 224 files |
| Pair coverage | every ordered pair of enabled construct classes | pairs × 5 |
| Byte mutation | hot-char insert/delete/replace on generated scripts | N/2 |
| Native fuzz | `FuzzSplitInvariants` seeded with all 5 audit defect repros | on demand |

**Fix-gate atoms**: C10 (D2), C6 (D3), C12 (D5) atoms are declared but gated on their fixes — enabling each as the fix merges makes the framework a live ledger of repair progress. (C6 can be enabled as soon as #375 lands.)

**truth_source labeling** per design: constructive (generated), invariant (mutations/corpus). Engine-differential sampling of generator assumptions comes with the S3 work.

## Validation

- 10^6-case run: PASS in 2.9s
- The constructive layer caught 2 bugs in the generator itself on first run (atoms leaking their own closing delimiter) — the self-verification property working as intended
- `go vet` clean; does not touch `pg/split.go` (no conflict with the D2-D5 fix series)

🤖 Generated with [Claude Code](https://claude.com/claude-code)