### PR TITLE
mongo: make Parse strict, reserve recovery for ParseBestEffort

### DIFF
--- a/mongo/parse.go
+++ b/mongo/parse.go
@@ -46,13 +46,13 @@ type ParseResult struct {
 // Parse splits and parses a mongosh input string into statements.
 // Each statement includes the text, AST, and byte/line positions.
 //
-// On syntax error the parser recovers by skipping to the next statement
-// boundary and continues parsing. Returns a non-nil error only when no
-// statements could be parsed at all. Use ParseBestEffort for both partial
-// results and errors.
+// Parse is strict: it returns a non-nil error (the first one encountered)
+// when any statement in the input fails to parse, so callers never silently
+// lose statements. Use ParseBestEffort to recover partial results together
+// with all errors.
 func Parse(input string) ([]Statement, error) {
 	result := ParseBestEffort(input)
-	if len(result.Statements) == 0 && len(result.Errors) > 0 {
+	if len(result.Errors) > 0 {
 		return nil, result.Errors[0]
 	}
 	return result.Statements, nil

--- a/mongo/parse_test.go
+++ b/mongo/parse_test.go
@@ -1,0 +1,67 @@
+package mongo_test
+
+import (
+	"errors"
+	"testing"
+
+	mongo "github.com/bytebase/omni/mongo"
+	"github.com/bytebase/omni/mongo/parser"
+)
+
+// TestParseStrict pins the strict contract of Parse: any statement that fails
+// to parse fails the whole input, so callers never silently lose statements
+// (BYT-9950: a dropped statement made a migration appear to skip a command).
+func TestParseStrict(t *testing.T) {
+	t.Run("mixed valid and invalid fails", func(t *testing.T) {
+		input := "db.users.find();\nthis is not mongosh\ndb.orders.find();"
+		_, err := mongo.Parse(input)
+		if err == nil {
+			t.Fatal("expected error for input containing an invalid statement")
+		}
+		var pe *parser.ParseError
+		if !errors.As(err, &pe) {
+			t.Fatalf("expected *parser.ParseError, got %T: %v", err, err)
+		}
+		if pe.Line != 2 {
+			t.Errorf("expected error on line 2, got %d", pe.Line)
+		}
+	})
+
+	t.Run("best effort recovers partial results", func(t *testing.T) {
+		input := "db.users.find();\nthis is not mongosh\ndb.orders.find();"
+		result := mongo.ParseBestEffort(input)
+		if len(result.Statements) != 2 {
+			t.Fatalf("expected 2 statements, got %d", len(result.Statements))
+		}
+		if len(result.Errors) != 1 {
+			t.Fatalf("expected 1 error, got %d", len(result.Errors))
+		}
+	})
+
+	t.Run("all valid succeeds", func(t *testing.T) {
+		input := "db.users.find();\ndb.orders.countDocuments();"
+		stmts, err := mongo.Parse(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(stmts) != 2 {
+			t.Fatalf("expected 2 statements, got %d", len(stmts))
+		}
+	})
+}
+
+// TestParseCreateIndexArithmetic pins the BYT-9950 statement: createIndex with
+// a constant arithmetic TTL expression must parse through the public API.
+func TestParseCreateIndexArithmetic(t *testing.T) {
+	input := `db.cs_customer_frequency.createIndex(
+  { trans_date: 1 },
+  { expireAfterSeconds: 90 * 24 * 60 * 60, name: "cs_customer_frequency_idx2" }
+);`
+	stmts, err := mongo.Parse(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(stmts))
+	}
+}

--- a/mongo/parser/parser.go
+++ b/mongo/parser/parser.go
@@ -25,13 +25,13 @@ type ParseResult struct {
 // Parse parses a mongosh input string into a list of AST nodes.
 // Each semicolon-separated or newline-separated command becomes one node.
 //
-// On syntax error the parser recovers by skipping to the next statement
-// boundary and continues parsing. Returns a non-nil error only when no
-// statements could be parsed at all; otherwise partial results are returned
-// and errors are available via ParseBestEffort.
+// Parse is strict: it returns a non-nil error (the first one encountered)
+// when any statement in the input fails to parse, so callers never silently
+// lose statements. Use ParseBestEffort to recover partial results together
+// with all errors.
 func Parse(input string) ([]ast.Node, error) {
 	result := ParseBestEffort(input)
-	if len(result.Nodes) == 0 && len(result.Errors) > 0 {
+	if len(result.Errors) > 0 {
 		return nil, result.Errors[0]
 	}
 	return result.Nodes, nil

--- a/mongo/parsertest/error_test.go
+++ b/mongo/parsertest/error_test.go
@@ -83,16 +83,21 @@ func TestErrorPosition(t *testing.T) {
 
 func TestErrorOnSecondLine(t *testing.T) {
 	input := "show dbs\nfoobar"
-	// Parse recovers: returns the valid "show dbs" statement, error is nil.
-	nodes, err := parser.Parse(input)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	// Parse is strict: the invalid "foobar" statement fails the whole input
+	// even though "show dbs" parses.
+	_, err := parser.Parse(input)
+	if err == nil {
+		t.Fatal("expected error for input with an invalid statement")
 	}
-	if len(nodes) != 1 {
-		t.Fatalf("expected 1 node, got %d", len(nodes))
+	var strictErr *parser.ParseError
+	if !errors.As(err, &strictErr) {
+		t.Fatalf("expected *parser.ParseError, got %T: %v", err, err)
+	}
+	if strictErr.Line != 2 {
+		t.Errorf("expected line 2, got %d", strictErr.Line)
 	}
 
-	// ParseBestEffort exposes the error for "foobar".
+	// ParseBestEffort recovers the valid statement and exposes the error for "foobar".
 	result := parser.ParseBestEffort(input)
 	if len(result.Nodes) != 1 {
 		t.Fatalf("expected 1 node, got %d", len(result.Nodes))


### PR DESCRIPTION
## What

`mongo.Parse` and `mongo/parser.Parse` now return the first parse error whenever **any** statement in the input fails to parse. Previously they recovered by dropping unparseable statements and returned partial results with a nil error whenever at least one statement parsed — an error was reported only when *nothing* parsed.

`ParseBestEffort` is unchanged and remains the lenient API for callers that want partial results plus all errors (LSP diagnostics, statement ranges, mid-typing UX).

## Why

The lenient `Parse` silently lost statements for split-then-execute consumers. In Bytebase (BYT-9950), a migration batch containing one unparseable MongoDB statement executed the remaining statements and reported task success — the failing statement vanished from execution logs entirely. Strictness guarantees no statement is ever silently dropped: callers either get every statement or an error.

Consumers audited:
- **bytebase** funnels all omni mongo access through `ParseMongoShell` (strict is fail-closed for split/execute, SQL review, query classification; LSP paths already use `ParseMongoShellBestEffort`).
- **gomongo** `translator.Parse` translates a single statement and already propagates parse errors; a companion PR tightens its single-statement contract.

## Testing

- `TestParseStrict` pins the new contract (mixed valid+invalid fails, best-effort recovers partials, all-valid passes).
- `TestParseCreateIndexArithmeticTTL` pins the BYT-9950 statement (`expireAfterSeconds: 90 * 24 * 60 * 60`, folded by #393) parsing through the public API.
- `TestErrorOnSecondLine` updated from the lenient to the strict expectation.
- `go test ./mongo/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)