### PR TITLE
oracle: support constraint_state clause on constraints (BYT-10010)

### DIFF
--- a/oracle/ast/outfuncs.go
+++ b/oracle/ast/outfuncs.go
@@ -2879,6 +2879,10 @@ func writeCreateViewStmt(sb *strings.Builder, n *CreateViewStmt) {
 		sb.WriteString(" :columns ")
 		writeNode(sb, n.Columns)
 	}
+	if n.Constraints != nil {
+		sb.WriteString(" :constraints ")
+		writeNode(sb, n.Constraints)
+	}
 	if n.Query != nil {
 		sb.WriteString(" :query ")
 		writeNode(sb, n.Query)

--- a/oracle/ast/outfuncs.go
+++ b/oracle/ast/outfuncs.go
@@ -2067,6 +2067,12 @@ func writeColumnConstraint(sb *strings.Builder, n *ColumnConstraint) {
 	if n.Initially != "" {
 		sb.WriteString(fmt.Sprintf(" :initially %q", n.Initially))
 	}
+	if n.Tablespace != "" {
+		sb.WriteString(fmt.Sprintf(" :tablespace %q", n.Tablespace))
+	}
+	if n.UsingIndexLocal {
+		sb.WriteString(" :usingIndexLocal true")
+	}
 	sb.WriteString(fmt.Sprintf(" :loc_start %d :loc_end %d", n.Loc.Start, n.Loc.End))
 	sb.WriteString("}")
 }
@@ -2104,6 +2110,9 @@ func writeTableConstraint(sb *strings.Builder, n *TableConstraint) {
 	}
 	if n.Tablespace != "" {
 		sb.WriteString(fmt.Sprintf(" :tablespace %q", n.Tablespace))
+	}
+	if n.UsingIndexLocal {
+		sb.WriteString(" :usingIndexLocal true")
 	}
 	sb.WriteString(fmt.Sprintf(" :loc_start %d :loc_end %d", n.Loc.Start, n.Loc.End))
 	sb.WriteString("}")

--- a/oracle/ast/parsenodes.go
+++ b/oracle/ast/parsenodes.go
@@ -1818,6 +1818,7 @@ type CreateViewStmt struct {
 	Materialized      bool        // MATERIALIZED VIEW
 	Name              *ObjectName // view name
 	Columns           *List       // column aliases
+	Constraints       *List       // out-of-line view constraints (list of *TableConstraint)
 	Query             StmtNode    // AS SELECT ...
 	WithCheckOpt      bool        // WITH CHECK OPTION
 	WithReadOnly      bool        // WITH READ ONLY

--- a/oracle/ast/parsenodes.go
+++ b/oracle/ast/parsenodes.go
@@ -1608,32 +1608,35 @@ func (n *IdentityClause) nodeTag() {}
 
 // ColumnConstraint represents a column-level constraint.
 type ColumnConstraint struct {
-	Name       string         // constraint name (nil if unnamed)
-	Type       ConstraintType // constraint type
-	Expr       ExprNode       // CHECK expression
-	RefTable   *ObjectName    // REFERENCES table
-	RefColumns *List          // REFERENCES columns
-	OnDelete   string         // ON DELETE action
-	Deferrable bool           // DEFERRABLE
-	Initially  string         // INITIALLY DEFERRED/IMMEDIATE
-	Loc        Loc            // start location
+	Name            string         // constraint name (nil if unnamed)
+	Type            ConstraintType // constraint type
+	Expr            ExprNode       // CHECK expression
+	RefTable        *ObjectName    // REFERENCES table
+	RefColumns      *List          // REFERENCES columns
+	OnDelete        string         // ON DELETE action
+	Deferrable      bool           // DEFERRABLE
+	Initially       string         // INITIALLY DEFERRED/IMMEDIATE
+	Tablespace      string         // USING INDEX TABLESPACE
+	UsingIndexLocal bool           // USING INDEX LOCAL
+	Loc             Loc            // start location
 }
 
 func (n *ColumnConstraint) nodeTag() {}
 
 // TableConstraint represents a table-level constraint.
 type TableConstraint struct {
-	Name       string         // constraint name
-	Type       ConstraintType // constraint type
-	Columns    *List          // constraint columns (list of *String)
-	Expr       ExprNode       // CHECK expression
-	RefTable   *ObjectName    // REFERENCES table
-	RefColumns *List          // REFERENCES columns
-	OnDelete   string         // ON DELETE action
-	Deferrable bool           // DEFERRABLE
-	Initially  string         // INITIALLY DEFERRED/IMMEDIATE
-	Tablespace string         // USING INDEX TABLESPACE
-	Loc        Loc            // start location
+	Name            string         // constraint name
+	Type            ConstraintType // constraint type
+	Columns         *List          // constraint columns (list of *String)
+	Expr            ExprNode       // CHECK expression
+	RefTable        *ObjectName    // REFERENCES table
+	RefColumns      *List          // REFERENCES columns
+	OnDelete        string         // ON DELETE action
+	Deferrable      bool           // DEFERRABLE
+	Initially       string         // INITIALLY DEFERRED/IMMEDIATE
+	Tablespace      string         // USING INDEX TABLESPACE
+	UsingIndexLocal bool           // USING INDEX LOCAL
+	Loc             Loc            // start location
 }
 
 func (n *TableConstraint) nodeTag() {}

--- a/oracle/ast/walk_generated.go
+++ b/oracle/ast/walk_generated.go
@@ -723,6 +723,7 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.Name)
 		}
 		walkList(v, n.Columns)
+		walkList(v, n.Constraints)
 		Walk(v, n.Query)
 		Walk(v, n.StartWith)
 		Walk(v, n.Next)

--- a/oracle/parser/alter_misc.go
+++ b/oracle/parser/alter_misc.go
@@ -1333,7 +1333,9 @@ func (p *Parser) parseAlterMaterializedViewStmt(start int) (nodes.StmtNode, erro
 		p.advance()
 
 	case p.cur.Type == kwUSING && p.peekNext().Type == kwINDEX:
-		// USING INDEX index_properties
+		// USING INDEX index_properties. Deliberately lenient: Oracle 23ai
+		// rejects PCTFREE here (ORA-02243) while accepting INITRANS/STORAGE,
+		// but this parser accepts the full property set.
 		stmt.Action = "USING_INDEX"
 		var cs constraintState
 		if err := p.parseUsingIndexClause(&cs); err != nil {

--- a/oracle/parser/alter_misc.go
+++ b/oracle/parser/alter_misc.go
@@ -1333,12 +1333,15 @@ func (p *Parser) parseAlterMaterializedViewStmt(start int) (nodes.StmtNode, erro
 		p.advance()
 
 	case p.cur.Type == kwUSING && p.peekNext().Type == kwINDEX:
-		// USING INDEX index_properties. Deliberately lenient: Oracle 23ai
-		// rejects PCTFREE here (ORA-02243) while accepting INITRANS/STORAGE,
-		// but this parser accepts the full property set.
+		// USING INDEX index_properties (properties only, like CREATE MV).
+		// Deliberately lenient: Oracle 23ai rejects PCTFREE here (ORA-02243)
+		// while accepting INITRANS/STORAGE, but this parser accepts the full
+		// property set.
 		stmt.Action = "USING_INDEX"
+		p.advance() // consume USING
+		p.advance() // consume INDEX
 		var cs constraintState
-		if err := p.parseUsingIndexClause(&cs); err != nil {
+		if err := p.parseUsingIndexProperties(&cs); err != nil {
 			return nil, err
 		}
 

--- a/oracle/parser/alter_misc.go
+++ b/oracle/parser/alter_misc.go
@@ -1332,6 +1332,14 @@ func (p *Parser) parseAlterMaterializedViewStmt(start int) (nodes.StmtNode, erro
 		stmt.Action = "NOCACHE"
 		p.advance()
 
+	case p.cur.Type == kwUSING && p.peekNext().Type == kwINDEX:
+		// USING INDEX index_properties
+		stmt.Action = "USING_INDEX"
+		var cs constraintState
+		if err := p.parseUsingIndexClause(&cs); err != nil {
+			return nil, err
+		}
+
 	case p.cur.Type == kwPARALLEL:
 		stmt.Action = "PARALLEL"
 		p.advance() // consume PARALLEL

--- a/oracle/parser/alter_misc.go
+++ b/oracle/parser/alter_misc.go
@@ -2849,13 +2849,16 @@ func (p *Parser) parseAlterViewStmt(start int) (nodes.StmtNode, error) {
 
 	case p.cur.Type == kwADD:
 		stmt.Action = "ADD_CONSTRAINT"
-		p.advance()
-		var // consume ADD
-		parseErr81 error
-		stmt.Constraint, parseErr81 = p.parseTableConstraint()
+		p.advance() // consume ADD
+		tc, parseErr81 := p.parseTableConstraintBody()
 		if parseErr81 != nil {
 			return nil, parseErr81
 		}
+		if err := p.parseViewConstraintState(); err != nil {
+			return nil, err
+		}
+		tc.Loc.End = p.prev.End
+		stmt.Constraint = tc
 
 	case p.cur.Type == kwMODIFY:
 		p.advance() // consume MODIFY

--- a/oracle/parser/alter_misc_test.go
+++ b/oracle/parser/alter_misc_test.go
@@ -146,3 +146,17 @@ func TestParseAlterLocSet(t *testing.T) {
 		t.Errorf("expected Loc.End > Loc.Start, got End=%d", stmt.Loc.End)
 	}
 }
+
+// TestParseAlterMaterializedViewUsingIndex tests ALTER MATERIALIZED VIEW
+// USING INDEX index_properties.
+func TestParseAlterMaterializedViewUsingIndex(t *testing.T) {
+	result := ParseAndCheck(t, "ALTER MATERIALIZED VIEW mv USING INDEX PCTFREE 10")
+	raw := result.Items[0].(*ast.RawStmt)
+	stmt, ok := raw.Stmt.(*ast.AlterMaterializedViewStmt)
+	if !ok {
+		t.Fatalf("expected AlterMaterializedViewStmt, got %T", raw.Stmt)
+	}
+	if stmt.Action != "USING_INDEX" {
+		t.Errorf("expected action USING_INDEX, got %q", stmt.Action)
+	}
+}

--- a/oracle/parser/alter_table.go
+++ b/oracle/parser/alter_table.go
@@ -396,13 +396,20 @@ func (p *Parser) parseAlterTableModify() (*nodes.AlterTableCmd, error) {
 			return nil, parseErr141
 		}
 
-		p.skipConstraintState()
+		var cs constraintState
+		if err := p.parseConstraintState(&cs); err != nil {
+			return nil, err
+		}
 		if p.cur.Type == kwCASCADE {
 			p.advance()
 		}
 		tc := &nodes.TableConstraint{
-			Name: name,
-			Loc:  nodes.Loc{Start: start, End: p.prev.End},
+			Name:            name,
+			Deferrable:      cs.Deferrable,
+			Initially:       cs.Initially,
+			Tablespace:      cs.Tablespace,
+			UsingIndexLocal: cs.UsingIndexLocal,
+			Loc:             nodes.Loc{Start: start, End: p.prev.End},
 		}
 		return &nodes.AlterTableCmd{
 			Action:     nodes.AT_MODIFY_CONSTRAINT,
@@ -417,7 +424,10 @@ func (p *Parser) parseAlterTableModify() (*nodes.AlterTableCmd, error) {
 		if p.cur.Type == kwKEY {
 			p.advance() // consume KEY
 		}
-		p.skipConstraintState()
+		var cs constraintState
+		if err := p.parseConstraintState(&cs); err != nil {
+			return nil, err
+		}
 		if p.cur.Type == kwCASCADE {
 			p.advance()
 		}
@@ -434,7 +444,10 @@ func (p *Parser) parseAlterTableModify() (*nodes.AlterTableCmd, error) {
 		if p.cur.Type == '(' {
 			p.skipParenthesized()
 		}
-		p.skipConstraintState()
+		var cs constraintState
+		if err := p.parseConstraintState(&cs); err != nil {
+			return nil, err
+		}
 		if p.cur.Type == kwCASCADE {
 			p.advance()
 		}
@@ -1275,16 +1288,10 @@ func (p *Parser) parseAlterTableEnableDisable() (*nodes.AlterTableCmd, error) {
 	}
 
 	// [ USING INDEX ... ]
-	if p.cur.Type == kwUSING {
-		p.advance()
-		if p.cur.Type == kwINDEX {
-			p.advance()
-		}
-		if p.cur.Type == '(' {
-			p.skipParenthesized()
-		} else if p.isIdentLike() && !p.isAlterTableActionStart() {
-			// index attributes or index name
-			p.collectAlterTableClauseDetails()
+	if p.cur.Type == kwUSING && p.peekNext().Type == kwINDEX {
+		var cs constraintState
+		if err := p.parseUsingIndexClause(&cs); err != nil {
+			return nil, err
 		}
 	}
 
@@ -2278,65 +2285,6 @@ func (p *Parser) parsePartitionNameOrFor() (string, error) {
 		return p.parseIdentifier()
 	}
 	return "", nil
-}
-
-// skipConstraintState skips constraint state tokens:
-// [ [NOT] DEFERRABLE [INITIALLY {DEFERRED|IMMEDIATE}] ]
-// [ RELY | NORELY ]
-// [ USING INDEX ... ]
-// [ { ENABLE | DISABLE } ]
-// [ { VALIDATE | NOVALIDATE } ]
-// [ exceptions_clause ]
-func (p *Parser) skipConstraintState() {
-	for p.cur.Type != ';' && p.cur.Type != tokEOF {
-		switch p.cur.Type {
-		case kwNOT:
-			p.advance()
-			if p.cur.Type == kwDEFERRED || p.isIdentLikeStr("DEFERRABLE") {
-				p.advance()
-			}
-		case kwDEFERRED:
-			p.advance()
-		case kwIMMEDIATE:
-			p.advance()
-		case kwENABLE, kwDISABLE:
-			p.advance()
-		case kwVALIDATE:
-			p.advance()
-		case kwUSING:
-			p.advance()
-			if p.cur.Type == kwINDEX {
-				p.advance()
-			}
-			if p.cur.Type == '(' {
-				p.skipParenthesized()
-			} else if p.isIdentLike() && !p.isAlterTableActionStart() {
-				p.parseIdentifier()
-			}
-		default:
-			if p.isIdentLikeStr("DEFERRABLE") || p.isIdentLikeStr("INITIALLY") {
-				p.advance()
-				continue
-			}
-			if p.isIdentLikeStr("NOVALIDATE") || p.isIdentLikeStr("NORELY") {
-				p.advance()
-				continue
-			}
-			if p.cur.Type == kwRELY {
-				p.advance()
-				continue
-			}
-			if p.isIdentLikeStr("EXCEPTIONS") {
-				p.advance()
-				if p.cur.Type == kwINTO {
-					p.advance()
-					p.parseObjectName()
-				}
-				continue
-			}
-			return
-		}
-	}
 }
 
 // skipDropColumnTrailing skips CASCADE CONSTRAINTS, INVALIDATE, CHECKPOINT, ONLINE after DROP COLUMN.

--- a/oracle/parser/alter_table.go
+++ b/oracle/parser/alter_table.go
@@ -224,6 +224,11 @@ func (p *Parser) parseAlterTableAdd() (*nodes.AlterTableCmd, error) {
 		if parseErr134 != nil {
 			return nil, parseErr134
 		}
+		// [ EXCEPTIONS INTO table ] — legal on ADD CONSTRAINT (unlike
+		// CREATE TABLE constraints), verified against Oracle 23ai.
+		if err := p.parseExceptionsIntoClause(); err != nil {
+			return nil, err
+		}
 		return &nodes.AlterTableCmd{
 			Action:     nodes.AT_ADD_CONSTRAINT,
 			Constraint: tc,

--- a/oracle/parser/alter_table.go
+++ b/oracle/parser/alter_table.go
@@ -400,6 +400,9 @@ func (p *Parser) parseAlterTableModify() (*nodes.AlterTableCmd, error) {
 		if err := p.parseConstraintState(&cs); err != nil {
 			return nil, err
 		}
+		if err := p.parseExceptionsIntoClause(); err != nil {
+			return nil, err
+		}
 		if p.cur.Type == kwCASCADE {
 			p.advance()
 		}
@@ -428,6 +431,9 @@ func (p *Parser) parseAlterTableModify() (*nodes.AlterTableCmd, error) {
 		if err := p.parseConstraintState(&cs); err != nil {
 			return nil, err
 		}
+		if err := p.parseExceptionsIntoClause(); err != nil {
+			return nil, err
+		}
 		if p.cur.Type == kwCASCADE {
 			p.advance()
 		}
@@ -446,6 +452,9 @@ func (p *Parser) parseAlterTableModify() (*nodes.AlterTableCmd, error) {
 		}
 		var cs constraintState
 		if err := p.parseConstraintState(&cs); err != nil {
+			return nil, err
+		}
+		if err := p.parseExceptionsIntoClause(); err != nil {
 			return nil, err
 		}
 		if p.cur.Type == kwCASCADE {
@@ -1296,20 +1305,11 @@ func (p *Parser) parseAlterTableEnableDisable() (*nodes.AlterTableCmd, error) {
 	}
 
 	// [ EXCEPTIONS INTO table ]
-	if p.isIdentLikeStr("EXCEPTIONS") {
-		p.advance()
-		if p.cur.Type == kwINTO {
-			p.advance()
-			parseDiscard181, parseErr180 := p.parseObjectName()
-			_ = parseDiscard181
-
-			// [ CASCADE ]
-			if parseErr180 != nil {
-				return nil, parseErr180
-			}
-		}
+	if err := p.parseExceptionsIntoClause(); err != nil {
+		return nil, err
 	}
 
+	// [ CASCADE ]
 	if p.cur.Type == kwCASCADE {
 		p.advance()
 	}

--- a/oracle/parser/alter_table.go
+++ b/oracle/parser/alter_table.go
@@ -440,7 +440,15 @@ func (p *Parser) parseAlterTableModify() (*nodes.AlterTableCmd, error) {
 		return &nodes.AlterTableCmd{
 			Action:  nodes.AT_MODIFY_CONSTRAINT,
 			Subtype: "PRIMARY KEY",
-			Loc:     nodes.Loc{Start: start, End: p.prev.End},
+			Constraint: &nodes.TableConstraint{
+				Type:            nodes.CONSTRAINT_PRIMARY,
+				Deferrable:      cs.Deferrable,
+				Initially:       cs.Initially,
+				Tablespace:      cs.Tablespace,
+				UsingIndexLocal: cs.UsingIndexLocal,
+				Loc:             nodes.Loc{Start: start, End: p.prev.End},
+			},
+			Loc: nodes.Loc{Start: start, End: p.prev.End},
 		}, nil
 	}
 
@@ -463,7 +471,15 @@ func (p *Parser) parseAlterTableModify() (*nodes.AlterTableCmd, error) {
 		return &nodes.AlterTableCmd{
 			Action:  nodes.AT_MODIFY_CONSTRAINT,
 			Subtype: "UNIQUE",
-			Loc:     nodes.Loc{Start: start, End: p.prev.End},
+			Constraint: &nodes.TableConstraint{
+				Type:            nodes.CONSTRAINT_UNIQUE,
+				Deferrable:      cs.Deferrable,
+				Initially:       cs.Initially,
+				Tablespace:      cs.Tablespace,
+				UsingIndexLocal: cs.UsingIndexLocal,
+				Loc:             nodes.Loc{Start: start, End: p.prev.End},
+			},
+			Loc: nodes.Loc{Start: start, End: p.prev.End},
 		}, nil
 	}
 

--- a/oracle/parser/alter_table_test.go
+++ b/oracle/parser/alter_table_test.go
@@ -401,3 +401,30 @@ func TestParseAlterTableModifyConstraintExceptions(t *testing.T) {
 	ParseShouldFail(t, "CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) EXCEPTIONS INTO bad_rows DISABLE)")
 	ParseShouldFail(t, "CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) ENABLE VALIDATE EXCEPTIONS INTO bad_rows)")
 }
+
+// TestParseAlterTableModifyPKPreservesState tests that MODIFY PRIMARY KEY /
+// UNIQUE attach the parsed constraint_state to the AST instead of
+// discarding it.
+func TestParseAlterTableModifyPKPreservesState(t *testing.T) {
+	result := ParseAndCheck(t, "ALTER TABLE t MODIFY PRIMARY KEY USING INDEX LOCAL")
+	raw := result.Items[0].(*ast.RawStmt)
+	stmt := raw.Stmt.(*ast.AlterTableStmt)
+	cmd := stmt.Actions.Items[0].(*ast.AlterTableCmd)
+	if cmd.Constraint == nil {
+		t.Fatal("expected non-nil Constraint on MODIFY PRIMARY KEY")
+	}
+	if cmd.Constraint.Type != ast.CONSTRAINT_PRIMARY {
+		t.Errorf("expected CONSTRAINT_PRIMARY, got %d", cmd.Constraint.Type)
+	}
+	if !cmd.Constraint.UsingIndexLocal {
+		t.Error("expected UsingIndexLocal to be preserved")
+	}
+
+	result = ParseAndCheck(t, "ALTER TABLE t MODIFY UNIQUE (a) USING INDEX TABLESPACE ts1")
+	raw = result.Items[0].(*ast.RawStmt)
+	stmt = raw.Stmt.(*ast.AlterTableStmt)
+	cmd = stmt.Actions.Items[0].(*ast.AlterTableCmd)
+	if cmd.Constraint == nil || cmd.Constraint.Tablespace != "TS1" {
+		t.Fatalf("expected Tablespace TS1 on MODIFY UNIQUE, got %+v", cmd.Constraint)
+	}
+}

--- a/oracle/parser/alter_table_test.go
+++ b/oracle/parser/alter_table_test.go
@@ -428,3 +428,15 @@ func TestParseAlterTableModifyPKPreservesState(t *testing.T) {
 		t.Fatalf("expected Tablespace TS1 on MODIFY UNIQUE, got %+v", cmd.Constraint)
 	}
 }
+
+// TestParseAlterTableAddConstraintExceptions tests EXCEPTIONS INTO on ADD
+// CONSTRAINT, verified accepted by Oracle 23ai.
+func TestParseAlterTableAddConstraintExceptions(t *testing.T) {
+	result := ParseAndCheck(t, "ALTER TABLE t ADD CONSTRAINT pk PRIMARY KEY (a) ENABLE VALIDATE EXCEPTIONS INTO bad_rows")
+	raw := result.Items[0].(*ast.RawStmt)
+	stmt := raw.Stmt.(*ast.AlterTableStmt)
+	cmd := stmt.Actions.Items[0].(*ast.AlterTableCmd)
+	if cmd.Action != ast.AT_ADD_CONSTRAINT || cmd.Constraint == nil {
+		t.Fatal("expected ADD_CONSTRAINT with constraint")
+	}
+}

--- a/oracle/parser/alter_table_test.go
+++ b/oracle/parser/alter_table_test.go
@@ -391,3 +391,13 @@ func TestParseAlterTableEnableConstraintUsingIndex(t *testing.T) {
 		})
 	}
 }
+
+// TestParseAlterTableModifyConstraintExceptions tests EXCEPTIONS INTO in
+// ALTER contexts (legal) — it is rejected inside CREATE TABLE constraints,
+// matching Oracle 23ai.
+func TestParseAlterTableModifyConstraintExceptions(t *testing.T) {
+	ParseAndCheck(t, "ALTER TABLE t MODIFY CONSTRAINT pk ENABLE VALIDATE EXCEPTIONS INTO bad_rows")
+	ParseAndCheck(t, "ALTER TABLE t MODIFY PRIMARY KEY ENABLE VALIDATE EXCEPTIONS INTO s.bad_rows")
+	ParseShouldFail(t, "CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) EXCEPTIONS INTO bad_rows DISABLE)")
+	ParseShouldFail(t, "CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) ENABLE VALIDATE EXCEPTIONS INTO bad_rows)")
+}

--- a/oracle/parser/alter_table_test.go
+++ b/oracle/parser/alter_table_test.go
@@ -312,3 +312,82 @@ func findAlterTableOption(cmd *ast.AlterTableCmd, key string) *ast.DDLOption {
 	}
 	return nil
 }
+
+// TestParseAlterTableAddConstraintUsingIndex tests ALTER TABLE ADD CONSTRAINT
+// with a using_index_clause (BYT-10010).
+func TestParseAlterTableAddConstraintUsingIndex(t *testing.T) {
+	result := ParseAndCheck(t, "ALTER TABLE t ADD CONSTRAINT pk PRIMARY KEY (a) USING INDEX TABLESPACE ts1")
+	raw := result.Items[0].(*ast.RawStmt)
+	stmt := raw.Stmt.(*ast.AlterTableStmt)
+	cmd := stmt.Actions.Items[0].(*ast.AlterTableCmd)
+	if cmd.Action != ast.AT_ADD_CONSTRAINT {
+		t.Errorf("expected AT_ADD_CONSTRAINT, got %d", cmd.Action)
+	}
+	if cmd.Constraint == nil {
+		t.Fatal("expected non-nil Constraint")
+	}
+	if cmd.Constraint.Tablespace != "TS1" {
+		t.Errorf("expected Tablespace TS1, got %q", cmd.Constraint.Tablespace)
+	}
+}
+
+// TestParseAlterTableAddConstraintUsingIndexLocal tests ALTER TABLE ADD
+// CONSTRAINT with USING INDEX LOCAL.
+func TestParseAlterTableAddConstraintUsingIndexLocal(t *testing.T) {
+	result := ParseAndCheck(t, "ALTER TABLE t ADD CONSTRAINT pk PRIMARY KEY (a, b) USING INDEX LOCAL ENABLE")
+	raw := result.Items[0].(*ast.RawStmt)
+	stmt := raw.Stmt.(*ast.AlterTableStmt)
+	cmd := stmt.Actions.Items[0].(*ast.AlterTableCmd)
+	if cmd.Constraint == nil || !cmd.Constraint.UsingIndexLocal {
+		t.Error("expected UsingIndexLocal on added constraint")
+	}
+}
+
+// TestParseAlterTableModifyConstraintState tests MODIFY CONSTRAINT / PRIMARY
+// KEY / UNIQUE followed by constraint_state clauses.
+func TestParseAlterTableModifyConstraintState(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{"modify_pk_using_index_tablespace", "ALTER TABLE t MODIFY PRIMARY KEY USING INDEX TABLESPACE ts1"},
+		{"modify_constraint_enable_novalidate", "ALTER TABLE t MODIFY CONSTRAINT pk ENABLE NOVALIDATE"},
+		{"modify_constraint_using_index", "ALTER TABLE t MODIFY CONSTRAINT pk USING INDEX TABLESPACE ts1"},
+		{"modify_unique_disable", "ALTER TABLE t MODIFY UNIQUE (a) DISABLE"},
+		{"modify_pk_rely", "ALTER TABLE t MODIFY PRIMARY KEY RELY DISABLE NOVALIDATE"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseAndCheck(t, tt.sql)
+			raw := result.Items[0].(*ast.RawStmt)
+			stmt := raw.Stmt.(*ast.AlterTableStmt)
+			cmd := stmt.Actions.Items[0].(*ast.AlterTableCmd)
+			if cmd.Action != ast.AT_MODIFY_CONSTRAINT {
+				t.Errorf("expected AT_MODIFY_CONSTRAINT, got %d", cmd.Action)
+			}
+		})
+	}
+}
+
+// TestParseAlterTableEnableConstraintUsingIndex tests ENABLE ... USING INDEX.
+func TestParseAlterTableEnableConstraintUsingIndex(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{"enable_pk_using_index_tablespace", "ALTER TABLE t ENABLE PRIMARY KEY USING INDEX TABLESPACE ts1"},
+		{"enable_validate_constraint_using_index_name", "ALTER TABLE t ENABLE VALIDATE CONSTRAINT pk USING INDEX idx1"},
+		{"enable_constraint_using_index_exceptions", "ALTER TABLE t ENABLE CONSTRAINT pk USING INDEX EXCEPTIONS INTO bad_rows"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseAndCheck(t, tt.sql)
+			raw := result.Items[0].(*ast.RawStmt)
+			stmt := raw.Stmt.(*ast.AlterTableStmt)
+			cmd := stmt.Actions.Items[0].(*ast.AlterTableCmd)
+			if cmd.Action != ast.AT_ENABLE_DISABLE {
+				t.Errorf("expected AT_ENABLE_DISABLE, got %d", cmd.Action)
+			}
+		})
+	}
+}

--- a/oracle/parser/compare_test.go
+++ b/oracle/parser/compare_test.go
@@ -2183,9 +2183,9 @@ func TestParseCreateDimensionFull(t *testing.T) {
 // TestParseCreateDatabase tests CREATE DATABASE statements.
 func TestParseCreateDatabase(t *testing.T) {
 	tests := []struct {
-		name     string
-		sql      string
-		minOpts  int // minimum expected options count
+		name      string
+		sql       string
+		minOpts   int    // minimum expected options count
 		checkName string // expected database name (empty = no check)
 	}{
 		{"basic", "CREATE DATABASE mydb", 0, "MYDB"},
@@ -2995,61 +2995,93 @@ func TestParseAdministerKeyMgmt(t *testing.T) {
 // TestBatch100_CreateAuditPolicy tests CREATE AUDIT POLICY statements.
 func TestBatch100_CreateAuditPolicy(t *testing.T) {
 	tests := []struct {
-		name string
-		sql  string
+		name  string
+		sql   string
 		check func(t *testing.T, stmt *ast.CreateAuditPolicyStmt)
 	}{
 		{"basic_action_on_object", "CREATE AUDIT POLICY my_policy ACTIONS SELECT ON hr.employees",
 			func(t *testing.T, stmt *ast.CreateAuditPolicyStmt) {
-				if stmt.Name != "MY_POLICY" { t.Errorf("name=%q", stmt.Name) }
-				if len(stmt.Actions) != 1 { t.Errorf("actions=%d", len(stmt.Actions)) }
+				if stmt.Name != "MY_POLICY" {
+					t.Errorf("name=%q", stmt.Name)
+				}
+				if len(stmt.Actions) != 1 {
+					t.Errorf("actions=%d", len(stmt.Actions))
+				}
 			}},
 		{"all_actions", "CREATE AUDIT POLICY my_policy ACTIONS ALL",
 			func(t *testing.T, stmt *ast.CreateAuditPolicyStmt) {
-				if len(stmt.Actions) != 1 || stmt.Actions[0].Action != "ALL" { t.Errorf("expected ALL action") }
+				if len(stmt.Actions) != 1 || stmt.Actions[0].Action != "ALL" {
+					t.Errorf("expected ALL action")
+				}
 			}},
 		{"multiple_actions", "CREATE AUDIT POLICY my_policy ACTIONS INSERT ON hr.employees, DELETE ON hr.employees",
 			func(t *testing.T, stmt *ast.CreateAuditPolicyStmt) {
-				if len(stmt.Actions) != 2 { t.Errorf("actions=%d", len(stmt.Actions)) }
+				if len(stmt.Actions) != 2 {
+					t.Errorf("actions=%d", len(stmt.Actions))
+				}
 			}},
 		{"privileges", "CREATE AUDIT POLICY priv_policy PRIVILEGES CREATE TABLE, DROP ANY TABLE",
 			func(t *testing.T, stmt *ast.CreateAuditPolicyStmt) {
-				if len(stmt.Privileges) != 2 { t.Errorf("privileges=%d, want 2", len(stmt.Privileges)) }
+				if len(stmt.Privileges) != 2 {
+					t.Errorf("privileges=%d, want 2", len(stmt.Privileges))
+				}
 			}},
 		{"roles", "CREATE AUDIT POLICY role_policy ROLES dba, resource",
 			func(t *testing.T, stmt *ast.CreateAuditPolicyStmt) {
-				if len(stmt.Roles) != 2 { t.Errorf("roles=%d", len(stmt.Roles)) }
+				if len(stmt.Roles) != 2 {
+					t.Errorf("roles=%d", len(stmt.Roles))
+				}
 			}},
 		{"when_condition", "CREATE AUDIT POLICY cond_policy ACTIONS SELECT ON hr.employees WHEN 'SYS_CONTEXT(''USERENV'', ''SESSION_USER'') = ''HR''' EVALUATE PER SESSION",
 			func(t *testing.T, stmt *ast.CreateAuditPolicyStmt) {
-				if stmt.WhenCondition == "" { t.Error("expected when condition") }
-				if stmt.EvaluatePer != "SESSION" { t.Errorf("evaluate_per=%q", stmt.EvaluatePer) }
+				if stmt.WhenCondition == "" {
+					t.Error("expected when condition")
+				}
+				if stmt.EvaluatePer != "SESSION" {
+					t.Errorf("evaluate_per=%q", stmt.EvaluatePer)
+				}
 			}},
 		{"system_actions", "CREATE AUDIT POLICY sys_policy ACTIONS CREATE TABLE, ALTER TABLE, DROP TABLE",
 			func(t *testing.T, stmt *ast.CreateAuditPolicyStmt) {
-				if len(stmt.Actions) != 3 { t.Errorf("actions=%d, want 3", len(stmt.Actions)) }
+				if len(stmt.Actions) != 3 {
+					t.Errorf("actions=%d, want 3", len(stmt.Actions))
+				}
 			}},
 		{"container_current", "CREATE AUDIT POLICY my_policy ACTIONS SELECT CONTAINER = CURRENT",
 			func(t *testing.T, stmt *ast.CreateAuditPolicyStmt) {
-				if stmt.ContainerAll == nil || *stmt.ContainerAll != false { t.Error("expected CURRENT") }
+				if stmt.ContainerAll == nil || *stmt.ContainerAll != false {
+					t.Error("expected CURRENT")
+				}
 			}},
 		{"only_toplevel", "CREATE AUDIT POLICY my_policy ACTIONS ALL ONLY TOPLEVEL",
 			func(t *testing.T, stmt *ast.CreateAuditPolicyStmt) {
-				if !stmt.OnlyToplevel { t.Error("expected ONLY TOPLEVEL") }
+				if !stmt.OnlyToplevel {
+					t.Error("expected ONLY TOPLEVEL")
+				}
 			}},
 		{"all_on_directory", "CREATE AUDIT POLICY dir_policy ACTIONS ALL ON DIRECTORY my_dir",
 			func(t *testing.T, stmt *ast.CreateAuditPolicyStmt) {
-				if len(stmt.Actions) != 1 { t.Fatalf("actions=%d", len(stmt.Actions)) }
-				if stmt.Actions[0].Directory != "MY_DIR" { t.Errorf("dir=%q", stmt.Actions[0].Directory) }
+				if len(stmt.Actions) != 1 {
+					t.Fatalf("actions=%d", len(stmt.Actions))
+				}
+				if stmt.Actions[0].Directory != "MY_DIR" {
+					t.Errorf("dir=%q", stmt.Actions[0].Directory)
+				}
 			}},
 		{"component_datapump", "CREATE AUDIT POLICY dp_policy ACTIONS COMPONENT = DATAPUMP EXPORT, IMPORT",
 			func(t *testing.T, stmt *ast.CreateAuditPolicyStmt) {
-				if len(stmt.ComponentActions) != 1 { t.Fatalf("comp=%d", len(stmt.ComponentActions)) }
-				if stmt.ComponentActions[0].Component != "DATAPUMP" { t.Errorf("comp=%q", stmt.ComponentActions[0].Component) }
+				if len(stmt.ComponentActions) != 1 {
+					t.Fatalf("comp=%d", len(stmt.ComponentActions))
+				}
+				if stmt.ComponentActions[0].Component != "DATAPUMP" {
+					t.Errorf("comp=%q", stmt.ComponentActions[0].Component)
+				}
 			}},
 		{"evaluate_per_instance", "CREATE AUDIT POLICY my_policy PRIVILEGES CREATE ANY TABLE WHEN 'TRUE' EVALUATE PER INSTANCE",
 			func(t *testing.T, stmt *ast.CreateAuditPolicyStmt) {
-				if stmt.EvaluatePer != "INSTANCE" { t.Errorf("evaluate_per=%q", stmt.EvaluatePer) }
+				if stmt.EvaluatePer != "INSTANCE" {
+					t.Errorf("evaluate_per=%q", stmt.EvaluatePer)
+				}
 			}},
 	}
 	for _, tt := range tests {
@@ -3073,43 +3105,63 @@ func TestBatch100_CreateAuditPolicy(t *testing.T) {
 // TestBatch100_AlterAuditPolicy tests ALTER AUDIT POLICY statements.
 func TestBatch100_AlterAuditPolicy(t *testing.T) {
 	tests := []struct {
-		name string
-		sql  string
+		name  string
+		sql   string
 		check func(t *testing.T, stmt *ast.AlterAuditPolicyStmt)
 	}{
 		{"add_actions", "ALTER AUDIT POLICY my_policy ADD ACTIONS DELETE ON hr.employees",
 			func(t *testing.T, stmt *ast.AlterAuditPolicyStmt) {
-				if stmt.AddDrop != "ADD" { t.Errorf("add_drop=%q", stmt.AddDrop) }
-				if len(stmt.Actions) != 1 { t.Errorf("actions=%d", len(stmt.Actions)) }
+				if stmt.AddDrop != "ADD" {
+					t.Errorf("add_drop=%q", stmt.AddDrop)
+				}
+				if len(stmt.Actions) != 1 {
+					t.Errorf("actions=%d", len(stmt.Actions))
+				}
 			}},
 		{"drop_actions", "ALTER AUDIT POLICY my_policy DROP ACTIONS SELECT ON hr.employees",
 			func(t *testing.T, stmt *ast.AlterAuditPolicyStmt) {
-				if stmt.AddDrop != "DROP" { t.Errorf("add_drop=%q", stmt.AddDrop) }
+				if stmt.AddDrop != "DROP" {
+					t.Errorf("add_drop=%q", stmt.AddDrop)
+				}
 			}},
 		{"add_privileges", "ALTER AUDIT POLICY my_policy ADD PRIVILEGES CREATE ANY TABLE",
 			func(t *testing.T, stmt *ast.AlterAuditPolicyStmt) {
-				if len(stmt.Privileges) != 1 { t.Errorf("privs=%d", len(stmt.Privileges)) }
+				if len(stmt.Privileges) != 1 {
+					t.Errorf("privs=%d", len(stmt.Privileges))
+				}
 			}},
 		{"add_roles", "ALTER AUDIT POLICY my_policy ADD ROLES connect",
 			func(t *testing.T, stmt *ast.AlterAuditPolicyStmt) {
-				if len(stmt.Roles) != 1 { t.Errorf("roles=%d", len(stmt.Roles)) }
+				if len(stmt.Roles) != 1 {
+					t.Errorf("roles=%d", len(stmt.Roles))
+				}
 			}},
 		{"condition_set", "ALTER AUDIT POLICY my_policy CONDITION 'SYS_CONTEXT(''USERENV'',''IP_ADDRESS'') = ''10.0.0.1''' EVALUATE PER SESSION",
 			func(t *testing.T, stmt *ast.AlterAuditPolicyStmt) {
-				if stmt.Condition == "" { t.Error("expected condition") }
-				if stmt.EvaluatePer != "SESSION" { t.Errorf("evaluate_per=%q", stmt.EvaluatePer) }
+				if stmt.Condition == "" {
+					t.Error("expected condition")
+				}
+				if stmt.EvaluatePer != "SESSION" {
+					t.Errorf("evaluate_per=%q", stmt.EvaluatePer)
+				}
 			}},
 		{"condition_drop", "ALTER AUDIT POLICY my_policy CONDITION DROP",
 			func(t *testing.T, stmt *ast.AlterAuditPolicyStmt) {
-				if !stmt.ConditionDrop { t.Error("expected condition drop") }
+				if !stmt.ConditionDrop {
+					t.Error("expected condition drop")
+				}
 			}},
 		{"add_toplevel", "ALTER AUDIT POLICY my_policy ADD ONLY TOPLEVEL",
 			func(t *testing.T, stmt *ast.AlterAuditPolicyStmt) {
-				if !stmt.AddToplevel { t.Error("expected add toplevel") }
+				if !stmt.AddToplevel {
+					t.Error("expected add toplevel")
+				}
 			}},
 		{"drop_toplevel", "ALTER AUDIT POLICY my_policy DROP ONLY TOPLEVEL",
 			func(t *testing.T, stmt *ast.AlterAuditPolicyStmt) {
-				if !stmt.DropToplevel { t.Error("expected drop toplevel") }
+				if !stmt.DropToplevel {
+					t.Error("expected drop toplevel")
+				}
 			}},
 	}
 	for _, tt := range tests {
@@ -3149,35 +3201,51 @@ func TestBatch100_DropAuditPolicy(t *testing.T) {
 // TestBatch100_AuditUnified tests AUDIT (Unified Auditing) statements.
 func TestBatch100_AuditUnified(t *testing.T) {
 	tests := []struct {
-		name string
-		sql  string
+		name  string
+		sql   string
 		check func(t *testing.T, stmt *ast.AuditStmt)
 	}{
 		{"policy_basic", "AUDIT POLICY my_policy",
 			func(t *testing.T, stmt *ast.AuditStmt) {
-				if stmt.Policy != "MY_POLICY" { t.Errorf("policy=%q", stmt.Policy) }
+				if stmt.Policy != "MY_POLICY" {
+					t.Errorf("policy=%q", stmt.Policy)
+				}
 			}},
 		{"policy_by_users", "AUDIT POLICY my_policy BY scott, hr",
 			func(t *testing.T, stmt *ast.AuditStmt) {
-				if len(stmt.ByUsers) != 2 { t.Errorf("by_users=%d", len(stmt.ByUsers)) }
+				if len(stmt.ByUsers) != 2 {
+					t.Errorf("by_users=%d", len(stmt.ByUsers))
+				}
 			}},
 		{"policy_except_users", "AUDIT POLICY my_policy EXCEPT scott",
 			func(t *testing.T, stmt *ast.AuditStmt) {
-				if len(stmt.ExceptUsers) != 1 { t.Errorf("except_users=%d", len(stmt.ExceptUsers)) }
+				if len(stmt.ExceptUsers) != 1 {
+					t.Errorf("except_users=%d", len(stmt.ExceptUsers))
+				}
 			}},
 		{"policy_with_role", "AUDIT POLICY my_policy BY USERS WITH ROLE dba, connect",
 			func(t *testing.T, stmt *ast.AuditStmt) {
-				if len(stmt.WithRoles) != 2 { t.Errorf("with_roles=%d", len(stmt.WithRoles)) }
+				if len(stmt.WithRoles) != 2 {
+					t.Errorf("with_roles=%d", len(stmt.WithRoles))
+				}
 			}},
 		{"policy_whenever", "AUDIT POLICY my_policy WHENEVER NOT SUCCESSFUL",
 			func(t *testing.T, stmt *ast.AuditStmt) {
-				if stmt.When != "WHENEVER NOT SUCCESSFUL" { t.Errorf("when=%q", stmt.When) }
+				if stmt.When != "WHENEVER NOT SUCCESSFUL" {
+					t.Errorf("when=%q", stmt.When)
+				}
 			}},
 		{"context", "AUDIT CONTEXT NAMESPACE my_ns ATTRIBUTES attr1, attr2 BY scott",
 			func(t *testing.T, stmt *ast.AuditStmt) {
-				if stmt.ContextNS != "MY_NS" { t.Errorf("ns=%q", stmt.ContextNS) }
-				if len(stmt.ContextAttrs) != 2 { t.Errorf("attrs=%d", len(stmt.ContextAttrs)) }
-				if len(stmt.ByUsers) != 1 { t.Errorf("by=%d", len(stmt.ByUsers)) }
+				if stmt.ContextNS != "MY_NS" {
+					t.Errorf("ns=%q", stmt.ContextNS)
+				}
+				if len(stmt.ContextAttrs) != 2 {
+					t.Errorf("attrs=%d", len(stmt.ContextAttrs))
+				}
+				if len(stmt.ByUsers) != 1 {
+					t.Errorf("by=%d", len(stmt.ByUsers))
+				}
 			}},
 	}
 	for _, tt := range tests {
@@ -3201,43 +3269,63 @@ func TestBatch100_AuditUnified(t *testing.T) {
 // TestBatch100_AuditTraditional tests AUDIT (Traditional Auditing) statements.
 func TestBatch100_AuditTraditional(t *testing.T) {
 	tests := []struct {
-		name string
-		sql  string
+		name  string
+		sql   string
 		check func(t *testing.T, stmt *ast.AuditStmt)
 	}{
 		{"basic_action", "AUDIT SELECT TABLE BY ACCESS",
 			func(t *testing.T, stmt *ast.AuditStmt) {
-				if len(stmt.Actions) == 0 { t.Error("expected actions") }
-				if stmt.By != "ACCESS" { t.Errorf("by=%q", stmt.By) }
+				if len(stmt.Actions) == 0 {
+					t.Error("expected actions")
+				}
+				if stmt.By != "ACCESS" {
+					t.Errorf("by=%q", stmt.By)
+				}
 			}},
 		{"on_object", "AUDIT SELECT ON hr.employees BY ACCESS WHENEVER SUCCESSFUL",
 			func(t *testing.T, stmt *ast.AuditStmt) {
-				if stmt.Object == nil { t.Error("expected object") }
-				if stmt.When != "WHENEVER SUCCESSFUL" { t.Errorf("when=%q", stmt.When) }
+				if stmt.Object == nil {
+					t.Error("expected object")
+				}
+				if stmt.When != "WHENEVER SUCCESSFUL" {
+					t.Errorf("when=%q", stmt.When)
+				}
 			}},
 		{"on_default", "AUDIT INSERT, UPDATE, DELETE ON DEFAULT BY ACCESS",
 			func(t *testing.T, stmt *ast.AuditStmt) {
-				if !stmt.OnDefault { t.Error("expected ON DEFAULT") }
+				if !stmt.OnDefault {
+					t.Error("expected ON DEFAULT")
+				}
 			}},
 		{"on_directory", "AUDIT SELECT ON DIRECTORY my_dir",
 			func(t *testing.T, stmt *ast.AuditStmt) {
-				if stmt.OnDirectory != "MY_DIR" { t.Errorf("dir=%q", stmt.OnDirectory) }
+				if stmt.OnDirectory != "MY_DIR" {
+					t.Errorf("dir=%q", stmt.OnDirectory)
+				}
 			}},
 		{"network", "AUDIT SELECT TABLE NETWORK",
 			func(t *testing.T, stmt *ast.AuditStmt) {
-				if !stmt.OnNetwork { t.Error("expected NETWORK") }
+				if !stmt.OnNetwork {
+					t.Error("expected NETWORK")
+				}
 			}},
 		{"by_users", "AUDIT SELECT TABLE BY scott, hr WHENEVER NOT SUCCESSFUL",
 			func(t *testing.T, stmt *ast.AuditStmt) {
-				if len(stmt.ByUsers2) != 2 { t.Errorf("by_users=%d", len(stmt.ByUsers2)) }
+				if len(stmt.ByUsers2) != 2 {
+					t.Errorf("by_users=%d", len(stmt.ByUsers2))
+				}
 			}},
 		{"all_statements", "AUDIT ALL STATEMENTS BY ACCESS",
 			func(t *testing.T, stmt *ast.AuditStmt) {
-				if len(stmt.Actions) == 0 { t.Error("expected actions") }
+				if len(stmt.Actions) == 0 {
+					t.Error("expected actions")
+				}
 			}},
 		{"container", "AUDIT ALL PRIVILEGES BY ACCESS CONTAINER = ALL",
 			func(t *testing.T, stmt *ast.AuditStmt) {
-				if stmt.ContainerAll == nil || !*stmt.ContainerAll { t.Error("expected CONTAINER=ALL") }
+				if stmt.ContainerAll == nil || !*stmt.ContainerAll {
+					t.Error("expected CONTAINER=ALL")
+				}
 			}},
 	}
 	for _, tt := range tests {
@@ -3261,26 +3349,36 @@ func TestBatch100_AuditTraditional(t *testing.T) {
 // TestBatch100_NoauditUnified tests NOAUDIT (Unified Auditing) statements.
 func TestBatch100_NoauditUnified(t *testing.T) {
 	tests := []struct {
-		name string
-		sql  string
+		name  string
+		sql   string
 		check func(t *testing.T, stmt *ast.NoauditStmt)
 	}{
 		{"policy_basic", "NOAUDIT POLICY my_policy",
 			func(t *testing.T, stmt *ast.NoauditStmt) {
-				if stmt.Policy != "MY_POLICY" { t.Errorf("policy=%q", stmt.Policy) }
+				if stmt.Policy != "MY_POLICY" {
+					t.Errorf("policy=%q", stmt.Policy)
+				}
 			}},
 		{"policy_by_users", "NOAUDIT POLICY my_policy BY scott, hr",
 			func(t *testing.T, stmt *ast.NoauditStmt) {
-				if len(stmt.ByUsers) != 2 { t.Errorf("by=%d", len(stmt.ByUsers)) }
+				if len(stmt.ByUsers) != 2 {
+					t.Errorf("by=%d", len(stmt.ByUsers))
+				}
 			}},
 		{"policy_with_role", "NOAUDIT POLICY my_policy BY scott WITH ROLE dba",
 			func(t *testing.T, stmt *ast.NoauditStmt) {
-				if len(stmt.WithRoles) != 1 { t.Errorf("roles=%d", len(stmt.WithRoles)) }
+				if len(stmt.WithRoles) != 1 {
+					t.Errorf("roles=%d", len(stmt.WithRoles))
+				}
 			}},
 		{"context", "NOAUDIT CONTEXT NAMESPACE my_ns ATTRIBUTES attr1, attr2",
 			func(t *testing.T, stmt *ast.NoauditStmt) {
-				if stmt.ContextNS != "MY_NS" { t.Errorf("ns=%q", stmt.ContextNS) }
-				if len(stmt.ContextAttrs) != 2 { t.Errorf("attrs=%d", len(stmt.ContextAttrs)) }
+				if stmt.ContextNS != "MY_NS" {
+					t.Errorf("ns=%q", stmt.ContextNS)
+				}
+				if len(stmt.ContextAttrs) != 2 {
+					t.Errorf("attrs=%d", len(stmt.ContextAttrs))
+				}
 			}},
 	}
 	for _, tt := range tests {
@@ -3304,26 +3402,36 @@ func TestBatch100_NoauditUnified(t *testing.T) {
 // TestBatch100_NoauditTraditional tests NOAUDIT (Traditional Auditing) statements.
 func TestBatch100_NoauditTraditional(t *testing.T) {
 	tests := []struct {
-		name string
-		sql  string
+		name  string
+		sql   string
 		check func(t *testing.T, stmt *ast.NoauditStmt)
 	}{
 		{"basic", "NOAUDIT SELECT TABLE",
 			func(t *testing.T, stmt *ast.NoauditStmt) {
-				if len(stmt.Actions) == 0 { t.Error("expected actions") }
+				if len(stmt.Actions) == 0 {
+					t.Error("expected actions")
+				}
 			}},
 		{"on_object", "NOAUDIT INSERT, UPDATE ON hr.employees WHENEVER SUCCESSFUL",
 			func(t *testing.T, stmt *ast.NoauditStmt) {
-				if stmt.Object == nil { t.Error("expected object") }
-				if stmt.When != "WHENEVER SUCCESSFUL" { t.Errorf("when=%q", stmt.When) }
+				if stmt.Object == nil {
+					t.Error("expected object")
+				}
+				if stmt.When != "WHENEVER SUCCESSFUL" {
+					t.Errorf("when=%q", stmt.When)
+				}
 			}},
 		{"on_default", "NOAUDIT ALL ON DEFAULT",
 			func(t *testing.T, stmt *ast.NoauditStmt) {
-				if !stmt.OnDefault { t.Error("expected ON DEFAULT") }
+				if !stmt.OnDefault {
+					t.Error("expected ON DEFAULT")
+				}
 			}},
 		{"by_users", "NOAUDIT SELECT TABLE BY scott",
 			func(t *testing.T, stmt *ast.NoauditStmt) {
-				if len(stmt.ByUsers2) != 1 { t.Errorf("by=%d", len(stmt.ByUsers2)) }
+				if len(stmt.ByUsers2) != 1 {
+					t.Errorf("by=%d", len(stmt.ByUsers2))
+				}
 			}},
 	}
 	for _, tt := range tests {
@@ -6145,477 +6253,707 @@ func TestParseIndexIndextypeOperator(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_emp ON employees (last_name)")
 		raw := result.Items[0].(*ast.RawStmt)
 		stmt, ok := raw.Stmt.(*ast.CreateIndexStmt)
-		if !ok { t.Fatalf("expected *CreateIndexStmt, got %T", raw.Stmt) }
-		if stmt.Name.Name != "IDX_EMP" { t.Errorf("expected IDX_EMP, got %q", stmt.Name.Name) }
-		if stmt.Table.Name != "EMPLOYEES" { t.Errorf("expected EMPLOYEES, got %q", stmt.Table.Name) }
+		if !ok {
+			t.Fatalf("expected *CreateIndexStmt, got %T", raw.Stmt)
+		}
+		if stmt.Name.Name != "IDX_EMP" {
+			t.Errorf("expected IDX_EMP, got %q", stmt.Name.Name)
+		}
+		if stmt.Table.Name != "EMPLOYEES" {
+			t.Errorf("expected EMPLOYEES, got %q", stmt.Table.Name)
+		}
 	})
 	t.Run("create_unique_index", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE UNIQUE INDEX idx_emp_id ON hr.employees (employee_id)")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if !stmt.Unique { t.Error("expected Unique=true") }
+		if !stmt.Unique {
+			t.Error("expected Unique=true")
+		}
 	})
 	t.Run("create_bitmap_index", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE BITMAP INDEX idx_status ON orders (status)")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if !stmt.Bitmap { t.Error("expected Bitmap=true") }
+		if !stmt.Bitmap {
+			t.Error("expected Bitmap=true")
+		}
 	})
 	t.Run("create_multivalue_index", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE MULTIVALUE INDEX idx_tags ON products (tags)")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if !stmt.Multivalue { t.Error("expected Multivalue=true") }
+		if !stmt.Multivalue {
+			t.Error("expected Multivalue=true")
+		}
 	})
 	t.Run("create_index_if_not_exists", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX IF NOT EXISTS idx_emp ON employees (last_name)")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if !stmt.IfNotExists { t.Error("expected IfNotExists=true") }
+		if !stmt.IfNotExists {
+			t.Error("expected IfNotExists=true")
+		}
 	})
 	t.Run("create_index_reverse", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_rev ON t (a) REVERSE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if !stmt.Reverse { t.Error("expected Reverse=true") }
+		if !stmt.Reverse {
+			t.Error("expected Reverse=true")
+		}
 	})
 	t.Run("create_index_nosort", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_ns ON t (a) NOSORT")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if !stmt.NoSort { t.Error("expected NoSort=true") }
+		if !stmt.NoSort {
+			t.Error("expected NoSort=true")
+		}
 	})
 	t.Run("create_index_sort", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_s ON t (a) SORT")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if !stmt.Sort { t.Error("expected Sort=true") }
+		if !stmt.Sort {
+			t.Error("expected Sort=true")
+		}
 	})
 	t.Run("create_index_visible", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_v ON t (a) VISIBLE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if !stmt.Visible { t.Error("expected Visible=true") }
+		if !stmt.Visible {
+			t.Error("expected Visible=true")
+		}
 	})
 	t.Run("create_index_invisible", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_i ON t (a) INVISIBLE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if !stmt.Invisible { t.Error("expected Invisible=true") }
+		if !stmt.Invisible {
+			t.Error("expected Invisible=true")
+		}
 	})
 	t.Run("create_index_logging", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_l ON t (a) LOGGING")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if !stmt.Logging { t.Error("expected Logging=true") }
+		if !stmt.Logging {
+			t.Error("expected Logging=true")
+		}
 	})
 	t.Run("create_index_nologging", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_nl ON t (a) NOLOGGING")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if !stmt.NoLogging { t.Error("expected NoLogging=true") }
+		if !stmt.NoLogging {
+			t.Error("expected NoLogging=true")
+		}
 	})
 	t.Run("create_index_compress_advanced", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_ca ON t (a) COMPRESS ADVANCED HIGH")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if stmt.Compress != "ADVANCED HIGH" { t.Errorf("expected 'ADVANCED HIGH', got %q", stmt.Compress) }
+		if stmt.Compress != "ADVANCED HIGH" {
+			t.Errorf("expected 'ADVANCED HIGH', got %q", stmt.Compress)
+		}
 	})
 	t.Run("create_index_domain", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_ctx ON docs (content) INDEXTYPE IS CTXSYS.CONTEXT")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if stmt.IndexType == nil { t.Fatal("expected non-nil IndexType") }
+		if stmt.IndexType == nil {
+			t.Fatal("expected non-nil IndexType")
+		}
 	})
 	t.Run("create_index_parameters", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_ctx ON docs (content) INDEXTYPE IS CTXSYS.CONTEXT PARAMETERS ('WORDLIST my_wordlist')")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if stmt.Parameters != "WORDLIST my_wordlist" { t.Errorf("expected parameters, got %q", stmt.Parameters) }
+		if stmt.Parameters != "WORDLIST my_wordlist" {
+			t.Errorf("expected parameters, got %q", stmt.Parameters)
+		}
 	})
 	t.Run("create_index_cluster", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_clust ON CLUSTER emp_dept_cluster")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if stmt.Cluster == nil { t.Fatal("expected non-nil Cluster") }
-		if stmt.Cluster.Name != "EMP_DEPT_CLUSTER" { t.Errorf("expected EMP_DEPT_CLUSTER, got %q", stmt.Cluster.Name) }
+		if stmt.Cluster == nil {
+			t.Fatal("expected non-nil Cluster")
+		}
+		if stmt.Cluster.Name != "EMP_DEPT_CLUSTER" {
+			t.Errorf("expected EMP_DEPT_CLUSTER, got %q", stmt.Cluster.Name)
+		}
 	})
 	t.Run("create_index_pctfree", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_pf ON t (a) PCTFREE 20")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if stmt.PctFree != "20" { t.Errorf("expected 20, got %q", stmt.PctFree) }
+		if stmt.PctFree != "20" {
+			t.Errorf("expected 20, got %q", stmt.PctFree)
+		}
 	})
 	t.Run("create_index_local", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_local ON t (a) LOCAL")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if !stmt.Local { t.Error("expected Local=true") }
+		if !stmt.Local {
+			t.Error("expected Local=true")
+		}
 	})
 	t.Run("create_index_global", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_global ON t (a) GLOBAL")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if !stmt.Global { t.Error("expected Global=true") }
+		if !stmt.Global {
+			t.Error("expected Global=true")
+		}
 	})
 	t.Run("create_index_deferred_invalidation", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_di ON t (a) DEFERRED INVALIDATION")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if stmt.Invalidation != "DEFERRED" { t.Errorf("expected DEFERRED, got %q", stmt.Invalidation) }
+		if stmt.Invalidation != "DEFERRED" {
+			t.Errorf("expected DEFERRED, got %q", stmt.Invalidation)
+		}
 	})
 	t.Run("create_index_indexing_full", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_if ON t (a) INDEXING FULL")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if !stmt.IndexingFull { t.Error("expected IndexingFull=true") }
+		if !stmt.IndexingFull {
+			t.Error("expected IndexingFull=true")
+		}
 	})
 	t.Run("create_index_multi_options", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE UNIQUE INDEX idx_m ON t (a, b DESC) TABLESPACE ts1 ONLINE PARALLEL 4 COMPRESS 2 NOLOGGING VISIBLE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if !stmt.Unique { t.Error("expected Unique=true") }
-		if stmt.Tablespace != "TS1" { t.Errorf("expected TS1, got %q", stmt.Tablespace) }
-		if !stmt.Online { t.Error("expected Online=true") }
-		if stmt.Parallel != "4" { t.Errorf("expected 4, got %q", stmt.Parallel) }
-		if stmt.Compress != "2" { t.Errorf("expected 2, got %q", stmt.Compress) }
-		if !stmt.NoLogging { t.Error("expected NoLogging=true") }
-		if !stmt.Visible { t.Error("expected Visible=true") }
+		if !stmt.Unique {
+			t.Error("expected Unique=true")
+		}
+		if stmt.Tablespace != "TS1" {
+			t.Errorf("expected TS1, got %q", stmt.Tablespace)
+		}
+		if !stmt.Online {
+			t.Error("expected Online=true")
+		}
+		if stmt.Parallel != "4" {
+			t.Errorf("expected 4, got %q", stmt.Parallel)
+		}
+		if stmt.Compress != "2" {
+			t.Errorf("expected 2, got %q", stmt.Compress)
+		}
+		if !stmt.NoLogging {
+			t.Error("expected NoLogging=true")
+		}
+		if !stmt.Visible {
+			t.Error("expected Visible=true")
+		}
 	})
 	t.Run("create_index_nocompress", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_nc ON t (a) NOCOMPRESS")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if stmt.Compress != "NOCOMPRESS" { t.Errorf("expected NOCOMPRESS, got %q", stmt.Compress) }
+		if stmt.Compress != "NOCOMPRESS" {
+			t.Errorf("expected NOCOMPRESS, got %q", stmt.Compress)
+		}
 	})
 	t.Run("create_index_noparallel", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_np ON t (a) NOPARALLEL")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if stmt.Parallel != "NOPARALLEL" { t.Errorf("expected NOPARALLEL, got %q", stmt.Parallel) }
+		if stmt.Parallel != "NOPARALLEL" {
+			t.Errorf("expected NOPARALLEL, got %q", stmt.Parallel)
+		}
 	})
 	t.Run("create_index_immediate_invalidation", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEX idx_ii ON t (a) IMMEDIATE INVALIDATION")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndexStmt)
-		if stmt.Invalidation != "IMMEDIATE" { t.Errorf("expected IMMEDIATE, got %q", stmt.Invalidation) }
+		if stmt.Invalidation != "IMMEDIATE" {
+			t.Errorf("expected IMMEDIATE, got %q", stmt.Invalidation)
+		}
 	})
 
 	// ===== ALTER INDEX =====
 	t.Run("alter_index_deallocate_unused", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 DEALLOCATE UNUSED")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Action != "DEALLOCATE_UNUSED" { t.Errorf("expected DEALLOCATE_UNUSED, got %q", stmt.Action) }
+		if stmt.Action != "DEALLOCATE_UNUSED" {
+			t.Errorf("expected DEALLOCATE_UNUSED, got %q", stmt.Action)
+		}
 	})
 	t.Run("alter_index_deallocate_unused_keep", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 DEALLOCATE UNUSED KEEP 100M")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.DeallocateKeep != "100M" { t.Errorf("expected 100M, got %q", stmt.DeallocateKeep) }
+		if stmt.DeallocateKeep != "100M" {
+			t.Errorf("expected 100M, got %q", stmt.DeallocateKeep)
+		}
 	})
 	t.Run("alter_index_allocate_extent", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 ALLOCATE EXTENT")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Action != "ALLOCATE_EXTENT" { t.Errorf("expected ALLOCATE_EXTENT, got %q", stmt.Action) }
+		if stmt.Action != "ALLOCATE_EXTENT" {
+			t.Errorf("expected ALLOCATE_EXTENT, got %q", stmt.Action)
+		}
 	})
 	t.Run("alter_index_parameters", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 PARAMETERS ('my_params')")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Parameters != "my_params" { t.Errorf("expected my_params, got %q", stmt.Parameters) }
+		if stmt.Parameters != "my_params" {
+			t.Errorf("expected my_params, got %q", stmt.Parameters)
+		}
 	})
 	t.Run("alter_index_deferred_invalidation", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 DEFERRED INVALIDATION")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Invalidation != "DEFERRED" { t.Errorf("expected DEFERRED, got %q", stmt.Invalidation) }
+		if stmt.Invalidation != "DEFERRED" {
+			t.Errorf("expected DEFERRED, got %q", stmt.Invalidation)
+		}
 	})
 	t.Run("alter_index_immediate_invalidation", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 IMMEDIATE INVALIDATION")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Invalidation != "IMMEDIATE" { t.Errorf("expected IMMEDIATE, got %q", stmt.Invalidation) }
+		if stmt.Invalidation != "IMMEDIATE" {
+			t.Errorf("expected IMMEDIATE, got %q", stmt.Invalidation)
+		}
 	})
 	t.Run("alter_index_modify_default_attrs", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 MODIFY DEFAULT ATTRIBUTES TABLESPACE ts_new")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Action != "MODIFY_DEFAULT_ATTRIBUTES" { t.Errorf("expected MODIFY_DEFAULT_ATTRIBUTES, got %q", stmt.Action) }
-		if stmt.Tablespace != "TS_NEW" { t.Errorf("expected TS_NEW, got %q", stmt.Tablespace) }
+		if stmt.Action != "MODIFY_DEFAULT_ATTRIBUTES" {
+			t.Errorf("expected MODIFY_DEFAULT_ATTRIBUTES, got %q", stmt.Action)
+		}
+		if stmt.Tablespace != "TS_NEW" {
+			t.Errorf("expected TS_NEW, got %q", stmt.Tablespace)
+		}
 	})
 	t.Run("alter_index_modify_default_attrs_for_partition", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 MODIFY DEFAULT ATTRIBUTES FOR PARTITION p1 LOGGING")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.ModifyDefaultFor != "P1" { t.Errorf("expected P1, got %q", stmt.ModifyDefaultFor) }
-		if !stmt.Logging { t.Error("expected Logging=true") }
+		if stmt.ModifyDefaultFor != "P1" {
+			t.Errorf("expected P1, got %q", stmt.ModifyDefaultFor)
+		}
+		if !stmt.Logging {
+			t.Error("expected Logging=true")
+		}
 	})
 	t.Run("alter_index_add_partition", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 ADD PARTITION p_new TABLESPACE ts1")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Action != "ADD_PARTITION" { t.Errorf("expected ADD_PARTITION, got %q", stmt.Action) }
-		if stmt.AddPartitionName != "P_NEW" { t.Errorf("expected P_NEW, got %q", stmt.AddPartitionName) }
+		if stmt.Action != "ADD_PARTITION" {
+			t.Errorf("expected ADD_PARTITION, got %q", stmt.Action)
+		}
+		if stmt.AddPartitionName != "P_NEW" {
+			t.Errorf("expected P_NEW, got %q", stmt.AddPartitionName)
+		}
 	})
 	t.Run("alter_index_modify_partition", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 MODIFY PARTITION p1 UNUSABLE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Action != "MODIFY_PARTITION" { t.Errorf("expected MODIFY_PARTITION, got %q", stmt.Action) }
-		if stmt.ModifyPartAction != "UNUSABLE" { t.Errorf("expected UNUSABLE, got %q", stmt.ModifyPartAction) }
+		if stmt.Action != "MODIFY_PARTITION" {
+			t.Errorf("expected MODIFY_PARTITION, got %q", stmt.Action)
+		}
+		if stmt.ModifyPartAction != "UNUSABLE" {
+			t.Errorf("expected UNUSABLE, got %q", stmt.ModifyPartAction)
+		}
 	})
 	t.Run("alter_index_rename_partition", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 RENAME PARTITION old_p TO new_p")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Action != "RENAME_PARTITION" { t.Errorf("expected RENAME_PARTITION, got %q", stmt.Action) }
-		if stmt.NewName != "NEW_P" { t.Errorf("expected NEW_P, got %q", stmt.NewName) }
+		if stmt.Action != "RENAME_PARTITION" {
+			t.Errorf("expected RENAME_PARTITION, got %q", stmt.Action)
+		}
+		if stmt.NewName != "NEW_P" {
+			t.Errorf("expected NEW_P, got %q", stmt.NewName)
+		}
 	})
 	t.Run("alter_index_rename_subpartition", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 RENAME SUBPARTITION old_sp TO new_sp")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Action != "RENAME_SUBPARTITION" { t.Errorf("expected RENAME_SUBPARTITION, got %q", stmt.Action) }
+		if stmt.Action != "RENAME_SUBPARTITION" {
+			t.Errorf("expected RENAME_SUBPARTITION, got %q", stmt.Action)
+		}
 	})
 	t.Run("alter_index_drop_partition", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 DROP PARTITION p1")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Action != "DROP_PARTITION" { t.Errorf("expected DROP_PARTITION, got %q", stmt.Action) }
-		if stmt.Partition != "P1" { t.Errorf("expected P1, got %q", stmt.Partition) }
+		if stmt.Action != "DROP_PARTITION" {
+			t.Errorf("expected DROP_PARTITION, got %q", stmt.Action)
+		}
+		if stmt.Partition != "P1" {
+			t.Errorf("expected P1, got %q", stmt.Partition)
+		}
 	})
 	t.Run("alter_index_split_partition", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 SPLIT PARTITION p_old AT (100)")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Action != "SPLIT_PARTITION" { t.Errorf("expected SPLIT_PARTITION, got %q", stmt.Action) }
-		if stmt.SplitPartition != "P_OLD" { t.Errorf("expected P_OLD, got %q", stmt.SplitPartition) }
+		if stmt.Action != "SPLIT_PARTITION" {
+			t.Errorf("expected SPLIT_PARTITION, got %q", stmt.Action)
+		}
+		if stmt.SplitPartition != "P_OLD" {
+			t.Errorf("expected P_OLD, got %q", stmt.SplitPartition)
+		}
 	})
 	t.Run("alter_index_coalesce_partition", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 COALESCE PARTITION")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Action != "COALESCE_PARTITION" { t.Errorf("expected COALESCE_PARTITION, got %q", stmt.Action) }
+		if stmt.Action != "COALESCE_PARTITION" {
+			t.Errorf("expected COALESCE_PARTITION, got %q", stmt.Action)
+		}
 	})
 	t.Run("alter_index_modify_subpartition", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 MODIFY SUBPARTITION sp1 UNUSABLE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Action != "MODIFY_SUBPARTITION" { t.Errorf("expected MODIFY_SUBPARTITION, got %q", stmt.Action) }
+		if stmt.Action != "MODIFY_SUBPARTITION" {
+			t.Errorf("expected MODIFY_SUBPARTITION, got %q", stmt.Action)
+		}
 	})
 	t.Run("alter_index_pctfree", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 PCTFREE 30")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.PctFree != "30" { t.Errorf("expected 30, got %q", stmt.PctFree) }
+		if stmt.PctFree != "30" {
+			t.Errorf("expected 30, got %q", stmt.PctFree)
+		}
 	})
 	t.Run("alter_index_rebuild_compress_advanced", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 REBUILD COMPRESS ADVANCED HIGH")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Compress != "ADVANCED HIGH" { t.Errorf("expected 'ADVANCED HIGH', got %q", stmt.Compress) }
+		if stmt.Compress != "ADVANCED HIGH" {
+			t.Errorf("expected 'ADVANCED HIGH', got %q", stmt.Compress)
+		}
 	})
 	t.Run("alter_index_rebuild_parameters", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 REBUILD PARAMETERS ('rebuild_params')")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Parameters != "rebuild_params" { t.Errorf("expected rebuild_params, got %q", stmt.Parameters) }
+		if stmt.Parameters != "rebuild_params" {
+			t.Errorf("expected rebuild_params, got %q", stmt.Parameters)
+		}
 	})
 	t.Run("alter_index_rebuild_deferred_invalidation", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 REBUILD DEFERRED INVALIDATION")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Invalidation != "DEFERRED" { t.Errorf("expected DEFERRED, got %q", stmt.Invalidation) }
+		if stmt.Invalidation != "DEFERRED" {
+			t.Errorf("expected DEFERRED, got %q", stmt.Invalidation)
+		}
 	})
 	t.Run("alter_index_modify_partition_parameters", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 MODIFY PARTITION p1 PARAMETERS ('some_params')")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Parameters != "some_params" { t.Errorf("expected some_params, got %q", stmt.Parameters) }
+		if stmt.Parameters != "some_params" {
+			t.Errorf("expected some_params, got %q", stmt.Parameters)
+		}
 	})
 	t.Run("alter_index_modify_partition_coalesce", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 MODIFY PARTITION p1 COALESCE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.ModifyPartAction != "COALESCE" { t.Errorf("expected COALESCE, got %q", stmt.ModifyPartAction) }
+		if stmt.ModifyPartAction != "COALESCE" {
+			t.Errorf("expected COALESCE, got %q", stmt.ModifyPartAction)
+		}
 	})
 	t.Run("alter_index_rebuild_subpartition", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEX idx1 REBUILD SUBPARTITION sp1 ONLINE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndexStmt)
-		if stmt.Subpartition != "SP1" { t.Errorf("expected SP1, got %q", stmt.Subpartition) }
-		if !stmt.Online { t.Error("expected Online=true") }
+		if stmt.Subpartition != "SP1" {
+			t.Errorf("expected SP1, got %q", stmt.Subpartition)
+		}
+		if !stmt.Online {
+			t.Error("expected Online=true")
+		}
 	})
 
 	// ===== DROP INDEX =====
 	t.Run("drop_index_basic", func(t *testing.T) {
 		result := ParseAndCheck(t, "DROP INDEX hr.idx_emp")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.DropStmt)
-		if stmt.ObjectType != ast.OBJECT_INDEX { t.Errorf("expected OBJECT_INDEX, got %d", stmt.ObjectType) }
+		if stmt.ObjectType != ast.OBJECT_INDEX {
+			t.Errorf("expected OBJECT_INDEX, got %d", stmt.ObjectType)
+		}
 	})
 	t.Run("drop_index_if_exists", func(t *testing.T) {
 		result := ParseAndCheck(t, "DROP INDEX IF EXISTS idx_emp")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.DropStmt)
-		if !stmt.IfExists { t.Error("expected IfExists=true") }
+		if !stmt.IfExists {
+			t.Error("expected IfExists=true")
+		}
 	})
 	t.Run("drop_index_online", func(t *testing.T) {
 		result := ParseAndCheck(t, "DROP INDEX idx_emp ONLINE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.DropStmt)
-		if !stmt.Online { t.Error("expected Online=true") }
+		if !stmt.Online {
+			t.Error("expected Online=true")
+		}
 	})
 	t.Run("drop_index_force", func(t *testing.T) {
 		result := ParseAndCheck(t, "DROP INDEX idx_emp FORCE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.DropStmt)
-		if !stmt.Force { t.Error("expected Force=true") }
+		if !stmt.Force {
+			t.Error("expected Force=true")
+		}
 	})
 	t.Run("drop_index_deferred_invalidation", func(t *testing.T) {
 		result := ParseAndCheck(t, "DROP INDEX idx_emp ONLINE FORCE DEFERRED INVALIDATION")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.DropStmt)
-		if !stmt.Online { t.Error("expected Online=true") }
-		if !stmt.Force { t.Error("expected Force=true") }
-		if stmt.Invalidation != "DEFERRED" { t.Errorf("expected DEFERRED, got %q", stmt.Invalidation) }
+		if !stmt.Online {
+			t.Error("expected Online=true")
+		}
+		if !stmt.Force {
+			t.Error("expected Force=true")
+		}
+		if stmt.Invalidation != "DEFERRED" {
+			t.Errorf("expected DEFERRED, got %q", stmt.Invalidation)
+		}
 	})
 	t.Run("drop_index_immediate_invalidation", func(t *testing.T) {
 		result := ParseAndCheck(t, "DROP INDEX idx_emp IMMEDIATE INVALIDATION")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.DropStmt)
-		if stmt.Invalidation != "IMMEDIATE" { t.Errorf("expected IMMEDIATE, got %q", stmt.Invalidation) }
+		if stmt.Invalidation != "IMMEDIATE" {
+			t.Errorf("expected IMMEDIATE, got %q", stmt.Invalidation)
+		}
 	})
 
 	// ===== CREATE INDEXTYPE =====
 	t.Run("create_indextype_basic", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEXTYPE my_itype FOR my_op(NUMBER) USING my_impl_type")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndextypeStmt)
-		if stmt.Name.Name != "MY_ITYPE" { t.Errorf("expected MY_ITYPE, got %q", stmt.Name.Name) }
-		if len(stmt.Operators) != 1 { t.Fatalf("expected 1 operator, got %d", len(stmt.Operators)) }
-		if stmt.UsingType == nil { t.Fatal("expected non-nil UsingType") }
+		if stmt.Name.Name != "MY_ITYPE" {
+			t.Errorf("expected MY_ITYPE, got %q", stmt.Name.Name)
+		}
+		if len(stmt.Operators) != 1 {
+			t.Fatalf("expected 1 operator, got %d", len(stmt.Operators))
+		}
+		if stmt.UsingType == nil {
+			t.Fatal("expected non-nil UsingType")
+		}
 	})
 	t.Run("create_or_replace_indextype", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE OR REPLACE INDEXTYPE my_itype FOR my_op(NUMBER, VARCHAR2) USING my_type")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndextypeStmt)
-		if !stmt.OrReplace { t.Error("expected OrReplace=true") }
-		if len(stmt.Operators[0].ParamTypes) != 2 { t.Errorf("expected 2 param types, got %d", len(stmt.Operators[0].ParamTypes)) }
+		if !stmt.OrReplace {
+			t.Error("expected OrReplace=true")
+		}
+		if len(stmt.Operators[0].ParamTypes) != 2 {
+			t.Errorf("expected 2 param types, got %d", len(stmt.Operators[0].ParamTypes))
+		}
 	})
 	t.Run("create_indextype_multi_operators", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEXTYPE my_itype FOR op1(NUMBER), op2(VARCHAR2) USING my_type")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndextypeStmt)
-		if len(stmt.Operators) != 2 { t.Fatalf("expected 2 operators, got %d", len(stmt.Operators)) }
+		if len(stmt.Operators) != 2 {
+			t.Fatalf("expected 2 operators, got %d", len(stmt.Operators))
+		}
 	})
 	t.Run("create_indextype_local_partition", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEXTYPE my_itype FOR my_op(NUMBER) USING my_type WITH LOCAL PARTITION")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndextypeStmt)
-		if !stmt.WithLocal { t.Error("expected WithLocal=true") }
+		if !stmt.WithLocal {
+			t.Error("expected WithLocal=true")
+		}
 	})
 	t.Run("create_indextype_local_range_partition", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEXTYPE my_itype FOR my_op(NUMBER) USING my_type WITH LOCAL RANGE PARTITION")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndextypeStmt)
-		if !stmt.WithRange { t.Error("expected WithRange=true") }
+		if !stmt.WithRange {
+			t.Error("expected WithRange=true")
+		}
 	})
 	t.Run("create_indextype_storage_table", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEXTYPE my_itype FOR my_op(NUMBER) USING my_type WITH SYSTEM MANAGED STORAGE TABLES")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndextypeStmt)
-		if stmt.StorageTable != "SYSTEM" { t.Errorf("expected SYSTEM, got %q", stmt.StorageTable) }
+		if stmt.StorageTable != "SYSTEM" {
+			t.Errorf("expected SYSTEM, got %q", stmt.StorageTable)
+		}
 	})
 	t.Run("create_indextype_if_not_exists", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEXTYPE IF NOT EXISTS my_itype FOR my_op(NUMBER) USING my_type")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndextypeStmt)
-		if !stmt.IfNotExists { t.Error("expected IfNotExists=true") }
+		if !stmt.IfNotExists {
+			t.Error("expected IfNotExists=true")
+		}
 	})
 	t.Run("create_indextype_sharing", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE INDEXTYPE my_itype SHARING = METADATA FOR my_op(NUMBER) USING my_type")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateIndextypeStmt)
-		if stmt.Sharing != "METADATA" { t.Errorf("expected METADATA, got %q", stmt.Sharing) }
+		if stmt.Sharing != "METADATA" {
+			t.Errorf("expected METADATA, got %q", stmt.Sharing)
+		}
 	})
 
 	// ===== ALTER INDEXTYPE =====
 	t.Run("alter_indextype_add", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEXTYPE my_itype ADD my_op2(VARCHAR2)")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndextypeStmt)
-		if stmt.Action != "ADD_DROP" { t.Errorf("expected ADD_DROP, got %q", stmt.Action) }
-		if !stmt.Modifications[0].Add { t.Error("expected Add=true") }
+		if stmt.Action != "ADD_DROP" {
+			t.Errorf("expected ADD_DROP, got %q", stmt.Action)
+		}
+		if !stmt.Modifications[0].Add {
+			t.Error("expected Add=true")
+		}
 	})
 	t.Run("alter_indextype_drop", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEXTYPE my_itype DROP my_op2(VARCHAR2)")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndextypeStmt)
-		if stmt.Modifications[0].Add { t.Error("expected Add=false") }
+		if stmt.Modifications[0].Add {
+			t.Error("expected Add=false")
+		}
 	})
 	t.Run("alter_indextype_compile", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEXTYPE my_itype COMPILE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndextypeStmt)
-		if stmt.Action != "COMPILE" { t.Errorf("expected COMPILE, got %q", stmt.Action) }
+		if stmt.Action != "COMPILE" {
+			t.Errorf("expected COMPILE, got %q", stmt.Action)
+		}
 	})
 	t.Run("alter_indextype_if_exists", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEXTYPE IF EXISTS my_itype COMPILE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndextypeStmt)
-		if !stmt.IfExists { t.Error("expected IfExists=true") }
+		if !stmt.IfExists {
+			t.Error("expected IfExists=true")
+		}
 	})
 	t.Run("alter_indextype_using_type", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEXTYPE my_itype ADD my_op2(NUMBER) USING my_new_type")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndextypeStmt)
-		if stmt.UsingType == nil { t.Fatal("expected non-nil UsingType") }
+		if stmt.UsingType == nil {
+			t.Fatal("expected non-nil UsingType")
+		}
 	})
 	t.Run("alter_indextype_local_partition", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEXTYPE my_itype ADD my_op2(NUMBER) WITH LOCAL PARTITION")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndextypeStmt)
-		if !stmt.WithLocal { t.Error("expected WithLocal=true") }
+		if !stmt.WithLocal {
+			t.Error("expected WithLocal=true")
+		}
 	})
 	t.Run("alter_indextype_storage_table", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER INDEXTYPE my_itype ADD my_op2(NUMBER) WITH SYSTEM MANAGED STORAGE TABLES")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterIndextypeStmt)
-		if stmt.StorageTable != "SYSTEM" { t.Errorf("expected SYSTEM, got %q", stmt.StorageTable) }
+		if stmt.StorageTable != "SYSTEM" {
+			t.Errorf("expected SYSTEM, got %q", stmt.StorageTable)
+		}
 	})
 
 	// ===== DROP INDEXTYPE =====
 	t.Run("drop_indextype_basic", func(t *testing.T) {
 		result := ParseAndCheck(t, "DROP INDEXTYPE my_itype")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.DropStmt)
-		if stmt.ObjectType != ast.OBJECT_INDEXTYPE { t.Errorf("expected OBJECT_INDEXTYPE, got %d", stmt.ObjectType) }
+		if stmt.ObjectType != ast.OBJECT_INDEXTYPE {
+			t.Errorf("expected OBJECT_INDEXTYPE, got %d", stmt.ObjectType)
+		}
 	})
 	t.Run("drop_indextype_force", func(t *testing.T) {
 		result := ParseAndCheck(t, "DROP INDEXTYPE my_itype FORCE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.DropStmt)
-		if !stmt.Force { t.Error("expected Force=true") }
+		if !stmt.Force {
+			t.Error("expected Force=true")
+		}
 	})
 	t.Run("drop_indextype_if_exists", func(t *testing.T) {
 		result := ParseAndCheck(t, "DROP INDEXTYPE IF EXISTS my_itype")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.DropStmt)
-		if !stmt.IfExists { t.Error("expected IfExists=true") }
+		if !stmt.IfExists {
+			t.Error("expected IfExists=true")
+		}
 	})
 
 	// ===== CREATE OPERATOR =====
 	t.Run("create_operator_basic", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE OPERATOR my_eq BINDING (NUMBER, NUMBER) RETURN NUMBER USING my_eq_func")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateOperatorStmt)
-		if stmt.Name.Name != "MY_EQ" { t.Errorf("expected MY_EQ, got %q", stmt.Name.Name) }
-		if len(stmt.Bindings) != 1 { t.Fatalf("expected 1 binding, got %d", len(stmt.Bindings)) }
-		if stmt.Bindings[0].ReturnType != "NUMBER" { t.Errorf("expected NUMBER, got %q", stmt.Bindings[0].ReturnType) }
+		if stmt.Name.Name != "MY_EQ" {
+			t.Errorf("expected MY_EQ, got %q", stmt.Name.Name)
+		}
+		if len(stmt.Bindings) != 1 {
+			t.Fatalf("expected 1 binding, got %d", len(stmt.Bindings))
+		}
+		if stmt.Bindings[0].ReturnType != "NUMBER" {
+			t.Errorf("expected NUMBER, got %q", stmt.Bindings[0].ReturnType)
+		}
 	})
 	t.Run("create_or_replace_operator", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE OR REPLACE OPERATOR my_eq BINDING (NUMBER, NUMBER) RETURN NUMBER USING my_eq_func")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateOperatorStmt)
-		if !stmt.OrReplace { t.Error("expected OrReplace=true") }
+		if !stmt.OrReplace {
+			t.Error("expected OrReplace=true")
+		}
 	})
 	t.Run("create_operator_schema_func", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE OPERATOR my_eq BINDING (NUMBER, NUMBER) RETURN NUMBER USING hr.my_eq_func")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateOperatorStmt)
-		if stmt.Bindings[0].UsingFunc == nil { t.Fatal("expected non-nil UsingFunc") }
+		if stmt.Bindings[0].UsingFunc == nil {
+			t.Fatal("expected non-nil UsingFunc")
+		}
 	})
 	t.Run("create_operator_ancillary", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE OPERATOR my_anc BINDING (NUMBER) RETURN NUMBER ANCILLARY TO my_primary(NUMBER) USING my_anc_func")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateOperatorStmt)
-		if stmt.Bindings[0].AncillaryTo == nil { t.Fatal("expected non-nil AncillaryTo") }
+		if stmt.Bindings[0].AncillaryTo == nil {
+			t.Fatal("expected non-nil AncillaryTo")
+		}
 	})
 	t.Run("create_operator_context", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE OPERATOR my_op BINDING (NUMBER) RETURN NUMBER WITH INDEX CONTEXT, SCAN CONTEXT my_impl_type COMPUTE ANCILLARY DATA USING my_func")
 		b := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateOperatorStmt).Bindings[0]
-		if !b.WithIndexCtx { t.Error("expected WithIndexCtx=true") }
-		if b.ScanCtxType != "MY_IMPL_TYPE" { t.Errorf("expected MY_IMPL_TYPE, got %q", b.ScanCtxType) }
-		if !b.ComputeAnc { t.Error("expected ComputeAnc=true") }
+		if !b.WithIndexCtx {
+			t.Error("expected WithIndexCtx=true")
+		}
+		if b.ScanCtxType != "MY_IMPL_TYPE" {
+			t.Errorf("expected MY_IMPL_TYPE, got %q", b.ScanCtxType)
+		}
+		if !b.ComputeAnc {
+			t.Error("expected ComputeAnc=true")
+		}
 	})
 	t.Run("create_operator_sharing", func(t *testing.T) {
 		result := ParseAndCheck(t, "CREATE OPERATOR my_eq BINDING (NUMBER, NUMBER) RETURN NUMBER USING my_eq_func SHARING = METADATA")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.CreateOperatorStmt)
-		if stmt.Sharing != "METADATA" { t.Errorf("expected METADATA, got %q", stmt.Sharing) }
+		if stmt.Sharing != "METADATA" {
+			t.Errorf("expected METADATA, got %q", stmt.Sharing)
+		}
 	})
 
 	// ===== ALTER OPERATOR =====
 	t.Run("alter_operator_add_binding", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER OPERATOR my_eq ADD BINDING (VARCHAR2, VARCHAR2) RETURN NUMBER USING my_eq_str")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterOperatorStmt)
-		if stmt.Action != "ADD_BINDING" { t.Errorf("expected ADD_BINDING, got %q", stmt.Action) }
-		if stmt.Binding == nil { t.Fatal("expected non-nil Binding") }
+		if stmt.Action != "ADD_BINDING" {
+			t.Errorf("expected ADD_BINDING, got %q", stmt.Action)
+		}
+		if stmt.Binding == nil {
+			t.Fatal("expected non-nil Binding")
+		}
 	})
 	t.Run("alter_operator_drop_binding", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER OPERATOR my_eq DROP BINDING (VARCHAR2, VARCHAR2)")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterOperatorStmt)
-		if stmt.Action != "DROP_BINDING" { t.Errorf("expected DROP_BINDING, got %q", stmt.Action) }
-		if len(stmt.DropTypes) != 2 { t.Errorf("expected 2 types, got %d", len(stmt.DropTypes)) }
+		if stmt.Action != "DROP_BINDING" {
+			t.Errorf("expected DROP_BINDING, got %q", stmt.Action)
+		}
+		if len(stmt.DropTypes) != 2 {
+			t.Errorf("expected 2 types, got %d", len(stmt.DropTypes))
+		}
 	})
 	t.Run("alter_operator_drop_binding_force", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER OPERATOR my_eq DROP BINDING (NUMBER) FORCE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterOperatorStmt)
-		if !stmt.DropForce { t.Error("expected DropForce=true") }
+		if !stmt.DropForce {
+			t.Error("expected DropForce=true")
+		}
 	})
 	t.Run("alter_operator_compile", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER OPERATOR my_eq COMPILE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterOperatorStmt)
-		if stmt.Action != "COMPILE" { t.Errorf("expected COMPILE, got %q", stmt.Action) }
+		if stmt.Action != "COMPILE" {
+			t.Errorf("expected COMPILE, got %q", stmt.Action)
+		}
 	})
 	t.Run("alter_operator_if_exists", func(t *testing.T) {
 		result := ParseAndCheck(t, "ALTER OPERATOR IF EXISTS my_eq COMPILE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.AlterOperatorStmt)
-		if !stmt.IfExists { t.Error("expected IfExists=true") }
+		if !stmt.IfExists {
+			t.Error("expected IfExists=true")
+		}
 	})
 
 	// ===== DROP OPERATOR =====
 	t.Run("drop_operator_basic", func(t *testing.T) {
 		result := ParseAndCheck(t, "DROP OPERATOR my_eq")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.DropStmt)
-		if stmt.ObjectType != ast.OBJECT_OPERATOR { t.Errorf("expected OBJECT_OPERATOR, got %d", stmt.ObjectType) }
+		if stmt.ObjectType != ast.OBJECT_OPERATOR {
+			t.Errorf("expected OBJECT_OPERATOR, got %d", stmt.ObjectType)
+		}
 	})
 	t.Run("drop_operator_force", func(t *testing.T) {
 		result := ParseAndCheck(t, "DROP OPERATOR my_eq FORCE")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.DropStmt)
-		if !stmt.Force { t.Error("expected Force=true") }
+		if !stmt.Force {
+			t.Error("expected Force=true")
+		}
 	})
 	t.Run("drop_operator_if_exists", func(t *testing.T) {
 		result := ParseAndCheck(t, "DROP OPERATOR IF EXISTS my_eq")
 		stmt := result.Items[0].(*ast.RawStmt).Stmt.(*ast.DropStmt)
-		if !stmt.IfExists { t.Error("expected IfExists=true") }
+		if !stmt.IfExists {
+			t.Error("expected IfExists=true")
+		}
 	})
 
 	// ===== Serialization =====
@@ -6631,7 +6969,9 @@ func TestParseIndexIndextypeOperator(t *testing.T) {
 		for _, sql := range sqls {
 			result := ParseAndCheck(t, sql)
 			s := ast.NodeToString(result.Items[0])
-			if s == "" { t.Errorf("expected non-empty serialization for %q", sql) }
+			if s == "" {
+				t.Errorf("expected non-empty serialization for %q", sql)
+			}
 		}
 	})
 }
@@ -9156,14 +9496,14 @@ func TestCommit(t *testing.T) {
 // Covers single table, multiple tables, partition_extension_clause, NOWAIT, and WAIT integer.
 func TestLockTable(t *testing.T) {
 	tests := []struct {
-		sql          string
-		tableCount   int
-		lockMode     string
-		nowait       bool
-		hasWait      bool
-		partType     string // partition type of first table entry
-		partFor      bool   // whether PARTITION FOR / SUBPARTITION FOR
-		partName     string // partition name of first table entry
+		sql        string
+		tableCount int
+		lockMode   string
+		nowait     bool
+		hasWait    bool
+		partType   string // partition type of first table entry
+		partFor    bool   // whether PARTITION FOR / SUBPARTITION FOR
+		partName   string // partition name of first table entry
 	}{
 		{
 			sql:        "LOCK TABLE employees IN EXCLUSIVE MODE",
@@ -9258,14 +9598,14 @@ func TestLockTable(t *testing.T) {
 // TO BEFORE SCN/TIMESTAMP, and ENABLE/DISABLE TRIGGERS.
 func TestFlashbackTable(t *testing.T) {
 	tests := []struct {
-		sql             string
-		tableCount      int
-		hasToSCN        bool
-		hasToTimestamp  bool
-		toRestorePoint  string
-		before          bool
-		toBeforeDrop    bool
-		enableTriggers  *bool // nil=not set, true=ENABLE, false=DISABLE
+		sql            string
+		tableCount     int
+		hasToSCN       bool
+		hasToTimestamp bool
+		toRestorePoint string
+		before         bool
+		toBeforeDrop   bool
+		enableTriggers *bool // nil=not set, true=ENABLE, false=DISABLE
 	}{
 		{
 			sql:            "FLASHBACK TABLE employees TO TIMESTAMP SYSDATE",
@@ -9273,9 +9613,9 @@ func TestFlashbackTable(t *testing.T) {
 			hasToTimestamp: true,
 		},
 		{
-			sql:         "FLASHBACK TABLE hr.orders TO SCN 1234567",
-			tableCount:  1,
-			hasToSCN:    true,
+			sql:        "FLASHBACK TABLE hr.orders TO SCN 1234567",
+			tableCount: 1,
+			hasToSCN:   true,
 		},
 		{
 			sql:            "FLASHBACK TABLE hr.orders TO RESTORE POINT my_restore_point",

--- a/oracle/parser/constraint_state.go
+++ b/oracle/parser/constraint_state.go
@@ -247,7 +247,9 @@ func (p *Parser) parseUsingIndexClause(cs *constraintState) error {
 		case p.cur.Type == kwLOCAL:
 			p.advance() // consume LOCAL
 			cs.UsingIndexLocal = true
-			// LOCAL [ STORE IN (tablespace [, ...]) ] [ (partition specs) ]
+			// LOCAL { STORE IN (tablespace [, ...]) | (partition specs) }.
+			// The two forms are mutually exclusive — Oracle 23ai raises
+			// ORA-14153 when both are given.
 			if p.isIdentLikeStr("STORE") && p.peekNext().Type == kwIN {
 				p.advance() // consume STORE
 				p.advance() // consume IN
@@ -255,8 +257,7 @@ func (p *Parser) parseUsingIndexClause(cs *constraintState) error {
 					return p.syntaxErrorAtCur()
 				}
 				p.skipParenthesized()
-			}
-			if p.cur.Type == '(' {
+			} else if p.cur.Type == '(' {
 				p.skipParenthesized()
 			}
 
@@ -270,6 +271,7 @@ func (p *Parser) parseUsingIndexClause(cs *constraintState) error {
 					return p.syntaxErrorAtCur()
 				}
 				p.advance() // consume BY
+				isHash := p.cur.Type == kwHASH
 				if p.cur.Type == kwRANGE || p.cur.Type == kwHASH {
 					p.advance()
 				}
@@ -277,8 +279,9 @@ func (p *Parser) parseUsingIndexClause(cs *constraintState) error {
 					return p.syntaxErrorAtCur()
 				}
 				p.skipParenthesized()
-				if p.isIdentLikeStr("PARTITIONS") {
-					// hash_partitions_by_quantity: PARTITIONS n [STORE IN (...)]
+				if isHash && p.isIdentLikeStr("PARTITIONS") {
+					// hash_partitions_by_quantity: PARTITIONS n [STORE IN (...)].
+					// HASH only — Oracle rejects the quantity form for RANGE.
 					p.advance() // consume PARTITIONS
 					if p.cur.Type != tokICONST {
 						return p.syntaxErrorAtCur()

--- a/oracle/parser/constraint_state.go
+++ b/oracle/parser/constraint_state.go
@@ -267,7 +267,8 @@ func (p *Parser) parseUsingIndexProperties(cs *constraintState) error {
 			if p.isIdentLikeStr("STORE") && p.peekNext().Type == kwIN {
 				p.advance() // consume STORE
 				p.advance() // consume IN
-				if p.cur.Type != '(' {
+				if p.cur.Type != '(' || p.peekNext().Type == ')' {
+					// STORE IN requires at least one tablespace (ORA-02216).
 					return p.syntaxErrorAtCur()
 				}
 				p.skipParenthesized()
@@ -295,6 +296,11 @@ func (p *Parser) parseUsingIndexProperties(cs *constraintState) error {
 					return p.syntaxErrorAtCur()
 				}
 				p.skipParenthesized()
+				// RANGE requires explicit partition specs (ORA-00906);
+				// for HASH the payload is optional (verified on 23ai).
+				if !isHash && p.cur.Type != '(' {
+					return p.syntaxErrorAtCur()
+				}
 				if isHash && p.isIdentLikeStr("PARTITIONS") {
 					// hash_partitions_by_quantity: PARTITIONS n [STORE IN (...)].
 					// HASH only — Oracle rejects the quantity form for RANGE.
@@ -306,7 +312,8 @@ func (p *Parser) parseUsingIndexProperties(cs *constraintState) error {
 					if p.isIdentLikeStr("STORE") && p.peekNext().Type == kwIN {
 						p.advance() // consume STORE
 						p.advance() // consume IN
-						if p.cur.Type != '(' {
+						if p.cur.Type != '(' || p.peekNext().Type == ')' {
+							// STORE IN requires at least one tablespace (ORA-02216).
 							return p.syntaxErrorAtCur()
 						}
 						p.skipParenthesized()

--- a/oracle/parser/constraint_state.go
+++ b/oracle/parser/constraint_state.go
@@ -89,6 +89,28 @@ func (p *Parser) parseConstraintState(cs *constraintState) error {
 	return nil
 }
 
+// parseViewConstraintState parses the constraint state allowed on view
+// constraints. Verified against Oracle 23ai: DISABLE is mandatory
+// (ORA-02000 "missing DISABLE keyword" otherwise), RELY|NORELY may precede
+// it, NOVALIDATE may follow it, and VALIDATE is rejected outright
+// (ORA-03082). Table-only clauses (DEFERRABLE, INITIALLY, USING INDEX,
+// ENABLE) are not accepted.
+//
+//	[ RELY | NORELY ] DISABLE [ NOVALIDATE ]
+func (p *Parser) parseViewConstraintState() error {
+	if p.cur.Type == kwRELY || p.isIdentLikeStr("NORELY") {
+		p.advance()
+	}
+	if p.cur.Type != kwDISABLE {
+		return p.syntaxErrorAtCur()
+	}
+	p.advance() // consume DISABLE
+	if p.isIdentLikeStr("NOVALIDATE") {
+		p.advance()
+	}
+	return nil
+}
+
 // parseExceptionsIntoClause parses [ EXCEPTIONS INTO [schema.]table ] if
 // present. Oracle allows this only in ALTER TABLE enable/modify-constraint
 // contexts, not inside CREATE TABLE constraints.
@@ -122,6 +144,7 @@ var identLikeUsingIndexProperties = map[string]bool{
 	"VISIBLE":    true,
 	"INVISIBLE":  true,
 	"STORE":      true,
+	"INDEXING":   true,
 	"NORELY":     true,
 	"NOVALIDATE": true,
 	"EXCEPTIONS": true,
@@ -140,9 +163,31 @@ func (p *Parser) parseUsingIndexClause(cs *constraintState) error {
 	p.advance() // consume USING
 	p.advance() // consume INDEX
 
-	// (create_index_statement)
+	// (create_index_statement) — validate the CREATE [UNIQUE|BITMAP] INDEX
+	// prefix (Oracle raises ORA-02000 "missing CREATE keyword" for anything
+	// else), then skip the balanced remainder.
 	if p.cur.Type == '(' {
-		p.skipParenthesized()
+		p.advance() // consume '('
+		if p.cur.Type != kwCREATE {
+			return p.syntaxErrorAtCur()
+		}
+		p.advance() // consume CREATE
+		if p.cur.Type == kwUNIQUE || p.cur.Type == kwBITMAP {
+			p.advance()
+		}
+		if p.cur.Type != kwINDEX {
+			return p.syntaxErrorAtCur()
+		}
+		depth := 1
+		for depth > 0 && p.cur.Type != tokEOF {
+			switch p.cur.Type {
+			case '(':
+				depth++
+			case ')':
+				depth--
+			}
+			p.advance()
+		}
 		return nil
 	}
 
@@ -236,13 +281,34 @@ func (p *Parser) parseUsingIndexClause(cs *constraintState) error {
 			p.advance() // consume STATISTICS
 
 		case p.cur.Type == kwCOMPRESS:
+			// COMPRESS [ integer | ADVANCED [ LOW | HIGH ] ]
+			p.advance()
+			if p.cur.Type == tokICONST {
+				p.advance()
+			} else if p.isIdentLikeStr("ADVANCED") {
+				p.advance()
+				if p.isIdentLikeStr("LOW") || p.isIdentLikeStr("HIGH") {
+					p.advance()
+				}
+			}
+
+		case p.cur.Type == kwPARALLEL:
 			p.advance()
 			if p.cur.Type == tokICONST {
 				p.advance()
 			}
 
+		case p.isIdentLikeStr("INDEXING"):
+			// INDEXING { FULL | PARTIAL }
+			p.advance()
+			if !p.isIdentLikeStr("FULL") && !p.isIdentLikeStr("PARTIAL") {
+				return p.syntaxErrorAtCur()
+			}
+			p.advance()
+
 		case p.cur.Type == kwLOGGING || p.cur.Type == kwNOLOGGING ||
-			p.cur.Type == kwONLINE || p.cur.Type == kwREVERSE:
+			p.cur.Type == kwONLINE || p.cur.Type == kwREVERSE ||
+			p.cur.Type == kwNOPARALLEL:
 			p.advance()
 
 		case p.isIdentLikeStr("NOCOMPRESS") || p.isIdentLikeStr("SORT") ||

--- a/oracle/parser/constraint_state.go
+++ b/oracle/parser/constraint_state.go
@@ -238,6 +238,13 @@ func (p *Parser) parseUsingIndexClause(cs *constraintState) error {
 	}
 
 	// index_properties
+	return p.parseUsingIndexProperties(cs)
+}
+
+// parseUsingIndexProperties parses the index_properties alternative of
+// using_index_clause. Materialized-view USING INDEX accepts only this form —
+// Oracle rejects an index name or a nested CREATE INDEX there (ORA-02000).
+func (p *Parser) parseUsingIndexProperties(cs *constraintState) error {
 	for {
 		switch {
 		case p.cur.Type == kwTABLESPACE:
@@ -309,7 +316,7 @@ func (p *Parser) parseUsingIndexClause(cs *constraintState) error {
 				}
 			}
 
-		case p.cur.Type == kwPCTFREE || p.isIdentLikeStr("PCTUSED") ||
+		case p.cur.Type == kwPCTFREE ||
 			p.isIdentLikeStr("INITRANS") || p.isIdentLikeStr("MAXTRANS"):
 			p.advance()
 			if p.cur.Type != tokICONST {

--- a/oracle/parser/constraint_state.go
+++ b/oracle/parser/constraint_state.go
@@ -163,9 +163,11 @@ func (p *Parser) parseUsingIndexClause(cs *constraintState) error {
 	p.advance() // consume USING
 	p.advance() // consume INDEX
 
-	// (create_index_statement) — validate the CREATE [UNIQUE|BITMAP] INDEX
-	// prefix (Oracle raises ORA-02000 "missing CREATE keyword" for anything
-	// else), then skip the balanced remainder.
+	// (create_index_statement) — validate the required structure CREATE
+	// [UNIQUE|BITMAP] INDEX name ON table (...) before skipping the balanced
+	// remainder (index attributes). Oracle raises ORA-02000 for a missing
+	// CREATE keyword, ORA-00953 for a missing index name, and ORA-00969 for
+	// a missing ON.
 	if p.cur.Type == '(' {
 		p.advance() // consume '('
 		if p.cur.Type != kwCREATE {
@@ -178,7 +180,29 @@ func (p *Parser) parseUsingIndexClause(cs *constraintState) error {
 		if p.cur.Type != kwINDEX {
 			return p.syntaxErrorAtCur()
 		}
-		depth := 1
+		p.advance() // consume INDEX
+		indexName, err := p.parseObjectName()
+		if err != nil {
+			return err
+		}
+		if indexName == nil || indexName.Name == "" {
+			return p.syntaxErrorAtCur()
+		}
+		if p.cur.Type != kwON {
+			return p.syntaxErrorAtCur()
+		}
+		p.advance() // consume ON
+		tableName, err := p.parseObjectName()
+		if err != nil {
+			return err
+		}
+		if tableName == nil || tableName.Name == "" {
+			return p.syntaxErrorAtCur()
+		}
+		if p.cur.Type != '(' {
+			return p.syntaxErrorAtCur()
+		}
+		depth := 1 // the outer '(' consumed above is still open
 		for depth > 0 && p.cur.Type != tokEOF {
 			switch p.cur.Type {
 			case '(':
@@ -238,7 +262,8 @@ func (p *Parser) parseUsingIndexClause(cs *constraintState) error {
 
 		case p.cur.Type == kwGLOBAL:
 			p.advance() // consume GLOBAL
-			// GLOBAL [ PARTITION BY { RANGE | HASH } (cols) [ (partition specs) ] ]
+			// GLOBAL [ PARTITION BY { RANGE | HASH } (cols)
+			//   { (partition specs) | PARTITIONS n [ STORE IN (ts, ...) ] } ]
 			if p.cur.Type == kwPARTITION {
 				p.advance() // consume PARTITION
 				if p.cur.Type != kwBY {
@@ -252,7 +277,22 @@ func (p *Parser) parseUsingIndexClause(cs *constraintState) error {
 					return p.syntaxErrorAtCur()
 				}
 				p.skipParenthesized()
-				if p.cur.Type == '(' {
+				if p.isIdentLikeStr("PARTITIONS") {
+					// hash_partitions_by_quantity: PARTITIONS n [STORE IN (...)]
+					p.advance() // consume PARTITIONS
+					if p.cur.Type != tokICONST {
+						return p.syntaxErrorAtCur()
+					}
+					p.advance()
+					if p.isIdentLikeStr("STORE") && p.peekNext().Type == kwIN {
+						p.advance() // consume STORE
+						p.advance() // consume IN
+						if p.cur.Type != '(' {
+							return p.syntaxErrorAtCur()
+						}
+						p.skipParenthesized()
+					}
+				} else if p.cur.Type == '(' {
 					p.skipParenthesized()
 				}
 			}

--- a/oracle/parser/constraint_state.go
+++ b/oracle/parser/constraint_state.go
@@ -11,29 +11,42 @@ type constraintState struct {
 	UsingIndexLocal bool   // USING INDEX LOCAL
 }
 
-// parseConstraintState parses Oracle's constraint_state clause, whose
-// subclauses may appear in any order after a constraint body:
+// parseConstraintState parses Oracle's constraint_state clause. Oracle
+// enforces the documented slot order (verified against Oracle 23ai, which
+// raises ORA-03075 for out-of-order subclauses such as ENABLE USING INDEX
+// or DISABLE RELY):
 //
-//	[ [NOT] DEFERRABLE ] [ INITIALLY { DEFERRED | IMMEDIATE } ]
+//	[ [NOT] DEFERRABLE ] [ INITIALLY { DEFERRED | IMMEDIATE } ]  -- either order
 //	[ RELY | NORELY ]
 //	[ using_index_clause ]
-//	[ ENABLE | DISABLE ] [ VALIDATE | NOVALIDATE ]
-//	[ EXCEPTIONS INTO [schema.]table ]
+//	[ ENABLE | DISABLE ]
+//	[ VALIDATE | NOVALIDATE ]
+//
+// EXCEPTIONS INTO is not part of this clause: Oracle rejects it inside a
+// CREATE TABLE constraint (ORA-00922) and accepts it only in ALTER TABLE
+// enable/modify-constraint contexts — see parseExceptionsIntoClause.
 //
 // Ref: https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/constraint.html
 func (p *Parser) parseConstraintState(cs *constraintState) error {
+	// [NOT] DEFERRABLE and INITIALLY {DEFERRED|IMMEDIATE}: one group, either
+	// order within it (Oracle accepts INITIALLY DEFERRED DEFERRABLE), each at
+	// most once.
+	seenDeferrable, seenInitially := false, false
 	for {
-		switch {
-		case p.cur.Type == kwDEFERRABLE:
+		if !seenDeferrable && p.cur.Type == kwDEFERRABLE {
 			cs.Deferrable = true
+			seenDeferrable = true
 			p.advance()
-
-		case p.cur.Type == kwNOT && p.peekNext().Type == kwDEFERRABLE:
+			continue
+		}
+		if !seenDeferrable && p.cur.Type == kwNOT && p.peekNext().Type == kwDEFERRABLE {
 			p.advance() // consume NOT
 			p.advance() // consume DEFERRABLE
 			cs.Deferrable = false
-
-		case p.cur.Type == kwINITIALLY:
+			seenDeferrable = true
+			continue
+		}
+		if !seenInitially && p.cur.Type == kwINITIALLY {
 			p.advance() // consume INITIALLY
 			switch p.cur.Type {
 			case kwDEFERRED:
@@ -45,36 +58,54 @@ func (p *Parser) parseConstraintState(cs *constraintState) error {
 			default:
 				return p.syntaxErrorAtCur()
 			}
+			seenInitially = true
+			continue
+		}
+		break
+	}
 
-		case p.cur.Type == kwRELY || p.isIdentLikeStr("NORELY"):
-			p.advance()
+	// [ RELY | NORELY ]
+	if p.cur.Type == kwRELY || p.isIdentLikeStr("NORELY") {
+		p.advance()
+	}
 
-		case p.cur.Type == kwENABLE || p.cur.Type == kwDISABLE:
-			p.advance()
-
-		case p.cur.Type == kwVALIDATE || p.isIdentLikeStr("NOVALIDATE"):
-			p.advance()
-
-		case p.cur.Type == kwUSING && p.peekNext().Type == kwINDEX:
-			if err := p.parseUsingIndexClause(cs); err != nil {
-				return err
-			}
-
-		case p.isIdentLikeStr("EXCEPTIONS") && p.peekNext().Type == kwINTO:
-			p.advance() // consume EXCEPTIONS
-			p.advance() // consume INTO
-			name, err := p.parseObjectName()
-			if err != nil {
-				return err
-			}
-			if name == nil || name.Name == "" {
-				return p.syntaxErrorAtCur()
-			}
-
-		default:
-			return nil
+	// [ using_index_clause ]
+	if p.cur.Type == kwUSING && p.peekNext().Type == kwINDEX {
+		if err := p.parseUsingIndexClause(cs); err != nil {
+			return err
 		}
 	}
+
+	// [ ENABLE | DISABLE ]
+	if p.cur.Type == kwENABLE || p.cur.Type == kwDISABLE {
+		p.advance()
+	}
+
+	// [ VALIDATE | NOVALIDATE ]
+	if p.cur.Type == kwVALIDATE || p.isIdentLikeStr("NOVALIDATE") {
+		p.advance()
+	}
+
+	return nil
+}
+
+// parseExceptionsIntoClause parses [ EXCEPTIONS INTO [schema.]table ] if
+// present. Oracle allows this only in ALTER TABLE enable/modify-constraint
+// contexts, not inside CREATE TABLE constraints.
+func (p *Parser) parseExceptionsIntoClause() error {
+	if !p.isIdentLikeStr("EXCEPTIONS") || p.peekNext().Type != kwINTO {
+		return nil
+	}
+	p.advance() // consume EXCEPTIONS
+	p.advance() // consume INTO
+	name, err := p.parseObjectName()
+	if err != nil {
+		return err
+	}
+	if name == nil || name.Name == "" {
+		return p.syntaxErrorAtCur()
+	}
+	return nil
 }
 
 // identLikeUsingIndexProperties are index_properties that lex as plain

--- a/oracle/parser/constraint_state.go
+++ b/oracle/parser/constraint_state.go
@@ -134,20 +134,21 @@ func (p *Parser) parseExceptionsIntoClause() error {
 // identifiers rather than keywords. They must not be mistaken for an index
 // name after USING INDEX.
 var identLikeUsingIndexProperties = map[string]bool{
-	"PCTUSED":    true,
-	"INITRANS":   true,
-	"MAXTRANS":   true,
-	"COMPUTE":    true,
-	"NOCOMPRESS": true,
-	"SORT":       true,
-	"NOSORT":     true,
-	"VISIBLE":    true,
-	"INVISIBLE":  true,
-	"STORE":      true,
-	"INDEXING":   true,
-	"NORELY":     true,
-	"NOVALIDATE": true,
-	"EXCEPTIONS": true,
+	"PCTUSED":     true,
+	"INITRANS":    true,
+	"MAXTRANS":    true,
+	"COMPUTE":     true,
+	"NOCOMPRESS":  true,
+	"SORT":        true,
+	"NOSORT":      true,
+	"VISIBLE":     true,
+	"INVISIBLE":   true,
+	"STORE":       true,
+	"INDEXING":    true,
+	"ANNOTATIONS": true,
+	"NORELY":      true,
+	"NOVALIDATE":  true,
+	"EXCEPTIONS":  true,
 }
 
 // parseUsingIndexClause parses using_index_clause:
@@ -200,6 +201,12 @@ func (p *Parser) parseUsingIndexClause(cs *constraintState) error {
 			return p.syntaxErrorAtCur()
 		}
 		if p.cur.Type != '(' {
+			return p.syntaxErrorAtCur()
+		}
+		if p.peekNext().Type == ')' {
+			// Empty column list — Oracle raises ORA-00936. Deeper column
+			// expression validation is deliberately left to the engine.
+			p.advance()
 			return p.syntaxErrorAtCur()
 		}
 		depth := 1 // the outer '(' consumed above is still open
@@ -271,10 +278,12 @@ func (p *Parser) parseUsingIndexClause(cs *constraintState) error {
 					return p.syntaxErrorAtCur()
 				}
 				p.advance() // consume BY
-				isHash := p.cur.Type == kwHASH
-				if p.cur.Type == kwRANGE || p.cur.Type == kwHASH {
-					p.advance()
+				// Oracle requires RANGE or HASH here (ORA-14151 otherwise).
+				if p.cur.Type != kwRANGE && p.cur.Type != kwHASH {
+					return p.syntaxErrorAtCur()
 				}
+				isHash := p.cur.Type == kwHASH
+				p.advance()
 				if p.cur.Type != '(' {
 					return p.syntaxErrorAtCur()
 				}
@@ -348,6 +357,15 @@ func (p *Parser) parseUsingIndexClause(cs *constraintState) error {
 				return p.syntaxErrorAtCur()
 			}
 			p.advance()
+
+		case p.isIdentLikeStr("ANNOTATIONS"):
+			// ANNOTATIONS ( annotation [, ...] ) — accepted by Oracle 23ai
+			// inside using_index_clause.
+			p.advance()
+			if p.cur.Type != '(' {
+				return p.syntaxErrorAtCur()
+			}
+			p.skipParenthesized()
 
 		case p.cur.Type == kwLOGGING || p.cur.Type == kwNOLOGGING ||
 			p.cur.Type == kwONLINE || p.cur.Type == kwREVERSE ||

--- a/oracle/parser/constraint_state.go
+++ b/oracle/parser/constraint_state.go
@@ -1,0 +1,226 @@
+package parser
+
+// constraintState carries the fields of Oracle's constraint_state clause that
+// are preserved in the AST. Subclauses that are parsed but not preserved
+// (ENABLE/DISABLE, VALIDATE/NOVALIDATE, RELY/NORELY, exceptions_clause) leave
+// no trace here.
+type constraintState struct {
+	Deferrable      bool
+	Initially       string // "DEFERRED" or "IMMEDIATE"
+	Tablespace      string // USING INDEX ... TABLESPACE
+	UsingIndexLocal bool   // USING INDEX LOCAL
+}
+
+// parseConstraintState parses Oracle's constraint_state clause, whose
+// subclauses may appear in any order after a constraint body:
+//
+//	[ [NOT] DEFERRABLE ] [ INITIALLY { DEFERRED | IMMEDIATE } ]
+//	[ RELY | NORELY ]
+//	[ using_index_clause ]
+//	[ ENABLE | DISABLE ] [ VALIDATE | NOVALIDATE ]
+//	[ EXCEPTIONS INTO [schema.]table ]
+//
+// Ref: https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/constraint.html
+func (p *Parser) parseConstraintState(cs *constraintState) error {
+	for {
+		switch {
+		case p.cur.Type == kwDEFERRABLE:
+			cs.Deferrable = true
+			p.advance()
+
+		case p.cur.Type == kwNOT && p.peekNext().Type == kwDEFERRABLE:
+			p.advance() // consume NOT
+			p.advance() // consume DEFERRABLE
+			cs.Deferrable = false
+
+		case p.cur.Type == kwINITIALLY:
+			p.advance() // consume INITIALLY
+			switch p.cur.Type {
+			case kwDEFERRED:
+				cs.Initially = "DEFERRED"
+				p.advance()
+			case kwIMMEDIATE:
+				cs.Initially = "IMMEDIATE"
+				p.advance()
+			default:
+				return p.syntaxErrorAtCur()
+			}
+
+		case p.cur.Type == kwRELY || p.isIdentLikeStr("NORELY"):
+			p.advance()
+
+		case p.cur.Type == kwENABLE || p.cur.Type == kwDISABLE:
+			p.advance()
+
+		case p.cur.Type == kwVALIDATE || p.isIdentLikeStr("NOVALIDATE"):
+			p.advance()
+
+		case p.cur.Type == kwUSING && p.peekNext().Type == kwINDEX:
+			if err := p.parseUsingIndexClause(cs); err != nil {
+				return err
+			}
+
+		case p.isIdentLikeStr("EXCEPTIONS") && p.peekNext().Type == kwINTO:
+			p.advance() // consume EXCEPTIONS
+			p.advance() // consume INTO
+			name, err := p.parseObjectName()
+			if err != nil {
+				return err
+			}
+			if name == nil || name.Name == "" {
+				return p.syntaxErrorAtCur()
+			}
+
+		default:
+			return nil
+		}
+	}
+}
+
+// identLikeUsingIndexProperties are index_properties that lex as plain
+// identifiers rather than keywords. They must not be mistaken for an index
+// name after USING INDEX.
+var identLikeUsingIndexProperties = map[string]bool{
+	"PCTUSED":    true,
+	"INITRANS":   true,
+	"MAXTRANS":   true,
+	"COMPUTE":    true,
+	"NOCOMPRESS": true,
+	"SORT":       true,
+	"NOSORT":     true,
+	"VISIBLE":    true,
+	"INVISIBLE":  true,
+	"STORE":      true,
+	"NORELY":     true,
+	"NOVALIDATE": true,
+	"EXCEPTIONS": true,
+}
+
+// parseUsingIndexClause parses using_index_clause:
+//
+//	USING INDEX { [schema.]index | (create_index_statement) | index_properties }
+//
+// The properties form is parsed with an explicit whitelist so the clause
+// terminates safely inside a CREATE TABLE column list: it never consumes the
+// table's closing ')' or a following ','. This is deliberately not shared
+// with parseCreateIndexAttributes, whose option collector runs to the
+// statement terminator.
+func (p *Parser) parseUsingIndexClause(cs *constraintState) error {
+	p.advance() // consume USING
+	p.advance() // consume INDEX
+
+	// (create_index_statement)
+	if p.cur.Type == '(' {
+		p.skipParenthesized()
+		return nil
+	}
+
+	// [schema.]index — a plain identifier that is not an identifier-like
+	// index property or a constraint_state continuation. Quoted identifiers
+	// are always names.
+	if p.cur.Type == tokQIDENT ||
+		(p.cur.Type == tokIDENT && !identLikeUsingIndexProperties[p.cur.Str]) {
+		name, err := p.parseObjectName()
+		if err != nil {
+			return err
+		}
+		if name == nil || name.Name == "" {
+			return p.syntaxErrorAtCur()
+		}
+		return nil
+	}
+
+	// index_properties
+	for {
+		switch {
+		case p.cur.Type == kwTABLESPACE:
+			p.advance() // consume TABLESPACE
+			name, err := p.parseIdentifier()
+			if err != nil {
+				return err
+			}
+			if name == "" {
+				return p.syntaxErrorAtCur()
+			}
+			cs.Tablespace = name
+
+		case p.cur.Type == kwLOCAL:
+			p.advance() // consume LOCAL
+			cs.UsingIndexLocal = true
+			// LOCAL [ STORE IN (tablespace [, ...]) ] [ (partition specs) ]
+			if p.isIdentLikeStr("STORE") && p.peekNext().Type == kwIN {
+				p.advance() // consume STORE
+				p.advance() // consume IN
+				if p.cur.Type != '(' {
+					return p.syntaxErrorAtCur()
+				}
+				p.skipParenthesized()
+			}
+			if p.cur.Type == '(' {
+				p.skipParenthesized()
+			}
+
+		case p.cur.Type == kwGLOBAL:
+			p.advance() // consume GLOBAL
+			// GLOBAL [ PARTITION BY { RANGE | HASH } (cols) [ (partition specs) ] ]
+			if p.cur.Type == kwPARTITION {
+				p.advance() // consume PARTITION
+				if p.cur.Type != kwBY {
+					return p.syntaxErrorAtCur()
+				}
+				p.advance() // consume BY
+				if p.cur.Type == kwRANGE || p.cur.Type == kwHASH {
+					p.advance()
+				}
+				if p.cur.Type != '(' {
+					return p.syntaxErrorAtCur()
+				}
+				p.skipParenthesized()
+				if p.cur.Type == '(' {
+					p.skipParenthesized()
+				}
+			}
+
+		case p.cur.Type == kwPCTFREE || p.isIdentLikeStr("PCTUSED") ||
+			p.isIdentLikeStr("INITRANS") || p.isIdentLikeStr("MAXTRANS"):
+			p.advance()
+			if p.cur.Type != tokICONST {
+				return p.syntaxErrorAtCur()
+			}
+			p.advance()
+
+		case p.cur.Type == kwSTORAGE:
+			p.advance() // consume STORAGE
+			if p.cur.Type != '(' {
+				return p.syntaxErrorAtCur()
+			}
+			p.skipParenthesized()
+
+		case p.isIdentLikeStr("COMPUTE"):
+			// COMPUTE STATISTICS (emitted by DBMS_METADATA)
+			p.advance() // consume COMPUTE
+			if !p.isIdentLikeStr("STATISTICS") {
+				return p.syntaxErrorAtCur()
+			}
+			p.advance() // consume STATISTICS
+
+		case p.cur.Type == kwCOMPRESS:
+			p.advance()
+			if p.cur.Type == tokICONST {
+				p.advance()
+			}
+
+		case p.cur.Type == kwLOGGING || p.cur.Type == kwNOLOGGING ||
+			p.cur.Type == kwONLINE || p.cur.Type == kwREVERSE:
+			p.advance()
+
+		case p.isIdentLikeStr("NOCOMPRESS") || p.isIdentLikeStr("SORT") ||
+			p.isIdentLikeStr("NOSORT") || p.isIdentLikeStr("VISIBLE") ||
+			p.isIdentLikeStr("INVISIBLE"):
+			p.advance()
+
+		default:
+			return nil
+		}
+	}
+}

--- a/oracle/parser/create_table.go
+++ b/oracle/parser/create_table.go
@@ -1650,24 +1650,28 @@ func (p *Parser) parseTableOptions(stmt *nodes.CreateTableStmt) error {
 					stmt.RowDependencies = "NOROWDEPENDENCIES"
 				case "PCTFREE":
 					p.advance() // consume PCTFREE
-					if p.cur.Type == tokICONST {
-						p.advance()
+					if p.cur.Type != tokICONST {
+						return p.syntaxErrorAtCur()
 					}
+					p.advance()
 				case "PCTUSED":
 					p.advance() // consume PCTUSED
-					if p.cur.Type == tokICONST {
-						p.advance()
+					if p.cur.Type != tokICONST {
+						return p.syntaxErrorAtCur()
 					}
+					p.advance()
 				case "INITRANS":
 					p.advance() // consume INITRANS
-					if p.cur.Type == tokICONST {
-						p.advance()
+					if p.cur.Type != tokICONST {
+						return p.syntaxErrorAtCur()
 					}
+					p.advance()
 				case "MAXTRANS":
 					p.advance() // consume MAXTRANS
-					if p.cur.Type == tokICONST {
-						p.advance()
+					if p.cur.Type != tokICONST {
+						return p.syntaxErrorAtCur()
 					}
+					p.advance()
 				case "PCTTHRESHOLD":
 					// PCTTHRESHOLD integer — index-organized tables only;
 					// Oracle rejects it on heap tables (ORA-00922).
@@ -1675,9 +1679,10 @@ func (p *Parser) parseTableOptions(stmt *nodes.CreateTableStmt) error {
 						return p.syntaxErrorAtCur()
 					}
 					p.advance() // consume PCTTHRESHOLD
-					if p.cur.Type == tokICONST {
-						p.advance()
+					if p.cur.Type != tokICONST {
+						return p.syntaxErrorAtCur()
 					}
+					p.advance()
 				case "COLUMN":
 					// COLUMN STORE COMPRESS FOR { QUERY | ARCHIVE } [ LOW | HIGH ]
 					next := p.peekNext()

--- a/oracle/parser/create_table.go
+++ b/oracle/parser/create_table.go
@@ -1170,10 +1170,33 @@ func (p *Parser) parseColumnConstraintInline() (*nodes.ColumnConstraint, error) 
 	return cc, nil
 }
 
-// parseTableConstraint parses a table-level constraint.
+// parseTableConstraint parses a table-level constraint including its
+// trailing constraint_state clause.
 //
-//	[ CONSTRAINT name ] { PRIMARY KEY (cols) | UNIQUE (cols) | CHECK (expr) | FOREIGN KEY (cols) REFERENCES ... }
+//	[ CONSTRAINT name ] { PRIMARY KEY (cols) | UNIQUE (cols) | CHECK (expr) | FOREIGN KEY (cols) REFERENCES ... } constraint_state
 func (p *Parser) parseTableConstraint() (*nodes.TableConstraint, error) {
+	tc, err := p.parseTableConstraintBody()
+	if err != nil {
+		return nil, err
+	}
+
+	var cs constraintState
+	if err := p.parseConstraintState(&cs); err != nil {
+		return nil, err
+	}
+	tc.Deferrable = cs.Deferrable
+	tc.Initially = cs.Initially
+	tc.Tablespace = cs.Tablespace
+	tc.UsingIndexLocal = cs.UsingIndexLocal
+
+	tc.Loc.End = p.prev.End
+	return tc, nil
+}
+
+// parseTableConstraintBody parses a table-level constraint without its
+// constraint_state clause. Used directly by view constraint parsing, where
+// the allowed state differs — see parseViewConstraintState.
+func (p *Parser) parseTableConstraintBody() (*nodes.TableConstraint, error) {
 	start := p.pos()
 	tc := &nodes.TableConstraint{
 		Loc: nodes.Loc{Start: start},
@@ -1311,15 +1334,6 @@ func (p *Parser) parseTableConstraint() (*nodes.TableConstraint, error) {
 	default:
 		return nil, p.syntaxErrorAtCur()
 	}
-
-	var cs constraintState
-	if err := p.parseConstraintState(&cs); err != nil {
-		return nil, err
-	}
-	tc.Deferrable = cs.Deferrable
-	tc.Initially = cs.Initially
-	tc.Tablespace = cs.Tablespace
-	tc.UsingIndexLocal = cs.UsingIndexLocal
 
 	tc.Loc.End = p.prev.End
 	return tc, nil

--- a/oracle/parser/create_table.go
+++ b/oracle/parser/create_table.go
@@ -782,6 +782,10 @@ func (p *Parser) parseColumnProperties(col *nodes.ColumnDef) error {
 				p.advance() // consume NOT
 				p.advance() // consume NULL
 				col.NotNull = true
+				var cs constraintState
+				if err := p.parseConstraintState(&cs); err != nil {
+					return err
+				}
 			} else {
 				return nil
 			}
@@ -789,6 +793,10 @@ func (p *Parser) parseColumnProperties(col *nodes.ColumnDef) error {
 		case kwNULL:
 			p.advance() // consume NULL
 			col.Null = true
+			var cs constraintState
+			if err := p.parseConstraintState(&cs); err != nil {
+				return err
+			}
 
 		case kwINVISIBLE:
 			p.advance()
@@ -1149,29 +1157,14 @@ func (p *Parser) parseColumnConstraintInline() (*nodes.ColumnConstraint, error) 
 		return nil, nil
 	}
 
-	if p.cur.Type == kwDEFERRABLE {
-		cc.Deferrable = true
-		p.advance()
-	} else if p.cur.Type == kwNOT {
-		next := p.peekNext()
-		if next.Type == kwDEFERRABLE {
-			p.advance() // consume NOT
-			p.advance() // consume DEFERRABLE
-			cc.Deferrable = false
-		}
+	var cs constraintState
+	if err := p.parseConstraintState(&cs); err != nil {
+		return nil, err
 	}
-
-	// INITIALLY DEFERRED / INITIALLY IMMEDIATE
-	if p.cur.Type == kwINITIALLY {
-		p.advance() // consume INITIALLY
-		if p.cur.Type == kwDEFERRED {
-			cc.Initially = "DEFERRED"
-			p.advance()
-		} else if p.cur.Type == kwIMMEDIATE {
-			cc.Initially = "IMMEDIATE"
-			p.advance()
-		}
-	}
+	cc.Deferrable = cs.Deferrable
+	cc.Initially = cs.Initially
+	cc.Tablespace = cs.Tablespace
+	cc.UsingIndexLocal = cs.UsingIndexLocal
 
 	cc.Loc.End = p.prev.End
 	return cc, nil
@@ -1319,29 +1312,14 @@ func (p *Parser) parseTableConstraint() (*nodes.TableConstraint, error) {
 		return nil, p.syntaxErrorAtCur()
 	}
 
-	if p.cur.Type == kwDEFERRABLE {
-		tc.Deferrable = true
-		p.advance()
-	} else if p.cur.Type == kwNOT {
-		next := p.peekNext()
-		if next.Type == kwDEFERRABLE {
-			p.advance() // consume NOT
-			p.advance() // consume DEFERRABLE
-			tc.Deferrable = false
-		}
+	var cs constraintState
+	if err := p.parseConstraintState(&cs); err != nil {
+		return nil, err
 	}
-
-	// INITIALLY DEFERRED / INITIALLY IMMEDIATE
-	if p.cur.Type == kwINITIALLY {
-		p.advance() // consume INITIALLY
-		if p.cur.Type == kwDEFERRED {
-			tc.Initially = "DEFERRED"
-			p.advance()
-		} else if p.cur.Type == kwIMMEDIATE {
-			tc.Initially = "IMMEDIATE"
-			p.advance()
-		}
-	}
+	tc.Deferrable = cs.Deferrable
+	tc.Initially = cs.Initially
+	tc.Tablespace = cs.Tablespace
+	tc.UsingIndexLocal = cs.UsingIndexLocal
 
 	tc.Loc.End = p.prev.End
 	return tc, nil
@@ -1668,6 +1646,17 @@ func (p *Parser) parseTableOptions(stmt *nodes.CreateTableStmt) error {
 					}
 				case "INITRANS":
 					p.advance() // consume INITRANS
+					if p.cur.Type == tokICONST {
+						p.advance()
+					}
+				case "MAXTRANS":
+					p.advance() // consume MAXTRANS
+					if p.cur.Type == tokICONST {
+						p.advance()
+					}
+				case "PCTTHRESHOLD":
+					// PCTTHRESHOLD integer (index-organized tables)
+					p.advance() // consume PCTTHRESHOLD
 					if p.cur.Type == tokICONST {
 						p.advance()
 					}

--- a/oracle/parser/create_table.go
+++ b/oracle/parser/create_table.go
@@ -1669,7 +1669,11 @@ func (p *Parser) parseTableOptions(stmt *nodes.CreateTableStmt) error {
 						p.advance()
 					}
 				case "PCTTHRESHOLD":
-					// PCTTHRESHOLD integer (index-organized tables)
+					// PCTTHRESHOLD integer — index-organized tables only;
+					// Oracle rejects it on heap tables (ORA-00922).
+					if stmt.Organization != "INDEX" {
+						return p.syntaxErrorAtCur()
+					}
 					p.advance() // consume PCTTHRESHOLD
 					if p.cur.Type == tokICONST {
 						p.advance()

--- a/oracle/parser/create_table_test.go
+++ b/oracle/parser/create_table_test.go
@@ -720,11 +720,33 @@ func TestParseCreateTableConstraintStateClauses(t *testing.T) {
 		{"ck_enable_validate", `CREATE TABLE t (a NUMBER, CONSTRAINT ck CHECK (a > 0) ENABLE VALIDATE)`},
 		{"fk_rely_disable_novalidate", `CREATE TABLE t (a NUMBER, CONSTRAINT fk FOREIGN KEY (a) REFERENCES p (id) RELY DISABLE NOVALIDATE)`},
 		{"pk_deferrable_enable", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) DEFERRABLE INITIALLY DEFERRED ENABLE)`},
-		{"pk_enable_before_deferrable", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) ENABLE NOVALIDATE NOT DEFERRABLE)`},
+		{"pk_initially_before_deferrable", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) INITIALLY DEFERRED DEFERRABLE)`},
+		{"pk_full_documented_order", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) RELY USING INDEX ENABLE NOVALIDATE)`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ParseAndCheck(t, tt.sql)
+		})
+	}
+}
+
+// TestParseCreateTableConstraintStateOrder tests that out-of-order
+// constraint_state subclauses are rejected, matching Oracle (ORA-03075,
+// verified against Oracle 23ai).
+func TestParseCreateTableConstraintStateOrder(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{"enable_before_using_index", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) ENABLE USING INDEX)`},
+		{"novalidate_before_enable", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) NOVALIDATE ENABLE)`},
+		{"disable_before_rely", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) DISABLE RELY)`},
+		{"using_index_before_rely", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX RELY)`},
+		{"enable_before_deferrable", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) ENABLE NOVALIDATE NOT DEFERRABLE)`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ParseShouldFail(t, tt.sql)
 		})
 	}
 }

--- a/oracle/parser/create_table_test.go
+++ b/oracle/parser/create_table_test.go
@@ -928,3 +928,17 @@ func TestParseCreateTableRound5EngineVerified(t *testing.T) {
 	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX store.idx)`)
 	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX PCTUSED 40)`)
 }
+
+// TestParseCreateTableRound6EngineVerified locks in sixth-round review
+// dispositions, each cross-checked against Oracle 23ai:
+//   - STORE IN requires at least one tablespace (ORA-02216)
+//   - GLOBAL PARTITION BY RANGE requires explicit partition specs
+//     (ORA-00906) while the HASH payload is optional
+//   - USING INDEX hash is rejected by Oracle itself (ORA-14071): property
+//     words take precedence over an index name even when such an index exists
+func TestParseCreateTableRound6EngineVerified(t *testing.T) {
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX LOCAL STORE IN ()) PARTITION BY HASH (a) PARTITIONS 2`)
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX GLOBAL PARTITION BY RANGE (a))`)
+	ParseAndCheck(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX GLOBAL PARTITION BY HASH (a))`)
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX HASH)`)
+}

--- a/oracle/parser/create_table_test.go
+++ b/oracle/parser/create_table_test.go
@@ -900,3 +900,18 @@ func TestParseCreateTableUsingIndexEngineVerifiedRestrictions(t *testing.T) {
 	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX (CREATE INDEX IF NOT EXISTS idx ON t (a)))`)
 	ParseShouldFail(t, `CREATE TABLE t (a NUMBER) PCTTHRESHOLD 20`)
 }
+
+// TestParseCreateTableRound4EngineVerified locks in fourth-round review
+// findings, each cross-checked against Oracle 23ai:
+//   - PARTITION BY requires RANGE or HASH (ORA-14151)
+//   - the nested CREATE INDEX column list must be non-empty (ORA-00936)
+//   - ANNOTATIONS (...) is a valid using_index property
+//   - physical attributes require their integer operand (ORA-02209/02211)
+func TestParseCreateTableRound4EngineVerified(t *testing.T) {
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX GLOBAL PARTITION BY (a) (PARTITION p1 VALUES LESS THAN (MAXVALUE)))`)
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX (CREATE INDEX idx ON t ()))`)
+	ParseAndCheck(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX ANNOTATIONS (classification 'pii'))`)
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER) MAXTRANS`)
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER) PCTFREE`)
+	ParseAndCheck(t, `CREATE TABLE t (a NUMBER) PCTFREE 10 PCTUSED 40 INITRANS 1 MAXTRANS 255`)
+}

--- a/oracle/parser/create_table_test.go
+++ b/oracle/parser/create_table_test.go
@@ -864,3 +864,22 @@ func TestParseCreateTableUsingIndexParenValidation(t *testing.T) {
 	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX (garbage))`)
 	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX (CREATE TABLE x (y NUMBER)))`)
 }
+
+// TestParseCreateTableUsingIndexGlobalHashQuantity tests the
+// hash_partitions_by_quantity form of a global partitioned index
+// (verified against Oracle 23ai).
+func TestParseCreateTableUsingIndexGlobalHashQuantity(t *testing.T) {
+	ParseAndCheck(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX GLOBAL PARTITION BY HASH (a) PARTITIONS 4)`)
+	ParseAndCheck(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX GLOBAL PARTITION BY HASH (a) PARTITIONS 2 STORE IN (ts1, ts2))`)
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX GLOBAL PARTITION BY HASH (a) PARTITIONS)`)
+}
+
+// TestParseCreateTableUsingIndexParenStructure tests that the nested CREATE
+// INDEX must carry its required structure — Oracle raises ORA-00953 for a
+// missing index name and ORA-00969 for a missing ON clause.
+func TestParseCreateTableUsingIndexParenStructure(t *testing.T) {
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX (CREATE INDEX))`)
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX (CREATE INDEX idx))`)
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX (CREATE INDEX idx ON t))`)
+	ParseAndCheck(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX (CREATE INDEX s.idx ON s.t (a) TABLESPACE ts1))`)
+}

--- a/oracle/parser/create_table_test.go
+++ b/oracle/parser/create_table_test.go
@@ -883,3 +883,20 @@ func TestParseCreateTableUsingIndexParenStructure(t *testing.T) {
 	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX (CREATE INDEX idx ON t))`)
 	ParseAndCheck(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX (CREATE INDEX s.idx ON s.t (a) TABLESPACE ts1))`)
 }
+
+// TestParseCreateTableUsingIndexEngineVerifiedRestrictions locks in
+// behavior cross-checked against Oracle 23ai for the third review round:
+//   - PARTITIONS quantity is HASH-only (RANGE rejected, ORA-00906)
+//   - LOCAL STORE IN and explicit partition specs are mutually exclusive
+//     (ORA-14153 / ORA-03075)
+//   - IF NOT EXISTS is NOT accepted inside the nested CREATE INDEX form
+//     (ORA-00969), although it is valid in a standalone CREATE INDEX
+//   - PCTTHRESHOLD requires ORGANIZATION INDEX (ORA-00922 on heap tables)
+func TestParseCreateTableUsingIndexEngineVerifiedRestrictions(t *testing.T) {
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX GLOBAL PARTITION BY RANGE (a) PARTITIONS 4)`)
+	ParseAndCheck(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX GLOBAL PARTITION BY RANGE (a) (PARTITION p1 VALUES LESS THAN (MAXVALUE)))`)
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX LOCAL (PARTITION p1) STORE IN (ts1)) PARTITION BY HASH (a) PARTITIONS 2`)
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX LOCAL STORE IN (ts1) (PARTITION p1)) PARTITION BY HASH (a) PARTITIONS 2`)
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX (CREATE INDEX IF NOT EXISTS idx ON t (a)))`)
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER) PCTTHRESHOLD 20`)
+}

--- a/oracle/parser/create_table_test.go
+++ b/oracle/parser/create_table_test.go
@@ -593,3 +593,221 @@ func TestParseCreateTableTablespace(t *testing.T) {
 		t.Errorf("expected tablespace USERS, got %q", ct.Tablespace)
 	}
 }
+
+// TestParseCreateTableConstraintUsingIndexLocal tests the minimal
+// PRIMARY KEY (...) USING INDEX LOCAL form (BYT-10010).
+func TestParseCreateTableConstraintUsingIndexLocal(t *testing.T) {
+	sql := `CREATE TABLE t (
+		a NUMBER,
+		b DATE,
+		CONSTRAINT pk_t PRIMARY KEY (a, b) USING INDEX LOCAL
+	)`
+	result := ParseAndCheck(t, sql)
+	raw := result.Items[0].(*ast.RawStmt)
+	ct := raw.Stmt.(*ast.CreateTableStmt)
+	if ct.Constraints.Len() != 1 {
+		t.Fatalf("expected 1 table constraint, got %d", ct.Constraints.Len())
+	}
+	tc := ct.Constraints.Items[0].(*ast.TableConstraint)
+	if tc.Type != ast.CONSTRAINT_PRIMARY {
+		t.Errorf("expected PRIMARY constraint, got %d", tc.Type)
+	}
+	if tc.Columns.Len() != 2 {
+		t.Errorf("expected 2 constraint columns, got %d", tc.Columns.Len())
+	}
+	if !tc.UsingIndexLocal {
+		t.Error("expected UsingIndexLocal to be true")
+	}
+}
+
+// TestParseCreateTablePartitionedPKUsingIndexLocal tests the full customer
+// statement from BYT-10010: an interval-partitioned table whose primary key
+// is backed by a local index.
+func TestParseCreateTablePartitionedPKUsingIndexLocal(t *testing.T) {
+	sql := `CREATE TABLE DATA.RC_FT_ADJ_CONFIG
+(
+    RC_FT_ADJ_CODE        VARCHAR2(250) NOT NULL,
+    RC_CODE               VARCHAR2(150),
+    DATE_REPORT           DATE,
+    IS_CHECK              VARCHAR2(255),
+    IS_ACTION             VARCHAR2(255),
+    CREATE_DATE           DATE DEFAULT SYSDATE NOT NULL,
+    CREATE_USER           VARCHAR2(50) DEFAULT 'ETL_USER',
+    UPDATE_DATE           DATE DEFAULT SYSDATE,
+    UPDATE_USER           VARCHAR2(50) DEFAULT 'ETL_USER',
+    TYPE                  VARCHAR2(50),
+    RC_FT_ADJ_STATUS      VARCHAR2(255),
+    PARENT_RC_FT_ADJ_CODE VARCHAR2(250),
+    E_STATUS              NUMBER,
+
+    CONSTRAINT PK_RC_FT_ADJ_CONFIG
+        PRIMARY KEY (RC_FT_ADJ_CODE, CREATE_DATE) USING INDEX LOCAL
+)
+PARTITION BY RANGE (CREATE_DATE)
+INTERVAL (NUMTOYMINTERVAL(1, 'MONTH'))
+(
+    PARTITION P202607
+        VALUES LESS THAN (DATE '2026-07-01')
+)`
+	result := ParseAndCheck(t, sql)
+	raw := result.Items[0].(*ast.RawStmt)
+	ct := raw.Stmt.(*ast.CreateTableStmt)
+	if ct.Columns.Len() != 13 {
+		t.Fatalf("expected 13 columns, got %d", ct.Columns.Len())
+	}
+	if ct.Constraints.Len() != 1 {
+		t.Fatalf("expected 1 table constraint, got %d", ct.Constraints.Len())
+	}
+	tc := ct.Constraints.Items[0].(*ast.TableConstraint)
+	if tc.Name != "PK_RC_FT_ADJ_CONFIG" {
+		t.Errorf("expected constraint name PK_RC_FT_ADJ_CONFIG, got %q", tc.Name)
+	}
+	if !tc.UsingIndexLocal {
+		t.Error("expected UsingIndexLocal to be true")
+	}
+	if ct.Partition == nil {
+		t.Error("expected partition clause to be preserved")
+	}
+}
+
+// TestParseCreateTableConstraintUsingIndexForms tests the remaining
+// using_index_clause forms on table constraints.
+func TestParseCreateTableConstraintUsingIndexForms(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{"bare", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX)`},
+		{"index_name", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX idx1)`},
+		{"schema_qualified_index", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX s.idx1)`},
+		{"create_index_stmt", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX (CREATE INDEX idx1 ON t (a) TABLESPACE ts1))`},
+		{"attributes", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX PCTFREE 10 INITRANS 2 STORAGE (INITIAL 64K) NOLOGGING)`},
+		{"tablespace_then_enable", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX TABLESPACE ts1 ENABLE)`},
+		{"unique_local", `CREATE TABLE t (a NUMBER, CONSTRAINT uq UNIQUE (a) USING INDEX LOCAL)`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ParseAndCheck(t, tt.sql)
+		})
+	}
+}
+
+// TestParseCreateTableConstraintUsingIndexTablespace tests that USING INDEX
+// TABLESPACE populates TableConstraint.Tablespace.
+func TestParseCreateTableConstraintUsingIndexTablespace(t *testing.T) {
+	sql := `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX TABLESPACE ts1)`
+	result := ParseAndCheck(t, sql)
+	raw := result.Items[0].(*ast.RawStmt)
+	ct := raw.Stmt.(*ast.CreateTableStmt)
+	tc := ct.Constraints.Items[0].(*ast.TableConstraint)
+	if tc.Tablespace != "TS1" {
+		t.Errorf("expected Tablespace TS1, got %q", tc.Tablespace)
+	}
+	if tc.UsingIndexLocal {
+		t.Error("expected UsingIndexLocal to be false")
+	}
+}
+
+// TestParseCreateTableConstraintStateClauses tests ENABLE/DISABLE,
+// VALIDATE/NOVALIDATE and RELY/NORELY on table constraints.
+func TestParseCreateTableConstraintStateClauses(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{"pk_enable", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) ENABLE)`},
+		{"uq_disable", `CREATE TABLE t (a NUMBER, CONSTRAINT uq UNIQUE (a) DISABLE)`},
+		{"ck_enable_validate", `CREATE TABLE t (a NUMBER, CONSTRAINT ck CHECK (a > 0) ENABLE VALIDATE)`},
+		{"fk_rely_disable_novalidate", `CREATE TABLE t (a NUMBER, CONSTRAINT fk FOREIGN KEY (a) REFERENCES p (id) RELY DISABLE NOVALIDATE)`},
+		{"pk_deferrable_enable", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) DEFERRABLE INITIALLY DEFERRED ENABLE)`},
+		{"pk_enable_before_deferrable", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) ENABLE NOVALIDATE NOT DEFERRABLE)`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ParseAndCheck(t, tt.sql)
+		})
+	}
+}
+
+// TestParseCreateTableColumnConstraintState tests constraint_state on
+// column-level constraints, including the implicit NOT NULL constraint.
+func TestParseCreateTableColumnConstraintState(t *testing.T) {
+	sql := `CREATE TABLE t (
+		a VARCHAR2(10) UNIQUE USING INDEX TABLESPACE ts1,
+		b NUMBER NOT NULL ENABLE,
+		c NUMBER PRIMARY KEY USING INDEX LOCAL,
+		d NUMBER CONSTRAINT nn_d NOT NULL ENABLE NOVALIDATE,
+		e NUMBER NULL ENABLE
+	)`
+	result := ParseAndCheck(t, sql)
+	raw := result.Items[0].(*ast.RawStmt)
+	ct := raw.Stmt.(*ast.CreateTableStmt)
+	if ct.Columns.Len() != 5 {
+		t.Fatalf("expected 5 columns, got %d", ct.Columns.Len())
+	}
+
+	colA := ct.Columns.Items[0].(*ast.ColumnDef)
+	ccA := colA.Constraints.Items[0].(*ast.ColumnConstraint)
+	if ccA.Type != ast.CONSTRAINT_UNIQUE {
+		t.Errorf("expected UNIQUE constraint on a, got %d", ccA.Type)
+	}
+	if ccA.Tablespace != "TS1" {
+		t.Errorf("expected Tablespace TS1 on a, got %q", ccA.Tablespace)
+	}
+
+	colB := ct.Columns.Items[1].(*ast.ColumnDef)
+	if !colB.NotNull {
+		t.Error("expected b to be NOT NULL")
+	}
+
+	colC := ct.Columns.Items[2].(*ast.ColumnDef)
+	ccC := colC.Constraints.Items[0].(*ast.ColumnConstraint)
+	if ccC.Type != ast.CONSTRAINT_PRIMARY {
+		t.Errorf("expected PRIMARY constraint on c, got %d", ccC.Type)
+	}
+	if !ccC.UsingIndexLocal {
+		t.Error("expected UsingIndexLocal on c")
+	}
+
+	colD := ct.Columns.Items[3].(*ast.ColumnDef)
+	if !colD.NotNull {
+		t.Error("expected d to be NOT NULL")
+	}
+}
+
+// TestParseCreateTableDBMSMetadataStyle tests a DBMS_METADATA.GET_DDL-style
+// dump: USING INDEX with physical attributes and COMPUTE STATISTICS, plus
+// table-level MAXTRANS.
+func TestParseCreateTableDBMSMetadataStyle(t *testing.T) {
+	sql := `CREATE TABLE "S"."T"
+   (	"A" NUMBER(*,0) NOT NULL ENABLE,
+	"B" VARCHAR2(20) DEFAULT NULL,
+	 CONSTRAINT "PK_T" PRIMARY KEY ("A")
+  USING INDEX PCTFREE 10 INITRANS 2 MAXTRANS 255 COMPUTE STATISTICS
+  STORAGE(INITIAL 65536 NEXT 1048576 MINEXTENTS 1 MAXEXTENTS 2147483645
+  PCTINCREASE 0 FREELISTS 1 FREELIST GROUPS 1 BUFFER_POOL DEFAULT FLASH_CACHE DEFAULT CELL_FLASH_CACHE DEFAULT)
+  TABLESPACE "USERS"  ENABLE
+   ) SEGMENT CREATION IMMEDIATE
+  PCTFREE 10 PCTUSED 40 INITRANS 1 MAXTRANS 255
+ NOCOMPRESS LOGGING
+  TABLESPACE "USERS"`
+	result := ParseAndCheck(t, sql)
+	raw := result.Items[0].(*ast.RawStmt)
+	ct := raw.Stmt.(*ast.CreateTableStmt)
+	tc := ct.Constraints.Items[0].(*ast.TableConstraint)
+	if tc.Tablespace != "USERS" {
+		t.Errorf("expected Tablespace USERS, got %q", tc.Tablespace)
+	}
+}
+
+// TestParseCreateTableIOTOptions tests index-organized table options
+// PCTTHRESHOLD and OVERFLOW.
+func TestParseCreateTableIOTOptions(t *testing.T) {
+	sql := `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a)) ORGANIZATION INDEX PCTTHRESHOLD 20 OVERFLOW TABLESPACE ts2`
+	result := ParseAndCheck(t, sql)
+	raw := result.Items[0].(*ast.RawStmt)
+	ct := raw.Stmt.(*ast.CreateTableStmt)
+	if ct.Organization != "INDEX" {
+		t.Errorf("expected ORGANIZATION INDEX, got %q", ct.Organization)
+	}
+}

--- a/oracle/parser/create_table_test.go
+++ b/oracle/parser/create_table_test.go
@@ -833,3 +833,34 @@ func TestParseCreateTableIOTOptions(t *testing.T) {
 		t.Errorf("expected ORGANIZATION INDEX, got %q", ct.Organization)
 	}
 }
+
+// TestParseCreateTableUsingIndexMoreAttributes tests index attributes flagged
+// in review: PARALLEL/NOPARALLEL, INDEXING FULL|PARTIAL, COMPRESS ADVANCED.
+// All verified as syntactically valid against Oracle 23ai.
+func TestParseCreateTableUsingIndexMoreAttributes(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{"parallel", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX PARALLEL 4)`},
+		{"noparallel", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX NOPARALLEL)`},
+		{"indexing_full", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX INDEXING FULL)`},
+		{"indexing_partial", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX INDEXING PARTIAL)`},
+		{"compress_advanced", `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX COMPRESS ADVANCED)`},
+		{"compress_advanced_low", `CREATE TABLE t (a NUMBER, b NUMBER, CONSTRAINT pk PRIMARY KEY (a, b) USING INDEX COMPRESS ADVANCED LOW)`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ParseAndCheck(t, tt.sql)
+		})
+	}
+}
+
+// TestParseCreateTableUsingIndexParenValidation tests that the parenthesized
+// using_index form requires a CREATE [UNIQUE|BITMAP] INDEX statement,
+// matching Oracle's ORA-02000 "missing CREATE keyword".
+func TestParseCreateTableUsingIndexParenValidation(t *testing.T) {
+	ParseAndCheck(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX (CREATE UNIQUE INDEX idx ON t (a)))`)
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX (garbage))`)
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX (CREATE TABLE x (y NUMBER)))`)
+}

--- a/oracle/parser/create_table_test.go
+++ b/oracle/parser/create_table_test.go
@@ -915,3 +915,16 @@ func TestParseCreateTableRound4EngineVerified(t *testing.T) {
 	ParseShouldFail(t, `CREATE TABLE t (a NUMBER) PCTFREE`)
 	ParseAndCheck(t, `CREATE TABLE t (a NUMBER) PCTFREE 10 PCTUSED 40 INITRANS 1 MAXTRANS 255`)
 }
+
+// TestParseCreateTableRound5EngineVerified locks in fifth-round review
+// dispositions, each cross-checked against Oracle 23ai:
+//   - bare USING INDEX GLOBAL is ACCEPTED by Oracle (review claim refuted)
+//   - a property-word schema qualifier (store.idx) is REJECTED by Oracle
+//     with ORA-03075 — Oracle's own parser gives property words precedence
+//     (review claim refuted)
+//   - PCTUSED inside using_index_clause is rejected (ORA-14071)
+func TestParseCreateTableRound5EngineVerified(t *testing.T) {
+	ParseAndCheck(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX GLOBAL)`)
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX store.idx)`)
+	ParseShouldFail(t, `CREATE TABLE t (a NUMBER, CONSTRAINT pk PRIMARY KEY (a) USING INDEX PCTUSED 40)`)
+}

--- a/oracle/parser/create_view.go
+++ b/oracle/parser/create_view.go
@@ -432,9 +432,13 @@ func (p *Parser) parseMaterializedViewOptions(stmt *nodes.CreateViewStmt) error 
 			}
 
 		case p.cur.Type == kwUSING && p.peekNext().Type == kwINDEX:
-			// USING INDEX index_properties (default index storage for the mview)
+			// USING INDEX index_properties (default index storage for the
+			// mview). Properties only: Oracle rejects an index name or a
+			// nested CREATE INDEX here (ORA-02000).
+			p.advance() // consume USING
+			p.advance() // consume INDEX
 			var cs constraintState
-			if err := p.parseUsingIndexClause(&cs); err != nil {
+			if err := p.parseUsingIndexProperties(&cs); err != nil {
 				return err
 			}
 

--- a/oracle/parser/create_view.go
+++ b/oracle/parser/create_view.go
@@ -294,6 +294,7 @@ func (p *Parser) finishCreateViewStmt(stmt *nodes.CreateViewStmt) (*nodes.Create
 
 // parseMaterializedViewOptions parses BUILD, REFRESH, and other options for materialized views.
 func (p *Parser) parseMaterializedViewOptions(stmt *nodes.CreateViewStmt) error {
+	seenRefresh := false
 	for {
 		switch {
 		case p.isIdentLike() && p.cur.Str == "BUILD":
@@ -343,6 +344,7 @@ func (p *Parser) parseMaterializedViewOptions(stmt *nodes.CreateViewStmt) error 
 			stmt.NeverRefresh = true
 
 		case p.cur.Type == kwREFRESH:
+			seenRefresh = true
 			p.advance()
 			// FAST | COMPLETE | FORCE
 			if p.isIdentLike() && p.cur.Str == "FAST" {
@@ -441,9 +443,10 @@ func (p *Parser) parseMaterializedViewOptions(stmt *nodes.CreateViewStmt) error 
 			}
 			p.advance() // consume INDEX
 
-		case p.cur.Type == kwUSING &&
+		case seenRefresh && p.cur.Type == kwUSING &&
 			(p.isIdentLikeStrAt(p.peekNext(), "TRUSTED") || p.isIdentLikeStrAt(p.peekNext(), "ENFORCED")):
-			// USING { TRUSTED | ENFORCED } CONSTRAINTS
+			// USING { TRUSTED | ENFORCED } CONSTRAINTS — part of create_mv_refresh;
+			// Oracle rejects it without a preceding REFRESH clause.
 			p.advance() // consume USING
 			p.advance() // consume TRUSTED/ENFORCED
 			if p.cur.Type != kwCONSTRAINTS {

--- a/oracle/parser/create_view.go
+++ b/oracle/parser/create_view.go
@@ -144,14 +144,16 @@ func (p *Parser) finishCreateViewStmt(stmt *nodes.CreateViewStmt) (*nodes.Create
 			}
 			// Out-of-line view constraint: CONSTRAINT name { PRIMARY KEY |
 			// UNIQUE | FOREIGN KEY } (cols) constraint_state. View constraints
-			// are declarative only (RELY DISABLE NOVALIDATE); the parsed
-			// constraint is validated but not yet preserved in the AST.
+			// are declarative only (RELY DISABLE NOVALIDATE).
 			if p.isTableConstraintStart() {
 				viewConstraint, err := p.parseTableConstraint()
 				if err != nil {
 					return nil, err
 				}
-				_ = viewConstraint
+				if stmt.Constraints == nil {
+					stmt.Constraints = &nodes.List{}
+				}
+				stmt.Constraints.Items = append(stmt.Constraints.Items, viewConstraint)
 				if p.cur.Type != ',' {
 					break
 				}

--- a/oracle/parser/create_view.go
+++ b/oracle/parser/create_view.go
@@ -87,6 +87,23 @@ func (p *Parser) parseCreateViewStmt(start int, orReplace bool) (*nodes.CreateVi
 	return p.finishCreateViewStmt(stmt)
 }
 
+// isViewConstraintStart reports whether the current position starts an
+// out-of-line view constraint. CONSTRAINT is unambiguous in a view alias
+// list; PRIMARY, FOREIGN, and UNIQUE are legal bare aliases (Oracle 23ai
+// accepts CREATE VIEW v (primary) AS ...), so they count only when followed
+// by their mandatory next token. CHECK constraints do not exist on views.
+func (p *Parser) isViewConstraintStart() bool {
+	switch p.cur.Type {
+	case kwCONSTRAINT:
+		return true
+	case kwPRIMARY, kwFOREIGN:
+		return p.peekNext().Type == kwKEY
+	case kwUNIQUE:
+		return p.peekNext().Type == '('
+	}
+	return false
+}
+
 // finishCreateViewStmt finishes parsing a CREATE VIEW statement after the
 // MATERIALIZED/FORCE/VIEW prefix has been consumed.
 func (p *Parser) finishCreateViewStmt(stmt *nodes.CreateViewStmt) (*nodes.CreateViewStmt, error) {
@@ -150,7 +167,10 @@ func (p *Parser) finishCreateViewStmt(stmt *nodes.CreateViewStmt) (*nodes.Create
 			// datatype ambiguity: CONSTRAINT always starts a constraint here
 			// (a constraint name may be a nonreserved datatype word like BLOB,
 			// while a bare alias named CONSTRAINT is rejected by Oracle).
-			if p.cur.Type == kwCONSTRAINT || p.isTableConstraintStart() {
+			// PRIMARY/FOREIGN/UNIQUE, however, are legal bare aliases
+			// (verified on 23ai), so they start a constraint only when the
+			// required following token is present.
+			if p.isViewConstraintStart() {
 				viewConstraint, err := p.parseTableConstraintBody()
 				if err != nil {
 					return nil, err

--- a/oracle/parser/create_view.go
+++ b/oracle/parser/create_view.go
@@ -142,6 +142,22 @@ func (p *Parser) finishCreateViewStmt(stmt *nodes.CreateViewStmt) (*nodes.Create
 			if p.cur.Type == ')' || p.cur.Type == tokEOF {
 				return nil, p.syntaxErrorAtCur()
 			}
+			// Out-of-line view constraint: CONSTRAINT name { PRIMARY KEY |
+			// UNIQUE | FOREIGN KEY } (cols) constraint_state. View constraints
+			// are declarative only (RELY DISABLE NOVALIDATE); the parsed
+			// constraint is validated but not yet preserved in the AST.
+			if p.isTableConstraintStart() {
+				viewConstraint, err := p.parseTableConstraint()
+				if err != nil {
+					return nil, err
+				}
+				_ = viewConstraint
+				if p.cur.Type != ',' {
+					break
+				}
+				p.advance()
+				continue
+			}
 			name, err := p.parseIdentifier()
 			if err != nil {
 				return nil, err
@@ -401,6 +417,32 @@ func (p *Parser) parseMaterializedViewOptions(stmt *nodes.CreateViewStmt) error 
 					p.advance()
 				}
 			}
+
+		case p.cur.Type == kwUSING && p.peekNext().Type == kwINDEX:
+			// USING INDEX index_properties (default index storage for the mview)
+			var cs constraintState
+			if err := p.parseUsingIndexClause(&cs); err != nil {
+				return err
+			}
+
+		case p.cur.Type == kwUSING && p.isIdentLikeStrAt(p.peekNext(), "NO"):
+			// USING NO INDEX
+			p.advance() // consume USING
+			p.advance() // consume NO
+			if p.cur.Type != kwINDEX {
+				return p.syntaxErrorAtCur()
+			}
+			p.advance() // consume INDEX
+
+		case p.cur.Type == kwUSING &&
+			(p.isIdentLikeStrAt(p.peekNext(), "TRUSTED") || p.isIdentLikeStrAt(p.peekNext(), "ENFORCED")):
+			// USING { TRUSTED | ENFORCED } CONSTRAINTS
+			p.advance() // consume USING
+			p.advance() // consume TRUSTED/ENFORCED
+			if p.cur.Type != kwCONSTRAINTS {
+				return p.syntaxErrorAtCur()
+			}
+			p.advance() // consume CONSTRAINTS
 
 		case p.cur.Type == kwENABLE:
 			p.advance()

--- a/oracle/parser/create_view.go
+++ b/oracle/parser/create_view.go
@@ -146,7 +146,11 @@ func (p *Parser) finishCreateViewStmt(stmt *nodes.CreateViewStmt) (*nodes.Create
 			// UNIQUE | FOREIGN KEY } (cols) [RELY|NORELY] DISABLE [NOVALIDATE].
 			// View constraints are declarative only; the table-only state
 			// clauses are rejected — see parseViewConstraintState.
-			if p.isTableConstraintStart() {
+			// Unlike a CREATE TABLE column list, a view alias list has no
+			// datatype ambiguity: CONSTRAINT always starts a constraint here
+			// (a constraint name may be a nonreserved datatype word like BLOB,
+			// while a bare alias named CONSTRAINT is rejected by Oracle).
+			if p.cur.Type == kwCONSTRAINT || p.isTableConstraintStart() {
 				viewConstraint, err := p.parseTableConstraintBody()
 				if err != nil {
 					return nil, err

--- a/oracle/parser/create_view.go
+++ b/oracle/parser/create_view.go
@@ -143,13 +143,18 @@ func (p *Parser) finishCreateViewStmt(stmt *nodes.CreateViewStmt) (*nodes.Create
 				return nil, p.syntaxErrorAtCur()
 			}
 			// Out-of-line view constraint: CONSTRAINT name { PRIMARY KEY |
-			// UNIQUE | FOREIGN KEY } (cols) constraint_state. View constraints
-			// are declarative only (RELY DISABLE NOVALIDATE).
+			// UNIQUE | FOREIGN KEY } (cols) [RELY|NORELY] DISABLE [NOVALIDATE].
+			// View constraints are declarative only; the table-only state
+			// clauses are rejected — see parseViewConstraintState.
 			if p.isTableConstraintStart() {
-				viewConstraint, err := p.parseTableConstraint()
+				viewConstraint, err := p.parseTableConstraintBody()
 				if err != nil {
 					return nil, err
 				}
+				if err := p.parseViewConstraintState(); err != nil {
+					return nil, err
+				}
+				viewConstraint.Loc.End = p.prev.End
 				if stmt.Constraints == nil {
 					stmt.Constraints = &nodes.List{}
 				}

--- a/oracle/parser/create_view_test.go
+++ b/oracle/parser/create_view_test.go
@@ -272,3 +272,12 @@ func TestParseCreateViewConstraintDatatypeName(t *testing.T) {
 		t.Errorf("expected constraint name BLOB, got %q", tc.Name)
 	}
 }
+
+// TestParseCreateMaterializedViewUsingIndexPropertiesOnly tests that mview
+// USING INDEX accepts only index properties — Oracle rejects an index name
+// or a nested CREATE INDEX there (ORA-02000, verified on 23ai).
+func TestParseCreateMaterializedViewUsingIndexPropertiesOnly(t *testing.T) {
+	ParseShouldFail(t, `CREATE MATERIALIZED VIEW mv USING INDEX existing_idx AS SELECT * FROM t`)
+	ParseShouldFail(t, `CREATE MATERIALIZED VIEW mv USING INDEX (CREATE INDEX cidx ON mv (id)) AS SELECT * FROM t`)
+	ParseAndCheck(t, `CREATE MATERIALIZED VIEW mv USING INDEX INITRANS 2 STORAGE (NEXT 1M) AS SELECT * FROM t`)
+}

--- a/oracle/parser/create_view_test.go
+++ b/oracle/parser/create_view_test.go
@@ -181,6 +181,16 @@ func TestParseCreateViewOutOfLineConstraint(t *testing.T) {
 			if cv.Columns == nil || cv.Columns.Len() == 0 {
 				t.Error("expected view columns to be preserved")
 			}
+			if cv.Constraints == nil || cv.Constraints.Len() != 1 {
+				t.Fatal("expected 1 view constraint in AST")
+			}
+			tc := cv.Constraints.Items[0].(*ast.TableConstraint)
+			if tc.Name == "" {
+				t.Error("expected view constraint name to be preserved")
+			}
+			if tc.Columns == nil || tc.Columns.Len() == 0 {
+				t.Error("expected view constraint columns to be preserved")
+			}
 		})
 	}
 }

--- a/oracle/parser/create_view_test.go
+++ b/oracle/parser/create_view_test.go
@@ -231,3 +231,27 @@ func TestParseCreateViewConstraintStateRestrictions(t *testing.T) {
 	ParseShouldFail(t, `ALTER VIEW v ADD CONSTRAINT uq UNIQUE (b) ENABLE`)
 	ParseAndCheck(t, `ALTER VIEW v ADD CONSTRAINT uq UNIQUE (b) RELY DISABLE NOVALIDATE`)
 }
+
+// TestParseCreateMaterializedViewTrustedRequiresRefresh tests that USING
+// TRUSTED/ENFORCED CONSTRAINTS is only accepted after a REFRESH clause,
+// matching Oracle 23ai (ORA-00906 for the standalone form).
+func TestParseCreateMaterializedViewTrustedRequiresRefresh(t *testing.T) {
+	ParseAndCheck(t, `CREATE MATERIALIZED VIEW mv REFRESH FORCE USING TRUSTED CONSTRAINTS AS SELECT * FROM t`)
+	ParseShouldFail(t, `CREATE MATERIALIZED VIEW mv USING TRUSTED CONSTRAINTS AS SELECT * FROM t`)
+	ParseShouldFail(t, `CREATE MATERIALIZED VIEW mv USING ENFORCED CONSTRAINTS AS SELECT * FROM t`)
+}
+
+// TestParseCreateViewAliasAfterConstraint locks in engine-verified behavior:
+// Oracle 23ai accepts column aliases after an out-of-line view constraint,
+// contrary to the documented BNF ordering.
+func TestParseCreateViewAliasAfterConstraint(t *testing.T) {
+	result := ParseAndCheck(t, `CREATE VIEW v (a, PRIMARY KEY (a) DISABLE, b) AS SELECT 1, 2 FROM dual`)
+	raw := result.Items[0].(*ast.RawStmt)
+	cv := raw.Stmt.(*ast.CreateViewStmt)
+	if cv.Columns == nil || cv.Columns.Len() != 2 {
+		t.Fatalf("expected 2 column aliases, got %v", cv.Columns)
+	}
+	if cv.Constraints == nil || cv.Constraints.Len() != 1 {
+		t.Fatal("expected 1 view constraint")
+	}
+}

--- a/oracle/parser/create_view_test.go
+++ b/oracle/parser/create_view_test.go
@@ -161,3 +161,46 @@ func TestParseCreateViewLoc(t *testing.T) {
 		t.Errorf("expected Loc.End > Loc.Start, got %d", stmt.Loc.End)
 	}
 }
+
+// TestParseCreateViewOutOfLineConstraint tests declarative view constraints
+// (always RELY DISABLE NOVALIDATE in practice).
+func TestParseCreateViewOutOfLineConstraint(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{"pk_rely", `CREATE VIEW v (a, b, CONSTRAINT pk_v PRIMARY KEY (a) RELY DISABLE NOVALIDATE) AS SELECT 1, 2 FROM dual`},
+		{"uq_rely", `CREATE VIEW v (a, CONSTRAINT uq_v UNIQUE (a) RELY DISABLE NOVALIDATE) AS SELECT 1 FROM dual`},
+		{"fk_rely", `CREATE VIEW v (a, CONSTRAINT fk_v FOREIGN KEY (a) REFERENCES t (id) RELY DISABLE NOVALIDATE) AS SELECT 1 FROM dual`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseAndCheck(t, tt.sql)
+			raw := result.Items[0].(*ast.RawStmt)
+			cv := raw.Stmt.(*ast.CreateViewStmt)
+			if cv.Columns == nil || cv.Columns.Len() == 0 {
+				t.Error("expected view columns to be preserved")
+			}
+		})
+	}
+}
+
+// TestParseCreateMaterializedViewUsingIndex tests the mview USING INDEX /
+// USING NO INDEX / USING ... CONSTRAINTS clauses.
+func TestParseCreateMaterializedViewUsingIndex(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{"using_index_tablespace", `CREATE MATERIALIZED VIEW mv USING INDEX TABLESPACE ts1 AS SELECT * FROM t`},
+		{"using_index_attrs", `CREATE MATERIALIZED VIEW mv USING INDEX PCTFREE 10 INITRANS 2 MAXTRANS 255 AS SELECT * FROM t`},
+		{"using_no_index", `CREATE MATERIALIZED VIEW mv USING NO INDEX AS SELECT * FROM t`},
+		{"refresh_then_using_index", `CREATE MATERIALIZED VIEW mv REFRESH FAST WITH PRIMARY KEY USING INDEX AS SELECT * FROM t`},
+		{"using_trusted_constraints", `CREATE MATERIALIZED VIEW mv REFRESH FORCE USING TRUSTED CONSTRAINTS AS SELECT * FROM t`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ParseAndCheck(t, tt.sql)
+		})
+	}
+}

--- a/oracle/parser/create_view_test.go
+++ b/oracle/parser/create_view_test.go
@@ -281,3 +281,20 @@ func TestParseCreateMaterializedViewUsingIndexPropertiesOnly(t *testing.T) {
 	ParseShouldFail(t, `CREATE MATERIALIZED VIEW mv USING INDEX (CREATE INDEX cidx ON mv (id)) AS SELECT * FROM t`)
 	ParseAndCheck(t, `CREATE MATERIALIZED VIEW mv USING INDEX INITRANS 2 STORAGE (NEXT 1M) AS SELECT * FROM t`)
 }
+
+// TestParseCreateViewBareConstraintKeywordAliases locks in engine-verified
+// behavior: PRIMARY and FOREIGN are legal bare view aliases on Oracle 23ai;
+// they start a constraint only when followed by KEY.
+func TestParseCreateViewBareConstraintKeywordAliases(t *testing.T) {
+	result := ParseAndCheck(t, `CREATE VIEW v (primary) AS SELECT 1 FROM dual`)
+	raw := result.Items[0].(*ast.RawStmt)
+	cv := raw.Stmt.(*ast.CreateViewStmt)
+	if cv.Columns == nil || cv.Columns.Len() != 1 {
+		t.Fatalf("expected 1 alias, got %v", cv.Columns)
+	}
+	if got := cv.Columns.Items[0].(*ast.String).Str; got != "PRIMARY" {
+		t.Errorf("expected alias PRIMARY, got %q", got)
+	}
+	ParseAndCheck(t, `CREATE VIEW v (foreign) AS SELECT 1 FROM dual`)
+	ParseAndCheck(t, `CREATE VIEW v (a, PRIMARY KEY (a) DISABLE) AS SELECT 1 FROM dual`)
+}

--- a/oracle/parser/create_view_test.go
+++ b/oracle/parser/create_view_test.go
@@ -214,3 +214,20 @@ func TestParseCreateMaterializedViewUsingIndex(t *testing.T) {
 		})
 	}
 }
+
+// TestParseCreateViewConstraintStateRestrictions tests that view constraints
+// accept only [RELY|NORELY] DISABLE [NOVALIDATE] — verified against Oracle
+// 23ai (DISABLE mandatory per ORA-02000, VALIDATE rejected per ORA-03082,
+// table-only clauses rejected).
+func TestParseCreateViewConstraintStateRestrictions(t *testing.T) {
+	ParseAndCheck(t, `CREATE VIEW v (a, CONSTRAINT pk PRIMARY KEY (a) DISABLE) AS SELECT 1 FROM dual`)
+	ParseAndCheck(t, `CREATE VIEW v (a, CONSTRAINT pk PRIMARY KEY (a) NORELY DISABLE NOVALIDATE) AS SELECT 1 FROM dual`)
+	ParseShouldFail(t, `CREATE VIEW v (a, CONSTRAINT pk PRIMARY KEY (a)) AS SELECT 1 FROM dual`)
+	ParseShouldFail(t, `CREATE VIEW v (a, CONSTRAINT pk PRIMARY KEY (a) RELY) AS SELECT 1 FROM dual`)
+	ParseShouldFail(t, `CREATE VIEW v (a, CONSTRAINT pk PRIMARY KEY (a) DEFERRABLE INITIALLY DEFERRED) AS SELECT 1 FROM dual`)
+	ParseShouldFail(t, `CREATE VIEW v (a, CONSTRAINT pk PRIMARY KEY (a) USING INDEX RELY DISABLE NOVALIDATE) AS SELECT 1 FROM dual`)
+	ParseShouldFail(t, `CREATE VIEW v (a, CONSTRAINT pk PRIMARY KEY (a) ENABLE NOVALIDATE) AS SELECT 1 FROM dual`)
+	ParseShouldFail(t, `CREATE VIEW v (a, CONSTRAINT pk PRIMARY KEY (a) DISABLE VALIDATE) AS SELECT 1 FROM dual`)
+	ParseShouldFail(t, `ALTER VIEW v ADD CONSTRAINT uq UNIQUE (b) ENABLE`)
+	ParseAndCheck(t, `ALTER VIEW v ADD CONSTRAINT uq UNIQUE (b) RELY DISABLE NOVALIDATE`)
+}

--- a/oracle/parser/create_view_test.go
+++ b/oracle/parser/create_view_test.go
@@ -255,3 +255,20 @@ func TestParseCreateViewAliasAfterConstraint(t *testing.T) {
 		t.Fatal("expected 1 view constraint")
 	}
 }
+
+// TestParseCreateViewConstraintDatatypeName tests that a view constraint
+// whose name is a nonreserved datatype word parses (Oracle 23ai accepts
+// CONSTRAINT blob PRIMARY KEY ... on views; a bare alias named CONSTRAINT
+// is rejected by Oracle with ORA-02250).
+func TestParseCreateViewConstraintDatatypeName(t *testing.T) {
+	result := ParseAndCheck(t, `CREATE VIEW v (a, CONSTRAINT blob PRIMARY KEY (a) DISABLE) AS SELECT 1 FROM dual`)
+	raw := result.Items[0].(*ast.RawStmt)
+	cv := raw.Stmt.(*ast.CreateViewStmt)
+	if cv.Constraints == nil || cv.Constraints.Len() != 1 {
+		t.Fatal("expected 1 view constraint")
+	}
+	tc := cv.Constraints.Items[0].(*ast.TableConstraint)
+	if tc.Name != "BLOB" {
+		t.Errorf("expected constraint name BLOB, got %q", tc.Name)
+	}
+}


### PR DESCRIPTION
Fixes the customer-blocking parser gap from [BYT-10010](https://linear.app/bytebase/issue/BYT-10010/sql-review-rejects-valid-oracle-using-index-local-table-constraint): SQL Review rejected valid Oracle DDL such as `PRIMARY KEY (...) USING INDEX LOCAL`, blocking MBBank's partitioned-table changes since 3.19.0 (when the ANTLR fallback was removed).

## What was broken

The Oracle parser implemented only `DEFERRABLE` / `INITIALLY` out of Oracle's `constraint_state` grammar. Everything else failed with a syntax error:

- every `USING INDEX` form (`LOCAL`, bare, `TABLESPACE`, index name, `(CREATE INDEX ...)`)
- `ENABLE` / `DISABLE`, `VALIDATE` / `NOVALIDATE`, `RELY` / `NORELY`
- column-level equivalents, including `NOT NULL ENABLE` — the default shape of `DBMS_METADATA.GET_DDL` output
- the same clauses on `ALTER TABLE ADD/MODIFY CONSTRAINT`

## What this PR does

**Commit 1 — shared constraint_state implementation.** One `parseConstraintState` plus a `parseUsingIndexClause` whose whitelist-driven property parser terminates safely inside a CREATE TABLE column list (deliberately not shared with `parseCreateIndexAttributes`, whose collector runs to the statement terminator). Wired into table-level, column-level, and `NOT NULL`/`NULL` paths; collapses the three ad-hoc ALTER TABLE implementations (`skipConstraintState` is deleted). Also fixes adjacent gaps found while auditing the same family: `COMPUTE STATISTICS` in `USING INDEX` (DBMS_METADATA output), table-level `MAXTRANS`, IOT `PCTTHRESHOLD`, out-of-line view constraints, and `CREATE/ALTER MATERIALIZED VIEW USING INDEX` / `USING NO INDEX` / `USING TRUSTED|ENFORCED CONSTRAINTS`.

**Commit 2 — view constraints in the AST.** `CreateViewStmt.Constraints` (list of `*TableConstraint`), walker regenerated.

**Commit 3 — slot order, verified against a real engine.** Cross-validated against Oracle 23ai (gvenzl/oracle-free testcontainer, real DDL execution). Oracle is not order-free: out-of-order subclauses raise ORA-03075, so `parseConstraintState` enforces the documented slot sequence (`DEFERRABLE`/`INITIALLY` interchangeable within their group, then `RELY|NORELY`, `using_index_clause`, `ENABLE|DISABLE`, `VALIDATE|NOVALIDATE`). `EXCEPTIONS INTO` moved to a separate helper used only by ALTER contexts — Oracle rejects it inside CREATE TABLE constraints (ORA-00922).

## AST changes

- `TableConstraint`: new `UsingIndexLocal`; the previously-dead `Tablespace` field is now populated
- `ColumnConstraint`: new `Tablespace`, `UsingIndexLocal`
- `CreateViewStmt`: new `Constraints`

## Verification

- 27 repro cases from the issue investigation pass, including MBBank's full statement
- BYT-9909's customer corpus replayed clean (every complete statement parses; the only failures are Excel's 32766-char cell truncation artifacts)
- **Real-engine comparison: 33/34 statements agree with Oracle 23ai** (accept ⇔ accept, reject ⇔ reject). The one deliberate leniency is `ALTER MATERIALIZED VIEW USING INDEX PCTFREE`, which 23ai rejects (ORA-02243) while accepting `INITRANS`/`STORAGE`; noted in a comment
- Full `./oracle/...` suite passes, including the parser contract gates

## Landing

After merge: `go get -u github.com/bytebase/omni` in bytebase, run `parser/plsql` / `advisor/oracle` / `schema/oracle`, cherry-pick to 3.21.x for MBBank. Wiring local-index semantics into `IndexMetadata` is deferred to a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)