### PR TITLE
oracle: support <<label>> on every PL/SQL statement

### DIFF
--- a/oracle/ast/loc.go
+++ b/oracle/ast/loc.go
@@ -475,6 +475,8 @@ func NodeLoc(n Node) Loc {
 	// PL/SQL nodes
 	case *PLSQLBlock:
 		return v.Loc
+	case *PLSQLLabeledStatement:
+		return v.Loc
 	case *PLSQLVarDecl:
 		return v.Loc
 	case *PLSQLCursorDecl:

--- a/oracle/ast/outfuncs.go
+++ b/oracle/ast/outfuncs.go
@@ -4796,7 +4796,9 @@ func writePLSQLLabeledStatement(sb *strings.Builder, n *PLSQLLabeledStatement) {
 			if i > 0 {
 				sb.WriteString(" ")
 			}
-			sb.WriteString(l)
+			// Quote: labels may be quoted identifiers with spaces
+			// (<<"a b">> is legal), which would otherwise be ambiguous.
+			sb.WriteString(fmt.Sprintf("%q", l))
 		}
 		sb.WriteString(")")
 	}

--- a/oracle/ast/outfuncs.go
+++ b/oracle/ast/outfuncs.go
@@ -539,6 +539,8 @@ func writeNode(sb *strings.Builder, node Node) {
 	// PL/SQL nodes
 	case *PLSQLBlock:
 		writePLSQLBlock(sb, n)
+	case *PLSQLLabeledStatement:
+		writePLSQLLabeledStatement(sb, n)
 	case *ExceptionHandler:
 		writeExceptionHandler(sb, n)
 	case *PLSQLIf:
@@ -4781,6 +4783,26 @@ func writeDisassociateStatisticsStmt(sb *strings.Builder, n *DisassociateStatist
 // ---------------------------------------------------------------------------
 // PL/SQL nodes
 // ---------------------------------------------------------------------------
+
+func writePLSQLLabeledStatement(sb *strings.Builder, n *PLSQLLabeledStatement) {
+	sb.WriteString("{PLSQLLABELEDSTATEMENT")
+	if len(n.Labels) > 0 {
+		sb.WriteString(" :labels (")
+		for i, l := range n.Labels {
+			if i > 0 {
+				sb.WriteString(" ")
+			}
+			sb.WriteString(l)
+		}
+		sb.WriteString(")")
+	}
+	if n.Statement != nil {
+		sb.WriteString(" :statement ")
+		writeNode(sb, n.Statement)
+	}
+	sb.WriteString(fmt.Sprintf(" :loc_start %d :loc_end %d", n.Loc.Start, n.Loc.End))
+	sb.WriteString("}")
+}
 
 func writePLSQLBlock(sb *strings.Builder, n *PLSQLBlock) {
 	sb.WriteString("{PLSQLBLOCK")

--- a/oracle/ast/outfuncs.go
+++ b/oracle/ast/outfuncs.go
@@ -2376,6 +2376,10 @@ func writeInsertStmt(sb *strings.Builder, n *InsertStmt) {
 		sb.WriteString(" :values ")
 		writeNode(sb, n.Values)
 	}
+	if n.ValuesRecord != nil {
+		sb.WriteString(" :valuesRecord ")
+		writeNode(sb, n.ValuesRecord)
+	}
 	if n.SetClauses != nil {
 		sb.WriteString(" :setClauses ")
 		writeNode(sb, n.SetClauses)

--- a/oracle/ast/parsenodes.go
+++ b/oracle/ast/parsenodes.go
@@ -2276,6 +2276,19 @@ type PLSQLBlock struct {
 func (n *PLSQLBlock) nodeTag()  {}
 func (n *PLSQLBlock) stmtNode() {}
 
+// PLSQLLabeledStatement carries one or more <<label>> prefixes attached to
+// a PL/SQL statement. Blocks and loops store their (first) label on their
+// own Label field for END-label matching; this wrapper holds labels on any
+// other statement kind, and any labels beyond the first on blocks/loops.
+type PLSQLLabeledStatement struct {
+	Labels    []string // label names, in source order
+	Statement StmtNode // the labeled statement
+	Loc       Loc      // start location (first label)
+}
+
+func (n *PLSQLLabeledStatement) nodeTag()  {}
+func (n *PLSQLLabeledStatement) stmtNode() {}
+
 // ExceptionHandler represents an exception handler in a PL/SQL block.
 type ExceptionHandler struct {
 	Exceptions *List // exception names (list of *String)

--- a/oracle/ast/parsenodes.go
+++ b/oracle/ast/parsenodes.go
@@ -1393,6 +1393,7 @@ type InsertStmt struct {
 	Alias        *Alias              // table alias
 	Columns      *List               // column list (list of *ColumnRef)
 	Values       *List               // VALUES list (list of expressions)
+	ValuesRecord ExprNode            // VALUES record form (PL/SQL record/collection element)
 	SetClauses   *List               // INSERT SET col=expr form (list of *SetClause)
 	ByName       bool                // BY NAME subquery
 	ByPosition   bool                // BY POSITION subquery

--- a/oracle/ast/walk_generated.go
+++ b/oracle/ast/walk_generated.go
@@ -940,6 +940,7 @@ func walkChildren(v Visitor, node Node) {
 		}
 		walkList(v, n.Columns)
 		walkList(v, n.Values)
+		Walk(v, n.ValuesRecord)
 		walkList(v, n.SetClauses)
 		if n.Select != nil {
 			Walk(v, n.Select)

--- a/oracle/ast/walk_generated.go
+++ b/oracle/ast/walk_generated.go
@@ -1159,6 +1159,8 @@ func walkChildren(v Visitor, node Node) {
 		walkList(v, n.Then)
 		walkList(v, n.ElsIfs)
 		walkList(v, n.Else)
+	case *PLSQLLabeledStatement:
+		Walk(v, n.Statement)
 	case *PLSQLLoop:
 		Walk(v, n.Condition)
 		Walk(v, n.LowerBound)

--- a/oracle/parser/insert.go
+++ b/oracle/parser/insert.go
@@ -195,7 +195,17 @@ func (p *Parser) parseInsertStmt() (*nodes.InsertStmt, error) {
 	case p.cur.Type == kwVALUES:
 		p.advance()
 		if p.cur.Type != '(' {
-			return nil, p.syntaxErrorAtCur()
+			// INSERT ... VALUES record — the PL/SQL record form (engine-
+			// verified, incl. FORALL collection elements: VALUES arr(i)).
+			var parseErrRec error
+			stmt.ValuesRecord, parseErrRec = p.parseExpr()
+			if parseErrRec != nil {
+				return nil, parseErrRec
+			}
+			if stmt.ValuesRecord == nil {
+				return nil, p.syntaxErrorAtCur()
+			}
+			break
 		}
 		p.advance()
 		var parseErr780 error

--- a/oracle/parser/insert_record_test.go
+++ b/oracle/parser/insert_record_test.go
@@ -1,0 +1,60 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	nodes "github.com/bytebase/omni/oracle/ast"
+)
+
+// TestInsertValuesRecord pins the PL/SQL record form of INSERT:
+// INSERT INTO t VALUES record — engine-verified on Oracle 23ai Free,
+// including FORALL collection elements (VALUES arr(i)) and RETURNING.
+// The tuple form stays unchanged.
+func TestInsertValuesRecord(t *testing.T) {
+	accepts := []struct {
+		name string
+		sql  string
+	}{
+		{"bare record", "BEGIN INSERT INTO sms_card VALUES v_row_smscard; END;"},
+		{"record with returning", "BEGIN INSERT INTO t VALUES v_rec RETURNING id INTO v_id; END;"},
+		{"package-qualified record", "BEGIN INSERT INTO t VALUES pkg.g_rec; END;"},
+		{"forall collection element", "BEGIN FORALL i IN 1 .. 2 INSERT INTO t9 VALUES arr(i); END;"},
+		{"tuple form control", "BEGIN INSERT INTO t VALUES (1, 2); END;"},
+	}
+	for _, tc := range accepts {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := Parse(tc.sql); err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+		})
+	}
+
+	t.Run("record lands on ValuesRecord not Values", func(t *testing.T) {
+		list, err := Parse("BEGIN INSERT INTO t VALUES v_rec; END;")
+		if err != nil {
+			t.Fatalf("parse failed: %v", err)
+		}
+		block := list.Items[0].(*nodes.RawStmt).Stmt.(*nodes.PLSQLBlock)
+		ins, ok := block.Statements.Items[0].(*nodes.InsertStmt)
+		if !ok {
+			t.Fatalf("expected InsertStmt, got %T", block.Statements.Items[0])
+		}
+		if ins.ValuesRecord == nil {
+			t.Fatal("ValuesRecord not set")
+		}
+		if ins.Values != nil {
+			t.Fatal("Values must stay nil for the record form")
+		}
+		out := nodes.NodeToString(list)
+		if !strings.Contains(out, ":valuesRecord") {
+			t.Fatalf("expected :valuesRecord in output, got %s", out)
+		}
+	})
+
+	t.Run("bare VALUES still rejected", func(t *testing.T) {
+		if _, err := Parse("INSERT INTO t VALUES"); err == nil {
+			t.Fatal("expected parse error for bare VALUES")
+		}
+	})
+}

--- a/oracle/parser/plsql_block.go
+++ b/oracle/parser/plsql_block.go
@@ -375,6 +375,10 @@ func (p *Parser) parsePLSQLStatement() (nodes.StmtNode, error) {
 			if err != nil {
 				return nil, err
 			}
+			if name == "" {
+				// <<>> is not a label (engine: PLS-00103).
+				return nil, p.syntaxErrorAtCur()
+			}
 			labels = append(labels, name)
 			if p.cur.Type != tokLABELCLOSE {
 				return nil, p.syntaxErrorAtCur()
@@ -390,11 +394,13 @@ func (p *Parser) parsePLSQLStatement() (nodes.StmtNode, error) {
 			if s.Label == "" {
 				s.Label = labels[0]
 				labels = labels[1:]
+				s.Loc.Start = start // the block's range covers its label
 			}
 		case *nodes.PLSQLLoop:
 			if s.Label == "" {
 				s.Label = labels[0]
 				labels = labels[1:]
+				s.Loc.Start = start
 			}
 		}
 		if len(labels) == 0 {

--- a/oracle/parser/plsql_block.go
+++ b/oracle/parser/plsql_block.go
@@ -361,10 +361,50 @@ func (p *Parser) parsePLSQLStatements() (*nodes.List, error) {
 }
 
 func (p *Parser) parsePLSQLStatement() (nodes.StmtNode, error) {
-	// Handle optional label before statement
+	// One or more <<label>> prefixes may precede ANY statement (engine-
+	// verified), not only blocks: consume them all, parse the statement,
+	// then attach — blocks and loops keep their first label on their own
+	// Label field (END-label matching); everything else, and any extra
+	// labels, ride on a PLSQLLabeledStatement wrapper.
 	if p.cur.Type == tokLABELOPEN {
-		// This could be a labeled block or labeled loop
-		return p.parsePLSQLBlock()
+		start := p.pos()
+		var labels []string
+		for p.cur.Type == tokLABELOPEN {
+			p.advance() // consume <<
+			name, err := p.parseIdentifier()
+			if err != nil {
+				return nil, err
+			}
+			labels = append(labels, name)
+			if p.cur.Type != tokLABELCLOSE {
+				return nil, p.syntaxErrorAtCur()
+			}
+			p.advance() // consume >>
+		}
+		stmt, err := p.parsePLSQLStatement()
+		if err != nil {
+			return nil, err
+		}
+		switch s := stmt.(type) {
+		case *nodes.PLSQLBlock:
+			if s.Label == "" {
+				s.Label = labels[0]
+				labels = labels[1:]
+			}
+		case *nodes.PLSQLLoop:
+			if s.Label == "" {
+				s.Label = labels[0]
+				labels = labels[1:]
+			}
+		}
+		if len(labels) == 0 {
+			return stmt, nil
+		}
+		return &nodes.PLSQLLabeledStatement{
+			Labels:    labels,
+			Statement: stmt,
+			Loc:       nodes.Loc{Start: start, End: p.prev.End},
+		}, nil
 	}
 
 	switch p.cur.Type {

--- a/oracle/parser/plsql_label_test.go
+++ b/oracle/parser/plsql_label_test.go
@@ -54,6 +54,49 @@ func TestPLSQLStatementLabels(t *testing.T) {
 		}
 	})
 
+	t.Run("empty label rejected", func(t *testing.T) {
+		// Engine: PLS-00103 at <<>>.
+		if _, err := Parse("BEGIN <<>> NULL; END;"); err == nil {
+			t.Fatal("expected parse error for empty label")
+		}
+	})
+
+	t.Run("quoted label with space accepted and quoted in output", func(t *testing.T) {
+		// Engine-verified: <<"a b">> is legal PL/SQL.
+		list, err := Parse(`BEGIN <<"a b">> NULL; END;`)
+		if err != nil {
+			t.Fatalf("parse failed: %v", err)
+		}
+		out := nodes.NodeToString(list)
+		if !strings.Contains(out, `"a b"`) {
+			t.Fatalf("expected quoted label in output, got %s", out)
+		}
+	})
+
+	t.Run("mismatched end loop label stays accepted like the engine", func(t *testing.T) {
+		// Engine-verified: Oracle ACCEPTS <<a>> LOOP ... END LOOP b; —
+		// review-flagged as a candidate reject, refuted by the engine.
+		if _, err := Parse("BEGIN <<a>> LOOP EXIT; END LOOP b; END;"); err != nil {
+			t.Fatalf("parse failed: %v", err)
+		}
+	})
+
+	t.Run("labeled block range covers its label", func(t *testing.T) {
+		sql := "BEGIN <<x>> BEGIN NULL; END; END;"
+		list, err := Parse(sql)
+		if err != nil {
+			t.Fatalf("parse failed: %v", err)
+		}
+		outer := list.Items[0].(*nodes.RawStmt).Stmt.(*nodes.PLSQLBlock)
+		inner := outer.Statements.Items[0].(*nodes.PLSQLBlock)
+		if got := sql[inner.Loc.Start:]; !strings.HasPrefix(got, "<<x>>") {
+			t.Fatalf("inner block starts at %q, want at the label", got[:10])
+		}
+		if nodes.NodeLoc(&nodes.PLSQLLabeledStatement{Loc: nodes.Loc{Start: 1, End: 2}}).Start != 1 {
+			t.Fatal("NodeLoc missing PLSQLLabeledStatement case")
+		}
+	})
+
 	t.Run("loop keeps first label on its Label field", func(t *testing.T) {
 		list, err := Parse("BEGIN <<lp>> LOOP EXIT lp; END LOOP lp; END;")
 		if err != nil {

--- a/oracle/parser/plsql_label_test.go
+++ b/oracle/parser/plsql_label_test.go
@@ -1,0 +1,82 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	nodes "github.com/bytebase/omni/oracle/ast"
+)
+
+// TestPLSQLStatementLabels pins <<label>> support on every statement kind:
+// one or more labels may precede ANY PL/SQL statement, not only blocks
+// (engine-verified on Oracle 23ai Free, including multiple labels and GOTO
+// targets). Blocks and loops keep their first label on their own Label
+// field for END-label matching; other statements carry labels on a
+// PLSQLLabeledStatement wrapper.
+func TestPLSQLStatementLabels(t *testing.T) {
+	accepts := []struct {
+		name string
+		sql  string
+	}{
+		{"label + assignment", "BEGIN <<lbl>> x := 1; END;"},
+		{"label + record field assignment", "BEGIN <<end_check>> v_row.input_note := a || '|' || b; END;"},
+		{"label + null", "BEGIN <<lbl>> NULL; END;"},
+		{"label + procedure call", "BEGIN <<lbl>> dbms_output.put_line('x'); END;"},
+		{"label + if", "BEGIN <<lbl>> IF a THEN NULL; END IF; END;"},
+		{"label + goto target flow", "BEGIN GOTO done; <<done>> NULL; END;"},
+		{"two labels one statement", "BEGIN <<a>> <<b>> x := 1; END;"},
+		{"label + block", "BEGIN <<outer>> BEGIN NULL; END; END;"},
+		{"label + basic loop with end label", "BEGIN <<lp>> LOOP EXIT lp; END LOOP lp; END;"},
+		{"label + for loop", "BEGIN <<lp>> FOR i IN 1 .. 3 LOOP NULL; END LOOP lp; END;"},
+		{"label + while loop", "BEGIN <<lp>> WHILE a LOOP NULL; END LOOP lp; END;"},
+		{"customer shape: label then labeled assignment in package body",
+			"CREATE OR REPLACE PACKAGE BODY p IS PROCEDURE q IS BEGIN <<end_check>> v_row.input_note := a; END; END;"},
+	}
+	for _, tc := range accepts {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := Parse(tc.sql); err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+		})
+	}
+
+	t.Run("unclosed label rejected", func(t *testing.T) {
+		if _, err := Parse("BEGIN <<lbl x := 1; END;"); err == nil {
+			t.Fatal("expected parse error for unclosed label")
+		}
+	})
+
+	t.Run("loop keeps first label on its Label field", func(t *testing.T) {
+		list, err := Parse("BEGIN <<lp>> LOOP EXIT lp; END LOOP lp; END;")
+		if err != nil {
+			t.Fatalf("parse failed: %v", err)
+		}
+		block := list.Items[0].(*nodes.RawStmt).Stmt.(*nodes.PLSQLBlock)
+		loop, ok := block.Statements.Items[0].(*nodes.PLSQLLoop)
+		if !ok {
+			t.Fatalf("expected PLSQLLoop, got %T", block.Statements.Items[0])
+		}
+		if loop.Label != "LP" && loop.Label != "lp" {
+			t.Fatalf("loop label = %q, want lp", loop.Label)
+		}
+	})
+
+	t.Run("plain statement labels ride the wrapper", func(t *testing.T) {
+		list, err := Parse("BEGIN <<a>> <<b>> x := 1; END;")
+		if err != nil {
+			t.Fatalf("parse failed: %v", err)
+		}
+		block := list.Items[0].(*nodes.RawStmt).Stmt.(*nodes.PLSQLBlock)
+		wrapped, ok := block.Statements.Items[0].(*nodes.PLSQLLabeledStatement)
+		if !ok {
+			t.Fatalf("expected PLSQLLabeledStatement, got %T", block.Statements.Items[0])
+		}
+		if len(wrapped.Labels) != 2 {
+			t.Fatalf("labels = %v, want 2", wrapped.Labels)
+		}
+		out := nodes.NodeToString(list)
+		if !strings.Contains(out, ":labels") {
+			t.Fatalf("expected :labels in output, got %s", out)
+		}
+	})
+}

--- a/oracle/parser/plsql_label_test.go
+++ b/oracle/parser/plsql_label_test.go
@@ -40,6 +40,14 @@ func TestPLSQLStatementLabels(t *testing.T) {
 		})
 	}
 
+	// Documented over-accepts (parser-unsure -> accept direction, per the
+	// failure-direction contract; the engine rejects these):
+	//   - a label inside a DECLARE section
+	//   - INSERT INTO t (a, b) VALUES rec (column list with record form)
+	//   - the record form in plain SQL outside PL/SQL
+	// Recorded by cross-validation; revisit only with engine-anchored
+	// tightening.
+
 	t.Run("unclosed label rejected", func(t *testing.T) {
 		if _, err := Parse("BEGIN <<lbl x := 1; END;"); err == nil {
 			t.Fatal("expected parse error for unclosed label")

--- a/oracle/parser/testdata/coverage/loc_node_coverage.tsv
+++ b/oracle/parser/testdata/coverage/loc_node_coverage.tsv
@@ -254,3 +254,4 @@ node_type	family	status	fixture	notes	debt_class	approval	next_action
 *nodes.PLSQLPipeRow	plsql	covered	CREATE FUNCTION f RETURN NUMBER PIPELINED IS BEGIN PIPE ROW (1); RETURN; END;	direct parser fixture added by strict Loc audit	none	covered	keep_regression_guard
 *nodes.PLSQLPragma	plsql	covered	DECLARE PRAGMA AUTONOMOUS_TRANSACTION; BEGIN NULL; END;	direct parser fixture added by strict Loc audit	none	covered	keep_regression_guard
 *nodes.ExceptionHandler	plsql	covered	BEGIN RAISE; EXCEPTION WHEN OTHERS THEN NULL; END;	direct parser fixture added by strict Loc audit	none	covered	keep_regression_guard
+*nodes.PLSQLLabeledStatement	plsql	covered	BEGIN <<a>> <<b>> x := 1; END;	labeled statement wrapper span (BYT-9909 label support)	none	covered	keep_regression_guard


### PR DESCRIPTION
Fixes the confirmed defect from BYT-9909 statement 3 (customer package failing SQL review at line 498, `<<end_check>>` followed by a record-field assignment).

## Problem

`parsePLSQLStatement` treated `tokLABELOPEN` as "labeled block" and dispatched to `parsePLSQLBlock` unconditionally, so a `<<label>>` before any non-block statement failed. Systematic probe: labeled assignment / NULL / procedure call / IF / double labels all rejected, while the same statements without labels pass. Engine-verified on Oracle 23ai Free: one or more labels are legal before ANY statement (GOTO targets included, multi-label included).

## Fix

Consume all leading `<<ident>>` labels, recurse into statement parsing, then attach: `PLSQLBlock`/`PLSQLLoop` keep their first label on their existing `Label` field (END-label matching untouched); any other statement — or labels beyond the first — ride on a new `PLSQLLabeledStatement` wrapper (`Labels []string` + `Statement`), serialized with `:labels`/`:statement` and wired into the generated walker.

With this fix the customer's package body parses past the failing line (the truncated attachment text now errors only at its Excel truncation point).

## Tests

`TestPLSQLStatementLabels`: 12 accept shapes (every statement kind, GOTO-target flow, loop END-label matching, the customer's package-body shape), unclosed-label reject, and AST-shape assertions (loop keeps `Label`, wrapper carries multi-labels, `:labels` serialized).

Consumer note for the next bytebase bump: walkthrough/span switches should treat `PLSQLLabeledStatement` as transparent (recurse into `.Statement`); labels carry no data flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)