### PR TITLE
pg/splittest: enable C10/C12 atoms, add whole-statement atom model

### DIFF
--- a/pg/splittest/atoms.go
+++ b/pg/splittest/atoms.go
@@ -32,6 +32,12 @@ type Atom struct {
 	// must land before this atom can be enabled in the composer. Empty
 	// means the construct is safe on current main.
 	RequiresFix string
+	// WholeStatement marks constructs that are only meaningful as a
+	// complete statement (e.g. COPY FROM stdin, whose data mode
+	// requires COPY as the statement's first word). The composer emits
+	// them verbatim as full segments and never embeds them mid-statement.
+	// Their Gen output must carry its own statement terminator.
+	WholeStatement bool
 }
 
 // identChars are safe identifier-continuation characters for generated names.
@@ -191,10 +197,16 @@ var Atoms = []Atom{
 		},
 	},
 	{
-		Class:       "C12-copy-stdin",
-		RequiresFix: "D5",
+		Class:          "C12-copy-stdin",
+		RequiresFix:    "D5",
+		WholeStatement: true,
 		Gen: func(r *rand.Rand) string {
-			return "COPY t FROM stdin;\na;b\nc;d\n\\."
+			// Complete segment: statement, its semicolon, data lines
+			// (with sealed semicolons), terminator line and its newline
+			// (contract: the terminator's newline belongs to this segment).
+			rows := []string{"a;b", "1\t\\N", "c;d;e"}
+			data := rows[r.Intn(len(rows))] + "\n" + rows[r.Intn(len(rows))]
+			return "COPY " + randIdent(r, 3) + " FROM stdin;\n" + data + "\n\\.\n"
 		},
 	},
 }
@@ -230,8 +242,12 @@ func Statement(r *rand.Rand, atoms []Atom) string {
 	n := 1 + r.Intn(3)
 	b.WriteString(glue(r))
 	for i := 0; i < n; i++ {
+		a := atoms[r.Intn(len(atoms))]
+		for a.WholeStatement {
+			a = atoms[r.Intn(len(atoms))]
+		}
 		b.WriteString(" ")
-		b.WriteString(atoms[r.Intn(len(atoms))].Gen(r))
+		b.WriteString(a.Gen(r))
 		b.WriteString(" ")
 		b.WriteString(glue(r))
 	}
@@ -267,11 +283,24 @@ func trivia(r *rand.Rand) string {
 // as a boundary is placed by this function; every other semicolon is
 // sealed inside an atom. That is the constructive-truth guarantee.
 func Compose(r *rand.Rand, atoms []Atom, n int) Script {
+	var whole []Atom
+	for _, a := range atoms {
+		if a.WholeStatement {
+			whole = append(whole, a)
+		}
+	}
 	var sql strings.Builder
 	var want []string
 	pending := "" // trivia belonging to the upcoming segment
 	for i := 0; i < n; i++ {
-		stmt := pending + Statement(r, atoms) + ";"
+		var stmt string
+		if len(whole) > 0 && r.Intn(4) == 0 {
+			// Whole-statement construct: emitted verbatim, carries its
+			// own terminator (e.g. COPY block through the \. line).
+			stmt = pending + whole[r.Intn(len(whole))].Gen(r)
+		} else {
+			stmt = pending + Statement(r, atoms) + ";"
+		}
 		sql.WriteString(stmt)
 		want = append(want, stmt)
 		pending = trivia(r)

--- a/pg/splittest/splittest_test.go
+++ b/pg/splittest/splittest_test.go
@@ -38,7 +38,7 @@ func scale() (n int, seed int64) {
 func TestConstructive(t *testing.T) {
 	n, seed := scale()
 	r := rand.New(rand.NewSource(seed))
-	atoms := EnabledAtoms("D3" /* D3 fixed in #375; enable "D2","D5" as fixes land */)
+	atoms := EnabledAtoms("D2", "D3", "D5" /* all splitter audit fixes merged (#374-#379) */)
 	t.Logf("constructive: n=%d seed=%d atoms=%d", n, seed, len(atoms))
 	fails := 0
 	for i := 0; i < n; i++ {
@@ -59,7 +59,15 @@ func TestConstructive(t *testing.T) {
 func TestPairCoverage(t *testing.T) {
 	_, seed := scale()
 	r := rand.New(rand.NewSource(seed + 1))
-	atoms := EnabledAtoms("D3")
+	// Whole-statement constructs cannot appear mid-statement by
+	// definition; their sequencing coverage lives in TestConstructive
+	// (Compose emits them as full segments among normal statements).
+	var atoms []Atom
+	for _, a := range EnabledAtoms("D2", "D3", "D5") {
+		if !a.WholeStatement {
+			atoms = append(atoms, a)
+		}
+	}
 	const perPair = 5
 	for ai := range atoms {
 		for bi := range atoms {
@@ -112,7 +120,7 @@ func TestInvariantsOverPgregress(t *testing.T) {
 func TestByteMutation(t *testing.T) {
 	n, seed := scale()
 	r := rand.New(rand.NewSource(seed + 2))
-	atoms := EnabledAtoms("D3")
+	atoms := EnabledAtoms("D2", "D3", "D5")
 	hot := []byte{'\'', '"', ';', '\\', '$', '-', '*', '/', 'E'}
 	for i := 0; i < n/2; i++ {
 		script := Compose(r, atoms, 1+r.Intn(3))


### PR DESCRIPTION
Follow-up to #377 now that the audit fix series (#374-#379) is merged:

- **C10 (paren-depth) and C12 (COPY-stdin) atoms enabled** — with C6 already on, all five audit defect classes are now in the constructive million-case pool
- **Whole-statement atom model**: enabling C12 immediately exposed a composition flaw (caught by the constructive layer itself): COPY FROM stdin only exists as a complete statement, so atoms gain a `WholeStatement` marker — emitted verbatim as full segments (own terminator through `\.` + newline per the D5 contract), never embedded mid-statement, filtered from pair embedding
- C12 generates pg_dump-flavored data rows (`\N`, tabs, semicolons) per the real-form direction

Validation: full splittest suite green; 3×10^5 constructive run green.

D6's C18b meta-command atom follows once Tommy's fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)