### PR TITLE
pg: keep COPY FROM STDIN inline data inside the statement segment

### DIFF
--- a/pg/split.go
+++ b/pg/split.go
@@ -124,6 +124,14 @@ func Split(sql string) []Segment {
 		// buffering to end of input.
 		case b == ';' && parenDepth == 0:
 			i++
+			// COPY ... FROM STDIN is followed by inline data lines that end
+			// at a line containing only "\.": psql scripts and pg_dump
+			// plain-format output carry the data in the SQL stream, and the
+			// data may contain semicolons that are not boundaries. Keep the
+			// statement, its data, and the terminator as one segment.
+			if isCopyFromStdin(sql[start:i]) {
+				i = skipCopyData(sql, i)
+			}
 			segments = append(segments, Segment{
 				Text:      sql[start:i],
 				ByteStart: start,
@@ -425,4 +433,114 @@ func skipBeginAtomic(sql string, i int) int {
 		}
 	}
 	return i
+}
+
+// isCopyFromStdin reports whether the statement text is a COPY command
+// reading inline data: the first word is COPY and the words FROM STDIN
+// appear in sequence at parenthesis depth zero (so a relation named
+// "stdin" inside a COPY (query) form does not match). Word scanning skips
+// strings, comments, and dollar-quotes with the same helpers as Split.
+func isCopyFromStdin(stmt string) bool {
+	i := 0
+	depth := 0
+	sawCopy := false
+	prevWord := ""
+	for i < len(stmt) {
+		b := stmt[i]
+		switch {
+		case b == '\'':
+			if isEscapeStringQuote(stmt, i) {
+				i = skipEscapeString(stmt, i)
+			} else {
+				i = skipSingleQuote(stmt, i)
+			}
+		case b == '"':
+			i = skipDoubleQuote(stmt, i)
+		case b == '$' && isDollarQuoteStart(stmt, i):
+			i = skipDollarQuote(stmt, i)
+		case b == '/' && i+1 < len(stmt) && stmt[i+1] == '*':
+			i = skipBlockComment(stmt, i)
+		case b == '-' && i+1 < len(stmt) && stmt[i+1] == '-':
+			i = skipLineComment(stmt, i)
+		case b == '(':
+			depth++
+			i++
+		case b == ')':
+			if depth > 0 {
+				depth--
+			}
+			i++
+		case isIdentByte(b):
+			j := i
+			for j < len(stmt) && isIdentByte(stmt[j]) {
+				j++
+			}
+			word := strings.ToUpper(stmt[i:j])
+			if !sawCopy {
+				// The statement must start with COPY.
+				if word != "COPY" {
+					return false
+				}
+				sawCopy = true
+			} else if depth == 0 && word == "STDIN" && prevWord == "FROM" {
+				return true
+			}
+			if depth == 0 {
+				prevWord = word
+			}
+			i = j
+		default:
+			i++
+		}
+	}
+	return false
+}
+
+// skipCopyData consumes the inline COPY data block starting at position i
+// (just past the COPY statement's semicolon): the remainder of that line,
+// then data lines up to and including a line containing only "\." (psql
+// recognizes the terminator only at the start of a line). Without a
+// terminator the data runs to end of input, matching psql reading to EOF.
+func skipCopyData(sql string, i int) int {
+	// Finish the line the semicolon is on; data starts on the next line.
+	for i < len(sql) && sql[i] != '\n' {
+		i++
+	}
+	if i < len(sql) {
+		i++ // consume the newline
+	}
+	for i < len(sql) {
+		// i is at the start of a data line.
+		if isCopyTerminatorLine(sql, i) {
+			// Consume through the terminator line's newline (or EOF).
+			for i < len(sql) && sql[i] != '\n' {
+				i++
+			}
+			if i < len(sql) {
+				i++
+			}
+			return i
+		}
+		for i < len(sql) && sql[i] != '\n' {
+			i++
+		}
+		if i < len(sql) {
+			i++
+		}
+	}
+	return i
+}
+
+// isCopyTerminatorLine reports whether the line starting at i consists of
+// exactly "\." (optionally followed by a carriage return before the
+// newline or end of input).
+func isCopyTerminatorLine(sql string, i int) bool {
+	if i+1 >= len(sql) || sql[i] != '\\' || sql[i+1] != '.' {
+		return false
+	}
+	j := i + 2
+	if j < len(sql) && sql[j] == '\r' {
+		j++
+	}
+	return j >= len(sql) || sql[j] == '\n'
 }

--- a/pg/split_test.go
+++ b/pg/split_test.go
@@ -610,3 +610,110 @@ func TestSplitParenDepth(t *testing.T) {
 		})
 	}
 }
+
+// TestSplitCopyFromStdin pins inline COPY data handling: psql scripts and
+// pg_dump plain-format output carry the data lines in the SQL stream, the
+// data may contain semicolons, and the block ends only at a line that is
+// exactly "\.". The statement, its data, and the terminator stay one
+// segment. Engine-verified on PostgreSQL 17 (lowercase copy, WITH options,
+// column lists, semicolons in data all load correctly via psql).
+func TestSplitCopyFromStdin(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "pg_dump shape with semicolons in data",
+			input: "COPY t (a, b) FROM stdin;\nx;y\t1\np;q;r\t2\n\\.\nSELECT 2;",
+			want:  []string{"COPY t (a, b) FROM stdin;\nx;y\t1\np;q;r\t2\n\\.\n", "SELECT 2;"},
+		},
+		{
+			name:  "lowercase with options",
+			input: "copy t from stdin with (format text);\na;b\t1\n\\.\nSELECT 2;",
+			want:  []string{"copy t from stdin with (format text);\na;b\t1\n\\.\n", "SELECT 2;"},
+		},
+		{
+			name:  "two copy blocks",
+			input: "COPY a FROM stdin;\n1;\n\\.\nCOPY b FROM stdin;\n2;\n\\.\n",
+			want:  []string{"COPY a FROM stdin;\n1;\n\\.\n", "COPY b FROM stdin;\n2;\n\\.\n"},
+		},
+		{
+			name:  "missing terminator swallows to EOF like psql",
+			input: "COPY t FROM stdin;\na;b\t1\nSELECT 2;",
+			want:  []string{"COPY t FROM stdin;\na;b\t1\nSELECT 2;"},
+		},
+		{
+			name:  "terminator only at line start",
+			input: "COPY t FROM stdin;\ndata \\. not end\n\\.\nSELECT 2;",
+			want:  []string{"COPY t FROM stdin;\ndata \\. not end\n\\.\n", "SELECT 2;"},
+		},
+		{
+			name:  "terminator line with more content is data",
+			input: "COPY t FROM stdin;\n\\.x\n\\.\nSELECT 2;",
+			want:  []string{"COPY t FROM stdin;\n\\.x\n\\.\n", "SELECT 2;"},
+		},
+		{
+			name:  "terminator at EOF without newline",
+			input: "COPY t FROM stdin;\na\t1\n\\.",
+			want:  []string{"COPY t FROM stdin;\na\t1\n\\."},
+		},
+		{
+			name:  "CRLF data and terminator",
+			input: "COPY t FROM stdin;\r\na;b\t1\r\n\\.\r\nSELECT 2;",
+			want:  []string{"COPY t FROM stdin;\r\na;b\t1\r\n\\.\r\n", "SELECT 2;"},
+		},
+		{
+			name:  "copy from file does not enter data mode",
+			input: "COPY t FROM 'x.csv'; SELECT 2;",
+			want:  []string{"COPY t FROM 'x.csv';", " SELECT 2;"},
+		},
+		{
+			name:  "copy to stdout does not enter data mode",
+			input: "COPY t TO stdout; SELECT 2;",
+			want:  []string{"COPY t TO stdout;", " SELECT 2;"},
+		},
+		{
+			name:  "relation named stdin inside copy query form does not match",
+			input: "COPY (SELECT a FROM stdin) TO stdout; SELECT 2;",
+			want:  []string{"COPY (SELECT a FROM stdin) TO stdout;", " SELECT 2;"},
+		},
+		{
+			name:  "non-copy statement mentioning from stdin in string",
+			input: "SELECT 'COPY t FROM stdin;'; SELECT 2;",
+			want:  []string{"SELECT 'COPY t FROM stdin;';", " SELECT 2;"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			segs := Split(tt.input)
+
+			var rebuilt []byte
+			for _, s := range segs {
+				if s.Text != tt.input[s.ByteStart:s.ByteEnd] {
+					t.Fatalf("segment text %q does not match input[%d:%d]", s.Text, s.ByteStart, s.ByteEnd)
+				}
+				rebuilt = append(rebuilt, s.Text...)
+			}
+			if string(rebuilt) != tt.input {
+				t.Fatalf("segments do not reconstruct input:\ngot  %q\nwant %q", rebuilt, tt.input)
+			}
+
+			var got []string
+			for _, s := range segs {
+				if !s.Empty() {
+					got = append(got, s.Text)
+				}
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d non-empty segments %q, want %d %q", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("segment[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes D5 from the PG splitter failure audit.

## Problem

psql scripts and pg_dump plain-format output carry COPY inline data in the SQL stream, terminated by a line containing only `\.`. The data may contain semicolons; the scanner treated them as statement boundaries and cut the block apart. pg_dump plain format is a real input shape for sheets, so this reaches production data.

Engine-verified on PostgreSQL 17: psql loads such scripts (semicolons in data, lowercase `copy`, `WITH (FORMAT text)`, column lists) — all covered in the fences.

## Fix

After a depth-zero semicolon closes a statement, `isCopyFromStdin` checks it lexically: first word COPY, then FROM STDIN in sequence at paren depth zero (a relation named `stdin` inside a `COPY (query)` form does not match), scanning with the same string/comment/dollar-quote skippers as Split. If it matches, `skipCopyData` consumes data lines through the terminator, which is recognized strictly at line start (psql rule; `\.x` and mid-line `\.` are data). Without a terminator the block runs to EOF, matching psql. The statement, its data, and the terminator stay one segment, so segment count still equals statement count and the concat-lossless invariant holds.

Contract note for review: the data block is *attached to the COPY statement's segment* rather than emitted as a separate segment — downstream consumers see one unit per statement. Flagging explicitly since this defines the execution-layer contract for inline COPY.

## Tests

`TestSplitCopyFromStdin`: 12 boundary-exact cases with offset-lossless reconstruction — pg_dump shape, options/case variants, back-to-back blocks, missing terminator, line-start strictness (both directions), EOF terminator, CRLF, and four non-matching forms (FROM 'file', TO STDOUT, stdin-named relation in query form, FROM stdin text inside a string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)