### PR TITLE
pg: count BEGIN ATOMIC keywords only in statement position

### DIFF
--- a/pg/split.go
+++ b/pg/split.go
@@ -405,34 +405,66 @@ func skipBeginAtomic(sql string, i int) int {
 	i += 6 // skip "ATOMIC"
 
 	depth := 1
+	// Keyword occurrences only count when they appear in statement position:
+	// dot-qualified references (t.end, t . case) and AS aliases (AS end) use
+	// reserved words as column labels, and bare unreserved BEGIN can be a
+	// plain column reference — none of them open or close a block
+	// (engine-verified on PostgreSQL 17). Track just enough left context to
+	// tell the difference; whitespace and comments preserve it.
+	afterDot := false
+	afterAS := false
 	for i < len(sql) && depth > 0 {
 		b := sql[i]
 
 		switch {
+		case b == ' ' || b == '\t' || b == '\n' || b == '\r':
+			i++
 		case b == '\'':
 			if isEscapeStringQuote(sql, i) {
 				i = skipEscapeString(sql, i)
 			} else {
 				i = skipSingleQuote(sql, i)
 			}
+			afterDot, afterAS = false, false
 		case b == '"':
 			i = skipDoubleQuote(sql, i)
+			afterDot, afterAS = false, false
 		case b == '$' && isDollarQuoteStart(sql, i):
 			i = skipDollarQuote(sql, i)
+			afterDot, afterAS = false, false
 		case b == '/' && i+1 < len(sql) && sql[i+1] == '*':
 			i = skipBlockComment(sql, i)
 		case b == '-' && i+1 < len(sql) && sql[i+1] == '-':
 			i = skipLineComment(sql, i)
-		case (b == 'c' || b == 'C') && matchKeyword(sql, i, "CASE"):
-			depth++
-			i += 4
-		case (b == 'b' || b == 'B') && matchKeyword(sql, i, "BEGIN"):
-			depth++
-			i += 5
-		case (b == 'e' || b == 'E') && matchKeyword(sql, i, "END"):
-			depth--
-			i += 3
+		case b == '.':
+			afterDot = true
+			afterAS = false
+			i++
+		case isIdentByte(b):
+			j := i
+			for j < len(sql) && isIdentByte(sql[j]) {
+				j++
+			}
+			word := strings.ToUpper(sql[i:j])
+			if !afterDot && !afterAS {
+				switch word {
+				case "CASE":
+					depth++
+				case "BEGIN":
+					// Only a nested BEGIN ATOMIC opens a block; bare BEGIN
+					// is an unreserved keyword usable as an identifier.
+					if isFollowedByAtomic(sql, j) {
+						depth++
+					}
+				case "END":
+					depth--
+				}
+			}
+			afterAS = word == "AS"
+			afterDot = false
+			i = j
 		default:
+			afterDot, afterAS = false, false
 			i++
 		}
 	}

--- a/pg/split_test.go
+++ b/pg/split_test.go
@@ -717,3 +717,92 @@ func TestSplitCopyFromStdin(t *testing.T) {
 		})
 	}
 }
+
+// TestSplitBeginAtomicKeywordContext pins context-aware keyword counting
+// inside BEGIN ATOMIC bodies: dot-qualified references (t.end, t . case),
+// AS aliases (AS end), and bare unreserved BEGIN as a column name are
+// ordinary identifiers, not block delimiters. All positive shapes
+// engine-verified on PostgreSQL 17 (server-side; psql's own client
+// scanner mis-splits the dot/AS shapes — see KnownBetterThanPsql).
+func TestSplitBeginAtomicKeywordContext(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "dot-qualified end does not close block",
+			input: "CREATE FUNCTION f() RETURNS int BEGIN ATOMIC SELECT t4.end FROM t4; END; SELECT 3;",
+			want:  []string{"CREATE FUNCTION f() RETURNS int BEGIN ATOMIC SELECT t4.end FROM t4; END;", " SELECT 3;"},
+		},
+		{
+			name:  "spaced dot-qualified end",
+			input: "CREATE FUNCTION f() RETURNS int BEGIN ATOMIC SELECT t4 . end FROM t4; END; SELECT 3;",
+			want:  []string{"CREATE FUNCTION f() RETURNS int BEGIN ATOMIC SELECT t4 . end FROM t4; END;", " SELECT 3;"},
+		},
+		{
+			name:  "AS end alias does not close block",
+			input: "CREATE FUNCTION f() RETURNS int BEGIN ATOMIC SELECT 1 AS end; END; SELECT 3;",
+			want:  []string{"CREATE FUNCTION f() RETURNS int BEGIN ATOMIC SELECT 1 AS end; END;", " SELECT 3;"},
+		},
+		{
+			name:  "dot-qualified case does not open block",
+			input: "CREATE FUNCTION f() RETURNS int BEGIN ATOMIC SELECT t4.end + t4.case FROM t4; END; SELECT 3;",
+			want:  []string{"CREATE FUNCTION f() RETURNS int BEGIN ATOMIC SELECT t4.end + t4.case FROM t4; END;", " SELECT 3;"},
+		},
+		{
+			name:  "bare begin column does not open block",
+			input: "CREATE FUNCTION f() RETURNS int BEGIN ATOMIC SELECT begin FROM t4; END; SELECT 3;",
+			want:  []string{"CREATE FUNCTION f() RETURNS int BEGIN ATOMIC SELECT begin FROM t4; END;", " SELECT 3;"},
+		},
+		{
+			name:  "case expression still counts",
+			input: "CREATE FUNCTION f() RETURNS int BEGIN ATOMIC SELECT CASE WHEN t.end > 0 THEN 1 ELSE 2 END FROM t; END; SELECT 3;",
+			want:  []string{"CREATE FUNCTION f() RETURNS int BEGIN ATOMIC SELECT CASE WHEN t.end > 0 THEN 1 ELSE 2 END FROM t; END;", " SELECT 3;"},
+		},
+		{
+			// Lexical contract: nested BEGIN ATOMIC opens a nested block
+			// (grammar validity aside); bare BEGIN no longer does.
+			name:  "nested begin atomic still counts",
+			input: "CREATE PROCEDURE p() BEGIN ATOMIC BEGIN ATOMIC SELECT 1; END; END; SELECT 3;",
+			want:  []string{"CREATE PROCEDURE p() BEGIN ATOMIC BEGIN ATOMIC SELECT 1; END; END;", " SELECT 3;"},
+		},
+		{
+			name:  "quoted end identifier does not close block",
+			input: `CREATE FUNCTION f() RETURNS int BEGIN ATOMIC SELECT "end" FROM t4; END; SELECT 3;`,
+			want:  []string{`CREATE FUNCTION f() RETURNS int BEGIN ATOMIC SELECT "end" FROM t4; END;`, ` SELECT 3;`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			segs := Split(tt.input)
+
+			var rebuilt []byte
+			for _, s := range segs {
+				if s.Text != tt.input[s.ByteStart:s.ByteEnd] {
+					t.Fatalf("segment text %q does not match input[%d:%d]", s.Text, s.ByteStart, s.ByteEnd)
+				}
+				rebuilt = append(rebuilt, s.Text...)
+			}
+			if string(rebuilt) != tt.input {
+				t.Fatalf("segments do not reconstruct input:\ngot  %q\nwant %q", rebuilt, tt.input)
+			}
+
+			var got []string
+			for _, s := range segs {
+				if !s.Empty() {
+					got = append(got, s.Text)
+				}
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d non-empty segments %q, want %d %q", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("segment[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/pg/splittest/known_better.go
+++ b/pg/splittest/known_better.go
@@ -1,0 +1,17 @@
+package splittest
+
+// KnownBetterThanPsql lists inputs where this splitter intentionally
+// diverges from psql's client-side scanner (psqlscan): the server grammar
+// accepts each shape as a single statement — engine-verified via psql -c
+// on PostgreSQL 17 — but psql's script scanner mis-splits it inside
+// BEGIN ATOMIC bodies. The S3 server-differential harness must treat a
+// psql-vs-omni mismatch on these inputs as expected (omni matches the
+// server, which is the higher truth anchor); without this allowance S3
+// would report them as false mismatches.
+var KnownBetterThanPsql = []string{
+	// Dot-qualified reserved word inside a SQL-standard function body:
+	// psqlscan closes the block at ".end" and truncates the statement.
+	"CREATE FUNCTION f6() RETURNS int BEGIN ATOMIC SELECT t4.end FROM t4; END;",
+	// AS alias using a reserved word: same psqlscan truncation.
+	"CREATE FUNCTION f7() RETURNS int BEGIN ATOMIC SELECT 1 AS end; END;",
+}

--- a/pg/splittest/known_better_test.go
+++ b/pg/splittest/known_better_test.go
@@ -1,0 +1,25 @@
+package splittest
+
+import (
+	"testing"
+
+	pg "github.com/bytebase/omni/pg"
+)
+
+// TestKnownBetterThanPsqlSplitAsSingleStatements pins that every
+// known-better input splits as exactly one non-empty segment: these are
+// the shapes where omni intentionally exceeds psql's client scanner.
+func TestKnownBetterThanPsqlSplitAsSingleStatements(t *testing.T) {
+	for _, sql := range KnownBetterThanPsql {
+		segs := pg.Split(sql)
+		n := 0
+		for _, s := range segs {
+			if !s.Empty() {
+				n++
+			}
+		}
+		if n != 1 {
+			t.Errorf("expected 1 statement, got %d for %q", n, sql)
+		}
+	}
+}


### PR DESCRIPTION
Fixes D4 from the PG splitter failure audit (the hardening option per verdict — exceed psql-parity toward server truth).

## Problem

Inside BEGIN ATOMIC bodies, CASE/BEGIN/END counted as block delimiters wherever word boundaries allowed. Engine-verified valid shapes that mis-split: `SELECT t4.end FROM t4` (dot-qualified reserved word, spaced form too), `SELECT 1 AS end` (reserved-word alias), `SELECT t4.case` (dot-qualified CASE), and `SELECT begin FROM t4` (bare unreserved BEGIN as a column). All confirmed on PostgreSQL 17 server-side. Notably psql's own client scanner shares the dot/AS mis-split — so this hardening intentionally exceeds psql, matching the server.

## Fix

Context-aware counting in `skipBeginAtomic`: keywords preceded by `.` or `AS` never count; `BEGIN` counts only when followed by `ATOMIC` (bare BEGIN is unreserved and usable as an identifier); whitespace and comments preserve context while strings/quotes reset it. CASE expressions and nested BEGIN ATOMIC keep counting; quoted `"end"` already never counted (consumed by the quote scanner).

## S3 known-better allowance (paired deliverable per review verdict)

`splittest.KnownBetterThanPsql` ships in this PR: the shapes where omni now exceeds psql's client scanner, so the future S3 server-differential harness treats psql-vs-omni mismatches on them as expected rather than reporting false positives on day one. Includes a fence asserting each splits as a single statement.

## Tests

`TestSplitBeginAtomicKeywordContext`: 8 boundary-exact cases with offset-lossless reconstruction — all four defect shapes, spaced dot form, CASE-still-counts, nested-BEGIN-ATOMIC-still-counts (lexical contract), and quoted-identifier control.

This closes the audit's D1-D5 fix line (D1 #374, D3 #375, D2 #376, D5 #378, D5b #379, D4 here). D6 (pg_dump `\restrict` metacommands) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)