### PR TITLE
pg/splittest: add C18b metacommand trivia variants to the composer

### DIFF
--- a/pg/splittest/atoms.go
+++ b/pg/splittest/atoms.go
@@ -265,15 +265,26 @@ type Script struct {
 }
 
 // trivia is inter-statement noise attached to the start of the next
-// segment: whitespace and full-line comments.
+// segment: whitespace, full-line comments, and psql meta-command lines
+// (C18b — boundary-neutral per the D6 trivia model; a meta-command is
+// only recognized after a real newline, so every variant here starts
+// with one).
 func trivia(r *rand.Rand) string {
-	switch r.Intn(4) {
+	switch r.Intn(7) {
 	case 0:
 		return " "
 	case 1:
 		return "\n"
 	case 2:
 		return " -- trailing note;\n"
+	case 3:
+		return "\n\\restrict aAbB0 \n"
+	case 4:
+		return "\n\\unrestrict aAbB0\n\\connect mydb\n"
+	case 5:
+		// Meta-command content must stay boundary-neutral even when it
+		// carries quotes, parens, and semicolons (D6 counterexample class).
+		return "\n\\if (bogus; 'q\n"
 	default:
 		return ""
 	}


### PR DESCRIPTION
Follow-up to #382/#383: psql metacommand lines enter the constructive trivia pool (`\restrict`, `\unrestrict`+`\connect` sequences, and the D6-counterexample form carrying quotes/parens/semicolons — boundary-neutral per the trivia model, strict newline-prefix rule respected).

Preparing exactly these variants is what surfaced **D6b** (metacommand before COPY defeating the first-word scan, the pg_dumpall shape) — with #383 merged, the interaction is now generated and asserted continuously at nightly 10^6 scale.

Validation: full splittest suite + 3×10^5 constructive run green on main-with-#383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)