### PR TITLE
pg: review-sweep follow-ups for the splitter series

### DIFF
--- a/pg/internal/copyscan/copyscan.go
+++ b/pg/internal/copyscan/copyscan.go
@@ -53,3 +53,19 @@ func IsTerminatorLine(sql string, i int) bool {
 	}
 	return j >= len(sql) || sql[j] == '\n'
 }
+
+// RestOfLineBlank reports whether only whitespace remains between position
+// i and the end of the current line (or end of input). psql buffers
+// same-line SQL after a COPY statement and executes it after the data is
+// consumed — an ordering a contiguous segment model cannot represent — so
+// data mode only engages when the statement ends its line; anything else
+// fails loudly downstream instead of silently swallowing statements.
+func RestOfLineBlank(sql string, i int) bool {
+	for i < len(sql) && sql[i] != '\n' {
+		if sql[i] != ' ' && sql[i] != '\t' && sql[i] != '\r' {
+			return false
+		}
+		i++
+	}
+	return true
+}

--- a/pg/parse_test.go
+++ b/pg/parse_test.go
@@ -184,3 +184,39 @@ func TestParseRealPgDumpPipeline(t *testing.T) {
 		t.Fatal("no COPY statement with inline data found in dump")
 	}
 }
+
+// TestParseCommentSweepFollowups pins the parse-layer halves of the review
+// sweep fixes: BOM'd scripts parse (psql strips the BOM), and same-line SQL
+// after a COPY statement stays a real statement instead of being swallowed
+// into InlineData.
+func TestParseCommentSweepFollowups(t *testing.T) {
+	t.Run("BOM script parses", func(t *testing.T) {
+		stmts, err := Parse("\xEF\xBB\xBFSELECT 1;")
+		if err != nil {
+			t.Fatalf("parse failed: %v", err)
+		}
+		if len(stmts) != 1 {
+			t.Fatalf("expected 1 statement, got %d", len(stmts))
+		}
+	})
+
+	t.Run("BOM copy pipeline", func(t *testing.T) {
+		stmts, err := Parse("\xEF\xBB\xBFCOPY t FROM stdin;\na\t1\n\\.\nSELECT 2;")
+		if err != nil {
+			t.Fatalf("parse failed: %v", err)
+		}
+		if len(stmts) != 2 {
+			t.Fatalf("expected 2 statements, got %d", len(stmts))
+		}
+	})
+
+	t.Run("same-line SQL after copy is not swallowed", func(t *testing.T) {
+		stmts, err := Parse("COPY t FROM stdin; SELECT 42;")
+		if err != nil {
+			t.Fatalf("parse failed: %v", err)
+		}
+		if len(stmts) != 2 {
+			t.Fatalf("expected 2 statements, got %d: the trailing SELECT must stay a statement", len(stmts))
+		}
+	})
+}

--- a/pg/parser/parser.go
+++ b/pg/parser/parser.go
@@ -10,6 +10,7 @@ import (
 	nodes "github.com/bytebase/omni/pg/ast"
 	"github.com/bytebase/omni/pg/internal/copyscan"
 	"github.com/bytebase/omni/pg/internal/metacmd"
+	"strings"
 )
 
 // Parser is a recursive descent parser for PostgreSQL SQL.
@@ -38,6 +39,11 @@ func Parse(sql string) (*nodes.List, error) {
 	p := &Parser{
 		lexer:  NewLexer(sql),
 		source: sql,
+	}
+	// A UTF-8 BOM at the start of the script is trivia: psql strips it
+	// before scanning (mainloop.c).
+	if strings.HasPrefix(sql, "\xEF\xBB\xBF") {
+		p.lexer.pos = 3
 	}
 	p.advance()
 
@@ -83,7 +89,7 @@ func Parse(sql string) (*nodes.List, error) {
 		// error it may have produced).
 		if cs, ok := stmt.(*nodes.CopyStmt); ok &&
 			cs.IsFrom && cs.Filename == "" && !cs.IsProgram && cs.Query == nil &&
-			p.cur.Type == ';' {
+			p.cur.Type == ';' && copyscan.RestOfLineBlank(p.source, p.cur.End) {
 			semiEnd := p.cur.End
 			dataEnd := copyscan.SkipData(p.source, semiEnd)
 			cs.InlineData = p.source[semiEnd:dataEnd]

--- a/pg/split.go
+++ b/pg/split.go
@@ -19,6 +19,9 @@ type Segment struct {
 func (s Segment) Empty() bool {
 	t := s.Text
 	i := 0
+	if strings.HasPrefix(t, "\xEF\xBB\xBF") {
+		i = 3
+	}
 	for i < len(t) {
 		b := t[i]
 		// psql metacommand line: statement-less.
@@ -78,6 +81,11 @@ func Split(sql string) []Segment {
 	var segments []Segment
 	start := 0
 	i := 0
+	// A UTF-8 BOM at the start of the script is trivia: psql strips it
+	// before scanning (mainloop.c). The bytes stay in the first segment.
+	if strings.HasPrefix(sql, "\xEF\xBB\xBF") {
+		i = 3
+	}
 	// Statement-separating semicolons only occur at parenthesis depth zero:
 	// PG's grammar nests semicolons inside parentheses (CREATE RULE's
 	// multi-action list), and psqlscan likewise never splits inside parens.
@@ -153,7 +161,7 @@ func Split(sql string) []Segment {
 			// plain-format output carry the data in the SQL stream, and the
 			// data may contain semicolons that are not boundaries. Keep the
 			// statement, its data, and the terminator as one segment.
-			if isCopyFromStdin(sql[start:i]) {
+			if isCopyFromStdin(sql[start:i]) && copyscan.RestOfLineBlank(sql, i) {
 				i = copyscan.SkipData(sql, i)
 			}
 			segments = append(segments, Segment{
@@ -202,11 +210,13 @@ func matchKeyword(sql string, i int, kw string) bool {
 			return false
 		}
 	}
-	// Check word boundaries.
-	if i > 0 && isIdentChar(sql[i-1]) {
+	// Check word boundaries with scan.l identifier bytes: '$' and
+	// multibyte bytes continue identifiers (x$BEGIN is one identifier),
+	// so they block a keyword match just like letters do.
+	if i > 0 && isIdentByte(sql[i-1]) {
 		return false
 	}
-	if i+n < len(sql) && isIdentChar(sql[i+n]) {
+	if i+n < len(sql) && isIdentByte(sql[i+n]) {
 		return false
 	}
 	return true
@@ -437,6 +447,12 @@ func skipBeginAtomic(sql string, i int) int {
 		b := sql[i]
 
 		switch {
+		// Metacommand lines are trivia here too: psql executes them
+		// mid-buffer and the body continues, so their words (\echo END)
+		// must not count as block delimiters. Context is preserved, same
+		// as comments.
+		case metacmd.IsLineStart(sql, i, i > 0 && sql[i-1] == '\n'):
+			i = metacmd.SkipLine(sql, i)
 		case b == ' ' || b == '\t' || b == '\n' || b == '\r':
 			i++
 		case b == '\'':
@@ -498,6 +514,9 @@ func skipBeginAtomic(sql string, i int) int {
 // strings, comments, and dollar-quotes with the same helpers as Split.
 func isCopyFromStdin(stmt string) bool {
 	i := 0
+	if strings.HasPrefix(stmt, "\xEF\xBB\xBF") {
+		i = 3 // leading UTF-8 BOM is trivia, same as in Split
+	}
 	depth := 0
 	sawCopy := false
 	prevWord := ""
@@ -546,7 +565,10 @@ func isCopyFromStdin(stmt string) bool {
 					return false
 				}
 				sawCopy = true
-			} else if depth == 0 && word == "STDIN" && prevWord == "FROM" {
+			} else if depth == 0 && (word == "STDIN" || word == "STDOUT") && prevWord == "FROM" {
+				// gram.y maps both STDIN and STDOUT to a NULL filename, and
+				// the server runs copy-in for either spelling of COPY FROM
+				// (engine-verified: inline data loads via FROM STDOUT).
 				return true
 			}
 			if depth == 0 {

--- a/pg/split_test.go
+++ b/pg/split_test.go
@@ -996,3 +996,92 @@ func TestSplitCopyAfterMetacommand(t *testing.T) {
 		})
 	}
 }
+
+// TestSplitCommentSweepFollowups pins the fixes from the post-merge review
+// sweep of the D1-D6b series, each engine-verified on PostgreSQL 17.
+func TestSplitCommentSweepFollowups(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			// psql strips a leading UTF-8 BOM (mainloop.c) and the COPY
+			// data loads; the BOM must not shadow COPY as the first word.
+			name:  "BOM then copy enters data mode",
+			input: "\xEF\xBB\xBFCOPY t FROM stdin;\na;b\t1\n\\.\nSELECT 2;",
+			want:  []string{"\xEF\xBB\xBFCOPY t FROM stdin;\na;b\t1\n\\.\n", "SELECT 2;"},
+		},
+		{
+			// Engine-verified: the server maps FROM STDIN and FROM STDOUT
+			// both to a NULL filename and runs copy-in, and psql loads the
+			// inline data. Swallowing the data lines IS the engine
+			// behavior — do not "fix" this back to a rejection.
+			name:  "copy from stdout is copy-in like the engine",
+			input: "COPY t FROM STDOUT;\nviastdout\t9\n\\.\nSELECT 2;",
+			want:  []string{"COPY t FROM STDOUT;\nviastdout\t9\n\\.\n", "SELECT 2;"},
+		},
+		{
+			// psql buffers same-line SQL after a COPY statement and runs it
+			// after the data — unrepresentable in contiguous segments. Data
+			// mode disengages so the remainder stays a real statement and
+			// the data lines fail loudly instead of being silently
+			// swallowed together with the trailing SQL.
+			name:  "same-line SQL after copy disables data mode",
+			input: "COPY t FROM stdin; SELECT 42 AS marker;\nsameline\t2\n\\.\n",
+			want:  []string{"COPY t FROM stdin;", " SELECT 42 AS marker;", "\nsameline\t2\n\\.\n"},
+		},
+		{
+			// psql executes metacommands mid-buffer and the function body
+			// continues (engine-verified: \echo END inside BEGIN ATOMIC,
+			// function created, body has both statements).
+			name:  "metacommand inside begin atomic body is trivia",
+			input: "CREATE FUNCTION fm() RETURNS int BEGIN ATOMIC\nSELECT 1;\n\\echo END\nSELECT 2;\nEND; SELECT 3;",
+			want:  []string{"CREATE FUNCTION fm() RETURNS int BEGIN ATOMIC\nSELECT 1;\n\\echo END\nSELECT 2;\nEND;", " SELECT 3;"},
+		},
+		{
+			// scan.l: x$BEGIN is one identifier — the BEGIN ATOMIC dispatch
+			// must not fire on an identifier tail.
+			name:  "identifier tail BEGIN does not open atomic block",
+			input: "SELECT 1 AS x$BEGIN ATOMIC; SELECT 2;",
+			want:  []string{"SELECT 1 AS x$BEGIN ATOMIC;", " SELECT 2;"},
+		},
+		{
+			name:  "BOM only script",
+			input: "\xEF\xBB\xBFSELECT 1;",
+			want:  []string{"\xEF\xBB\xBFSELECT 1;"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			segs := Split(tt.input)
+
+			var rebuilt []byte
+			for _, s := range segs {
+				if s.Text != tt.input[s.ByteStart:s.ByteEnd] {
+					t.Fatalf("segment text %q does not match input[%d:%d]", s.Text, s.ByteStart, s.ByteEnd)
+				}
+				rebuilt = append(rebuilt, s.Text...)
+			}
+			if string(rebuilt) != tt.input {
+				t.Fatalf("segments do not reconstruct input:\ngot  %q\nwant %q", rebuilt, tt.input)
+			}
+
+			var got []string
+			for _, s := range segs {
+				if !s.Empty() {
+					got = append(got, s.Text)
+				}
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d non-empty segments %q, want %d %q", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("segment[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-ups from the post-merge comment sweep of the D1-D6b splitter series (thread-dispatched: 4 fixes + 1 reversal), each engine-verified on PostgreSQL 17:

1. **UTF-8 BOM as trivia, both layers** (#378 comment): psql strips a leading BOM (mainloop.c). Previously a BOM'd script failed the parser outright and the BOM shadowed COPY as the first word in the split detector. Skipped now in Split, Empty, isCopyFromStdin, and the parser entry.
2. **Same-line SQL after COPY disables data mode, both layers** (#378 comment): engine-verified that psql buffers the remainder and executes it after the data — unrepresentable in contiguous segments. Failure-direction call: the remainder stays a real statement and data lines fail loudly, instead of silently swallowing a statement into InlineData.
3. **Metacommands inside BEGIN ATOMIC are trivia** (#382 comment): engine-verified `\echo END` mid-body — psql executes it and the function body continues; the depth counter no longer pierces.
4. **matchKeyword boundaries use scan.l identifier bytes** (extension of #375 comment): `x$BEGIN ATOMIC` is an identifier tail, not a dispatch trigger — completes the D3 byte-semantics unification (single identifier-byte definition across the file).
5. **COPY FROM STDOUT reversal** (#379 comment — declined with evidence, pinned): gram.y maps STDIN/STDOUT both to NULL filename; `psql -c "COPY t FROM STDOUT"` runs copy-in and script-inline data loads. Our predicate is isomorphic to the server's. The split-side word scan now accepts both spellings (parser side already did), and a fence with the engine citation prevents a future "fix" back into rejection.

Fences: 6 split-layer boundary-exact cases + 3 parse-layer cases including the BOM-COPY pipeline. Full `./pg/...` incl. splittest invariants green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)