### PR TITLE
doris/starrocks: close 10 expression-level parser gaps (BYT-10070)

### DIFF
--- a/doris/analysis/query_span.go
+++ b/doris/analysis/query_span.go
@@ -430,11 +430,36 @@ func renderColumnName(expr ast.Node) string {
 
 // collectColumnRefs returns every ColumnRef directly mentioned in expr.
 func collectColumnRefs(expr ast.Node) []ColumnRef {
+	return collectColumnRefsScoped(expr, nil)
+}
+
+// collectColumnRefsScoped collects direct column references, skipping any name
+// bound by an enclosing lambda. In array_map(x -> x + bonus, scores) the
+// parameter x is local to the lambda and is not a column of any table, so
+// reporting it would feed a nonexistent column into lineage and masking.
+func collectColumnRefsScoped(expr ast.Node, bound map[string]bool) []ColumnRef {
 	var refs []ColumnRef
 	ast.Inspect(expr, func(n ast.Node) bool {
 		switch node := n.(type) {
+		case *ast.LambdaExpr:
+			// Inspect has no post-order hook to pop a scope with, so recurse
+			// into the body with the widened binding set instead.
+			inner := make(map[string]bool, len(bound)+len(node.Params))
+			for name := range bound {
+				inner[name] = true
+			}
+			for _, param := range node.Params {
+				inner[strings.ToLower(param)] = true
+			}
+			refs = append(refs, collectColumnRefsScoped(node.Body, inner)...)
+			return false
 		case *ast.ColumnRef:
 			if node.Name == nil || len(node.Name.Parts) == 0 {
+				return false
+			}
+			// Only an unqualified name can be a lambda parameter; `t.x` is a
+			// column even when a parameter happens to be called x.
+			if len(node.Name.Parts) == 1 && bound[strings.ToLower(node.Name.Parts[0])] {
 				return false
 			}
 			refs = append(refs, columnRefFromObjectName(node.Name))

--- a/doris/analysis/query_span_test.go
+++ b/doris/analysis/query_span_test.go
@@ -365,23 +365,57 @@ func TestGetQuerySpan_ExtractSourceColumns(t *testing.T) {
 	}
 }
 
-func TestGetQuerySpan_LambdaAndArraySourceColumns(t *testing.T) {
-	// Columns referenced inside a lambda body and inside an array literal must
-	// still reach lineage — the walker has to descend into both node types.
-	span, err := GetQuerySpan("SELECT array_map(x -> x + bonus, scores) AS adj FROM t")
-	if err != nil {
-		t.Fatalf("GetQuerySpan returned error: %v", err)
+func TestGetQuerySpan_LambdaSourceColumns(t *testing.T) {
+	// Columns referenced inside a lambda body must reach lineage, but the
+	// lambda's own parameters must not: they are local bindings, not columns,
+	// and reporting one would feed a nonexistent column to masking.
+	tests := []struct {
+		name    string
+		sql     string
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "single parameter",
+			sql:     "SELECT array_map(x -> x + bonus, scores) AS adj FROM t",
+			want:    []string{"bonus", "scores"},
+			notWant: []string{"x"},
+		},
+		{
+			name:    "multiple parameters",
+			sql:     "SELECT array_map((x, y) -> x + y + bonus, a, b) AS adj FROM t",
+			want:    []string{"bonus", "a", "b"},
+			notWant: []string{"x", "y"},
+		},
+		{
+			name: "qualified name is a column even when it shadows a parameter",
+			sql:  "SELECT array_map(x -> t.x + bonus, scores) AS adj FROM t",
+			want: []string{"x", "bonus", "scores"},
+		},
 	}
-	if len(span.Results) != 1 {
-		t.Fatalf("Results len = %d, want 1 (%+v)", len(span.Results), span.Results)
-	}
-	got := map[string]bool{}
-	for _, sc := range span.Results[0].SourceColumns {
-		got[sc.Column] = true
-	}
-	for _, want := range []string{"bonus", "scores"} {
-		if !got[want] {
-			t.Errorf("SourceColumns %+v missing %q", span.Results[0].SourceColumns, want)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			span, err := GetQuerySpan(tt.sql)
+			if err != nil {
+				t.Fatalf("GetQuerySpan returned error: %v", err)
+			}
+			if len(span.Results) != 1 {
+				t.Fatalf("Results len = %d, want 1 (%+v)", len(span.Results), span.Results)
+			}
+			got := map[string]bool{}
+			for _, sc := range span.Results[0].SourceColumns {
+				got[sc.Column] = true
+			}
+			for _, want := range tt.want {
+				if !got[want] {
+					t.Errorf("SourceColumns %+v missing %q", span.Results[0].SourceColumns, want)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if got[notWant] {
+					t.Errorf("SourceColumns %+v contains lambda parameter %q", span.Results[0].SourceColumns, notWant)
+				}
+			}
+		})
 	}
 }

--- a/doris/analysis/query_span_test.go
+++ b/doris/analysis/query_span_test.go
@@ -339,3 +339,49 @@ func TestGetQuerySpan_CTEShadowsTable(t *testing.T) {
 		t.Errorf("AccessTables = %+v, want [underlying]", sigs)
 	}
 }
+
+func TestGetQuerySpan_ExtractSourceColumns(t *testing.T) {
+	// EXTRACT(unit FROM col) must expose col as a source column so masking and
+	// lineage see through the expression.
+	span, err := GetQuerySpan("SELECT EXTRACT(YEAR FROM created_at) AS y FROM t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.Results) != 1 {
+		t.Fatalf("Results len = %d, want 1 (%+v)", len(span.Results), span.Results)
+	}
+	r := span.Results[0]
+	if r.Name != "y" {
+		t.Errorf("Results[0].Name = %q, want y", r.Name)
+	}
+	want := []ColumnRef{{Column: "created_at"}}
+	if len(r.SourceColumns) != len(want) {
+		t.Fatalf("SourceColumns = %+v, want %+v", r.SourceColumns, want)
+	}
+	for i, w := range want {
+		if r.SourceColumns[i] != w {
+			t.Errorf("SourceColumns[%d] = %+v, want %+v", i, r.SourceColumns[i], w)
+		}
+	}
+}
+
+func TestGetQuerySpan_LambdaAndArraySourceColumns(t *testing.T) {
+	// Columns referenced inside a lambda body and inside an array literal must
+	// still reach lineage — the walker has to descend into both node types.
+	span, err := GetQuerySpan("SELECT array_map(x -> x + bonus, scores) AS adj FROM t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.Results) != 1 {
+		t.Fatalf("Results len = %d, want 1 (%+v)", len(span.Results), span.Results)
+	}
+	got := map[string]bool{}
+	for _, sc := range span.Results[0].SourceColumns {
+		got[sc.Column] = true
+	}
+	for _, want := range []string{"bonus", "scores"} {
+		if !got[want] {
+			t.Errorf("SourceColumns %+v missing %q", span.Results[0].SourceColumns, want)
+		}
+	}
+}

--- a/doris/ast/exprnodes.go
+++ b/doris/ast/exprnodes.go
@@ -98,6 +98,7 @@ const (
 	UnaryPlus                   // +
 	UnaryBitNot                 // ~
 	UnaryNot                    // NOT
+	UnaryBinary                 // BINARY
 )
 
 // String returns the SQL text form of the unary operator.
@@ -126,6 +127,8 @@ const (
 	LitBool                   // TRUE or FALSE
 	LitNull                   // NULL
 	LitKeyword                // keyword used as literal value, e.g. DEFAULT
+	LitHex                    // hex literal, X'1f'
+	LitBit                    // bit literal, B'101'
 )
 
 // CaseKind classifies a CASE expression as simple or searched.
@@ -233,6 +236,7 @@ type FuncCallExpr struct {
 	Star     bool   // COUNT(*)
 	OrderBy  []*OrderByItem // optional ORDER BY in aggregate (GROUP_CONCAT)
 	Separator string // optional SEPARATOR value for GROUP_CONCAT
+	Using     string // optional USING charset, as in CONVERT(x USING utf8)
 	Over     *WindowSpec // optional OVER (...) window specification
 	Loc      Loc
 }
@@ -283,6 +287,79 @@ type CastExpr struct {
 func (n *CastExpr) Tag() NodeTag { return T_CastExpr }
 
 var _ Node = (*CastExpr)(nil)
+
+// ExtractExpr represents EXTRACT(unit FROM expr).
+//
+// The grammar takes the unit as an identifier
+// (EXTRACT '(' field=identifier FROM source=valueExpression ')'), so Unit holds
+// the upper-cased source text rather than a closed enum.
+type ExtractExpr struct {
+	Expr Node
+	Unit string // e.g., "YEAR", "MONTH", "DAY_HOUR"
+	Loc  Loc
+}
+
+func (n *ExtractExpr) Tag() NodeTag { return T_ExtractExpr }
+
+var _ Node = (*ExtractExpr)(nil)
+
+// VariableRef represents a system variable (@@name, @@session.name,
+// @@global.name) or a user-defined variable (@name). It is deliberately not a
+// ColumnRef so that lineage and masking do not mistake it for a column.
+type VariableRef struct {
+	Name   string // variable name, without the @/@@ prefix and scope qualifier
+	Scope  string // "SESSION" or "GLOBAL"; empty when unqualified
+	System bool   // true for @@ (system) variables, false for @ (user) variables
+	Loc    Loc
+}
+
+func (n *VariableRef) Tag() NodeTag { return T_VariableRef }
+
+var _ Node = (*VariableRef)(nil)
+
+// LambdaExpr represents a lambda passed to a higher-order array function:
+// `x -> x + 1` or `(x, y) -> x + y`.
+type LambdaExpr struct {
+	Params []string
+	Body   Node
+	Loc    Loc
+}
+
+func (n *LambdaExpr) Tag() NodeTag { return T_LambdaExpr }
+
+var _ Node = (*LambdaExpr)(nil)
+
+// ArrayLiteral represents an array constructor: [e, ...].
+type ArrayLiteral struct {
+	ElemType *TypeName // array<t> element type for the typed form; nil for [...]
+	Elements []Node
+	Loc      Loc
+}
+
+func (n *ArrayLiteral) Tag() NodeTag { return T_ArrayLiteral }
+
+var _ Node = (*ArrayLiteral)(nil)
+
+// MapLiteral represents a map constructor: {k: v, ...}.
+type MapLiteral struct {
+	Entries []*MapEntry
+	Loc     Loc
+}
+
+func (n *MapLiteral) Tag() NodeTag { return T_MapLiteral }
+
+var _ Node = (*MapLiteral)(nil)
+
+// MapEntry is one key:value pair inside a MapLiteral.
+type MapEntry struct {
+	Key   Node
+	Value Node
+	Loc   Loc
+}
+
+func (n *MapEntry) Tag() NodeTag { return T_MapEntry }
+
+var _ Node = (*MapEntry)(nil)
 
 // CaseExpr represents CASE [operand] WHEN...THEN...ELSE...END.
 type CaseExpr struct {

--- a/doris/ast/exprnodes.go
+++ b/doris/ast/exprnodes.go
@@ -112,6 +112,8 @@ func (op UnaryOp) String() string {
 		return "~"
 	case UnaryNot:
 		return "NOT"
+	case UnaryBinary:
+		return "BINARY"
 	default:
 		return "?"
 	}

--- a/doris/ast/loc.go
+++ b/doris/ast/loc.go
@@ -54,6 +54,18 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *CastExpr:
 		return v.Loc
+	case *ExtractExpr:
+		return v.Loc
+	case *VariableRef:
+		return v.Loc
+	case *LambdaExpr:
+		return v.Loc
+	case *ArrayLiteral:
+		return v.Loc
+	case *MapLiteral:
+		return v.Loc
+	case *MapEntry:
+		return v.Loc
 	case *CaseExpr:
 		return v.Loc
 	case *WhenClause:

--- a/doris/ast/nodetags.go
+++ b/doris/ast/nodetags.go
@@ -86,6 +86,24 @@ const (
 	// T_CastExpr is the tag for *CastExpr (CAST/TRY_CAST).
 	T_CastExpr
 
+	// T_ExtractExpr is the tag for *ExtractExpr (EXTRACT(unit FROM expr)).
+	T_ExtractExpr
+
+	// T_VariableRef is the tag for *VariableRef (@@var / @var).
+	T_VariableRef
+
+	// T_LambdaExpr is the tag for *LambdaExpr (x -> body).
+	T_LambdaExpr
+
+	// T_ArrayLiteral is the tag for *ArrayLiteral ([e, ...]).
+	T_ArrayLiteral
+
+	// T_MapLiteral is the tag for *MapLiteral ({k: v, ...}).
+	T_MapLiteral
+
+	// T_MapEntry is the tag for *MapEntry (one k: v pair).
+	T_MapEntry
+
 	// T_CaseExpr is the tag for *CaseExpr (CASE...END).
 	T_CaseExpr
 
@@ -650,6 +668,18 @@ func (t NodeTag) String() string {
 		return "FuncCallExpr"
 	case T_CastExpr:
 		return "CastExpr"
+	case T_ExtractExpr:
+		return "ExtractExpr"
+	case T_VariableRef:
+		return "VariableRef"
+	case T_LambdaExpr:
+		return "LambdaExpr"
+	case T_ArrayLiteral:
+		return "ArrayLiteral"
+	case T_MapLiteral:
+		return "MapLiteral"
+	case T_MapEntry:
+		return "MapEntry"
 	case T_CaseExpr:
 		return "CaseExpr"
 	case T_WhenClause:

--- a/doris/ast/walk_children.go
+++ b/doris/ast/walk_children.go
@@ -103,6 +103,26 @@ func walkChildren(v Visitor, node Node) {
 	case *CastExpr:
 		Walk(v, n.Expr)
 		Walk(v, n.TypeName)
+	case *ExtractExpr:
+		Walk(v, n.Expr)
+	case *VariableRef:
+		// leaf
+	case *LambdaExpr:
+		Walk(v, n.Body)
+	case *ArrayLiteral:
+		if n.ElemType != nil {
+			Walk(v, n.ElemType)
+		}
+		for _, e := range n.Elements {
+			Walk(v, e)
+		}
+	case *MapLiteral:
+		for _, e := range n.Entries {
+			Walk(v, e)
+		}
+	case *MapEntry:
+		Walk(v, n.Key)
+		Walk(v, n.Value)
 	case *CaseExpr:
 		if n.Operand != nil {
 			Walk(v, n.Operand)

--- a/doris/parser/doris_container_test.go
+++ b/doris/parser/doris_container_test.go
@@ -1,0 +1,297 @@
+package parser
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	gomysql "github.com/go-sql-driver/mysql"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// dorisContainer wraps an Apache Doris standalone container used as a parse
+// oracle. Doris speaks the MySQL wire protocol on port 9030 (not 3306), so we
+// connect with go-sql-driver/mysql via a raw GenericContainer (there is no
+// testcontainers Doris module).
+//
+// dyrnq/doris publishes native arm64 and amd64 images, so unlike the StarRocks
+// harness no platform override is needed.
+type dorisContainer struct {
+	db  *sql.DB
+	ctx context.Context
+}
+
+var (
+	dorisOnce    sync.Once
+	dorisInst    *dorisContainer
+	dorisInitErr error
+)
+
+// startDoris starts (once) the Doris container and returns a ready
+// dorisContainer. Skipped in -short mode — omni CI runs `go test -short ./...`,
+// so container tests must be Short-gated (mirrors starrocks_container_test.go).
+func startDoris(t *testing.T) *dorisContainer {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping Doris container test in short mode")
+	}
+
+	dorisOnce.Do(func() {
+		ctx := context.Background()
+		req := testcontainers.ContainerRequest{
+			Image:        "dyrnq/doris:3.1.4",
+			ExposedPorts: []string{"9030/tcp"},
+			Env: map[string]string{
+				"RUN_MODE": "STANDALONE",
+				// bin/start_be.sh refuses to boot unless vm.max_map_count >=
+				// 2000000 and swap is off. Neither is settable from inside a
+				// container (vm.max_map_count is not namespaced), so use the
+				// script's own escape hatch rather than patching it.
+				"SKIP_CHECK_ULIMIT": "true",
+			},
+			WaitingFor: wait.ForListeningPort("9030/tcp").WithStartupTimeout(5 * time.Minute),
+		}
+		container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+			ContainerRequest: req,
+			Started:          true,
+		})
+		if err != nil {
+			dorisInitErr = fmt.Errorf("start Doris container: %w", err)
+			return
+		}
+		host, err := container.Host(ctx)
+		if err != nil {
+			_ = testcontainers.TerminateContainer(container)
+			dorisInitErr = err
+			return
+		}
+		port, err := container.MappedPort(ctx, "9030")
+		if err != nil {
+			_ = testcontainers.TerminateContainer(container)
+			dorisInitErr = err
+			return
+		}
+		dsn := func(db string) string {
+			return fmt.Sprintf("root@tcp(%s:%s)/%s?multiStatements=true&timeout=10s", host, port.Port(), db)
+		}
+		db, err := sql.Open("mysql", dsn(""))
+		if err != nil {
+			_ = testcontainers.TerminateContainer(container)
+			dorisInitErr = err
+			return
+		}
+
+		// Active readiness: the FE accepts connections before the BE has
+		// registered. Poll until SELECT 1 succeeds.
+		deadline := time.Now().Add(5 * time.Minute)
+		for {
+			ok := func() bool {
+				cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				defer cancel()
+				var one int
+				return db.QueryRowContext(cctx, "SELECT 1").Scan(&one) == nil && one == 1
+			}()
+			if ok {
+				break
+			}
+			if time.Now().After(deadline) {
+				_ = db.Close()
+				_ = testcontainers.TerminateContainer(container)
+				dorisInitErr = fmt.Errorf("readiness: SELECT 1 never succeeded")
+				return
+			}
+			time.Sleep(3 * time.Second)
+		}
+
+		// Doris reports "Current database is not set" before it even reaches
+		// analysis, which would mask whether a probe parsed. Select a database.
+		if _, err := db.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS doristest"); err != nil {
+			_ = db.Close()
+			_ = testcontainers.TerminateContainer(container)
+			dorisInitErr = fmt.Errorf("create doristest db: %w", err)
+			return
+		}
+		_ = db.Close()
+		db, err = sql.Open("mysql", dsn("doristest"))
+		if err != nil {
+			_ = testcontainers.TerminateContainer(container)
+			dorisInitErr = err
+			return
+		}
+		// Container intentionally leaked for singleton reuse; process exit reaps it.
+		dorisInst = &dorisContainer{db: db, ctx: ctx}
+	})
+
+	if dorisInitErr != nil {
+		t.Fatalf("Doris container: %v", dorisInitErr)
+	}
+	return dorisInst
+}
+
+// dorisSyntaxErrMarkers are the message fragments Doris's Nereids parser emits
+// for a genuine PARSE failure. CRITICAL: Doris codes parse AND semantic errors
+// alike as MySQL 1105 / "errCode = 2", so the code alone does not mean
+// rejected — only these ANTLR-generated fragments do.
+var dorisSyntaxErrMarkers = []string{
+	"mismatched input",
+	"extraneous input",
+	"no viable alternative",
+	"Syntax error",
+}
+
+// accepts reports whether Doris accepted sql at the PARSE layer: executed OK,
+// or failed with any non-syntax error (semantic/runtime) — both imply it
+// parsed. A non-driver error (connection drop/timeout) is NOT a parse verdict —
+// it is returned so the caller fails the test rather than silently passing an
+// accept it never proved.
+func (c *dorisContainer) accepts(sql string) (bool, error) {
+	ctx, cancel := context.WithTimeout(c.ctx, 15*time.Second)
+	defer cancel()
+	_, err := c.db.ExecContext(ctx, sql)
+	if err == nil {
+		return true, nil
+	}
+	myErr, ok := err.(*gomysql.MySQLError)
+	if !ok {
+		return false, fmt.Errorf("non-driver error (cannot determine parse verdict): %w", err)
+	}
+	for _, m := range dorisSyntaxErrMarkers {
+		if strings.Contains(myErr.Message, m) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// assertParity asserts the omni parser and Doris agree on sql (both accept or
+// both reject) — the accept+reject conformance discipline.
+func (c *dorisContainer) assertParity(t *testing.T, sql string, wantAccept bool) {
+	t.Helper()
+	_, errs := Parse(sql)
+	omni := len(errs) == 0
+	doris, err := c.accepts(sql)
+	if err != nil {
+		t.Fatalf("Doris oracle could not verdict %q: %v", sql, err)
+	}
+	if omni != doris {
+		t.Errorf("MISMATCH %q: omni=%v doris=%v (omniErrs=%v)", sql, omni, doris, errs)
+	}
+	if omni != wantAccept {
+		t.Errorf("omni %q: got accept=%v, want %v (errs=%v)", sql, omni, wantAccept, errs)
+	}
+}
+
+// TestDorisConnectivity is the harness smoke test: the container is reachable.
+func TestDorisConnectivity(t *testing.T) {
+	c := startDoris(t)
+	var one int
+	if err := c.db.QueryRowContext(c.ctx, "SELECT 1").Scan(&one); err != nil || one != 1 {
+		t.Fatalf("SELECT 1 = %d, err=%v", one, err)
+	}
+}
+
+// TestDorisSyntaxConformance is the container-grounded conformance matrix for
+// the expression and clause forms that the hand-written parser previously
+// rejected even though Doris accepts them (BYT-10070 and its follow-ups), plus
+// the sibling forms Doris itself rejects.
+//
+// The negative arm matters as much as the positive one: the Apache Doris ANTLR
+// grammar accepts several MySQL-style special forms (SUBSTRING(x FROM n),
+// TRIM(BOTH ... FROM ...), POSITION(x IN y), quantified comparisons) that the
+// shipping engine rejects at parse time. Asserting those stay rejected keeps
+// the parser aligned with the engine rather than with the grammar file.
+func TestDorisSyntaxConformance(t *testing.T) {
+	c := startDoris(t)
+
+	// The probes reference table `t`; a missing table is a semantic error, which
+	// still proves the statement parsed.
+	cases := []struct {
+		name       string
+		sql        string
+		wantAccept bool
+	}{
+		// EXTRACT — the originally reported gap.
+		{"extract_year", "SELECT EXTRACT(YEAR FROM MONTHS_ADD(NOW(), -1))", true},
+		{"extract_month", "SELECT EXTRACT(MONTH FROM NOW())", true},
+		{"extract_compound_unit", "SELECT EXTRACT(DAY_HOUR FROM NOW())", true},
+		{"extract_in_cte", "WITH c AS (SELECT EXTRACT(YEAR FROM NOW()) y) SELECT * FROM c", true},
+
+		// Reserved keywords usable as function names (functionNameIdentifier).
+		{"trim", "SELECT TRIM('  x  ')", true},
+		{"trim_two_arg", "SELECT TRIM('xax', 'x')", true},
+		{"left", "SELECT LEFT('abc', 2)", true},
+		{"right", "SELECT RIGHT('abc', 2)", true},
+		{"if", "SELECT IF(1, 2, 3)", true},
+		{"database", "SELECT DATABASE()", true},
+		{"schema", "SELECT SCHEMA()", true},
+		{"user", "SELECT USER()", true},
+		{"session_user", "SELECT SESSION_USER()", true},
+		{"current_user", "SELECT CURRENT_USER()", true},
+		{"current_catalog", "SELECT CURRENT_CATALOG()", true},
+		{"connection_id", "SELECT CONNECTION_ID()", true},
+		{"password", "SELECT PASSWORD('x')", true},
+
+		// Nilary datetime functions with a fractional-seconds precision.
+		{"current_timestamp_precision", "SELECT CURRENT_TIMESTAMP(3)", true},
+		{"current_time_precision", "SELECT CURRENT_TIME(3)", true},
+		{"localtime_precision", "SELECT LOCALTIME(3)", true},
+		{"localtimestamp_precision", "SELECT LOCALTIMESTAMP(3)", true},
+		{"current_date_parens", "SELECT CURRENT_DATE()", true},
+
+		// Literals.
+		{"hex_literal", "SELECT x'1f'", true},
+		{"bit_literal", "SELECT b'101'", true},
+		{"array_literal", "SELECT [1, 2, 3]", true},
+		{"map_literal", "SELECT {'a': 1}", true},
+
+		// Session and user variables.
+		{"system_var", "SELECT @@version_comment", true},
+		{"system_var_session_scope", "SELECT @@session.query_timeout", true},
+		{"system_var_global_scope", "SELECT @@global.query_timeout", true},
+		{"user_var", "SELECT @uservar", true},
+
+		// Lambdas in higher-order array functions.
+		{"lambda_array_map", "SELECT array_map(x -> x + 1, [1, 2, 3])", true},
+		{"lambda_array_filter", "SELECT array_filter(x -> x > 1, [1, 2, 3])", true},
+
+		// Optimizer hints.
+		{"set_var_hint", "SELECT /*+ SET_VAR(query_timeout = 100) */ 1", true},
+
+		// Grouping elements.
+		{"group_by_cube", "SELECT a, SUM(b) FROM t GROUP BY CUBE(a)", true},
+		{"group_by_rollup", "SELECT a, SUM(b) FROM t GROUP BY ROLLUP(a)", true},
+		{"group_by_grouping_sets", "SELECT a, SUM(b) FROM t GROUP BY GROUPING SETS ((a), ())", true},
+
+		// CONVERT / USING charset.
+		{"convert_using", "SELECT CONVERT('abc' USING utf8)", true},
+		{"convert_type", "SELECT CONVERT('1', SIGNED)", true},
+		{"char_using", "SELECT CHAR(65 USING utf8)", true},
+
+		// BINARY operator.
+		{"binary_operator", "SELECT BINARY 'abc'", true},
+
+		// --- Negative arm: the grammar file allows these, the engine does not.
+		{"substring_from_for", "SELECT SUBSTRING('abcdef' FROM 2 FOR 3)", false},
+		{"substring_from", "SELECT SUBSTRING('abcdef' FROM 2)", false},
+		{"trim_both_from", "SELECT TRIM(BOTH 'x' FROM 'xax')", false},
+		{"trim_leading_from", "SELECT TRIM(LEADING 'x' FROM 'xax')", false},
+		{"trim_expr_from", "SELECT TRIM(' ' FROM ' a ')", false},
+		{"position_in", "SELECT POSITION('b' IN 'abc')", false},
+		{"values_func", "SELECT VALUES(a) FROM t", false},
+		{"quantified_any", "SELECT * FROM t WHERE a = ANY (SELECT b FROM t)", false},
+		{"quantified_all", "SELECT * FROM t WHERE a > ALL (SELECT b FROM t)", false},
+		{"quantified_some", "SELECT * FROM t WHERE a = SOME (SELECT b FROM t)", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c.assertParity(t, tc.sql, tc.wantAccept)
+		})
+	}
+}

--- a/doris/parser/doris_container_test.go
+++ b/doris/parser/doris_container_test.go
@@ -259,12 +259,21 @@ func TestDorisSyntaxConformance(t *testing.T) {
 		// Lambdas in higher-order array functions.
 		{"lambda_array_map", "SELECT array_map(x -> x + 1, [1, 2, 3])", true},
 		{"lambda_array_filter", "SELECT array_filter(x -> x > 1, [1, 2, 3])", true},
+		{"lambda_multi_param", "SELECT array_map((x, y) -> x + y, [1, 2], [3, 4])", true},
+		{"lambda_three_param", "SELECT array_map((x, y, z) -> x + y + z, [1], [2], [3])", true},
+		// A single parameter must be written bare; the parenthesized form
+		// requires at least two.
+		{"lambda_single_param_parenthesized", "SELECT array_map((x) -> x + 1, [1, 2])", false},
 
 		// Optimizer hints.
 		{"set_var_hint", "SELECT /*+ SET_VAR(query_timeout = 100) */ 1", true},
 
-		// Grouping elements.
+		// Grouping elements. CUBE is the whole grouping specification: a
+		// trailing list after it is a parse error, so accepting one here would
+		// silently discard everything past the comma.
 		{"group_by_cube", "SELECT a, SUM(b) FROM t GROUP BY CUBE(a)", true},
+		{"group_by_cube_trailing_item", "SELECT a, b, SUM(c) FROM t GROUP BY CUBE(a), b", false},
+		{"group_by_cube_trailing_cube", "SELECT a, SUM(b) FROM t GROUP BY CUBE(a), CUBE(b)", false},
 		{"group_by_rollup", "SELECT a, SUM(b) FROM t GROUP BY ROLLUP(a)", true},
 		{"group_by_grouping_sets", "SELECT a, SUM(b) FROM t GROUP BY GROUPING SETS ((a), ())", true},
 
@@ -272,6 +281,10 @@ func TestDorisSyntaxConformance(t *testing.T) {
 		{"convert_using", "SELECT CONVERT('abc' USING utf8)", true},
 		{"convert_type", "SELECT CONVERT('1', SIGNED)", true},
 		{"char_using", "SELECT CHAR(65 USING utf8)", true},
+		{"char_multi_arg_using", "SELECT CHAR(65, 66 USING utf8)", true},
+		// The trailing USING clause belongs to CHAR and CONVERT only.
+		{"using_on_aggregate", "SELECT SUM(a USING utf8) FROM t", false},
+		{"using_on_scalar", "SELECT abs(1 USING utf8)", false},
 
 		// BINARY operator.
 		{"binary_operator", "SELECT BINARY 'abc'", true},

--- a/doris/parser/expr.go
+++ b/doris/parser/expr.go
@@ -527,9 +527,12 @@ func (p *Parser) parseFuncCall(name *ast.ObjectName) (*ast.FuncCallExpr, error) 
 		}
 		fc.Args = args
 
-		// Trailing USING charset, as in CHAR(65 USING utf8). parseExprList
-		// stops at USING because it is not a comma, so it is consumed here.
-		if p.cur.Kind == kwUSING {
+		// Trailing USING charset, as in CHAR(65 USING utf8): the argument
+		// parser stops at USING because it is not a comma. Only CHAR takes it
+		// on this generic path — CONVERT has its own production, and the engine
+		// rejects the clause on anything else (`SUM(a USING utf8)` is a syntax
+		// error), so it must not be consumed for arbitrary function names.
+		if funcName == "CHAR" && p.cur.Kind == kwUSING {
 			p.advance() // consume USING
 			charset, ok := p.identOrKeywordToken()
 			if !ok {
@@ -735,6 +738,57 @@ func (p *Parser) parseWindowFrameBound() (string, ast.Node, error) {
 	}
 }
 
+// tryParseParenLambda speculatively parses the parenthesized multi-parameter
+// lambda form `(x, y) -> body`, rolling the parser back and reporting ok=false
+// when the input turns out to be an ordinary parenthesized expression.
+//
+// The grammar requires at least two parameters in this form; a single
+// parameter must be written bare (`x -> ...`), and the engine rejects
+// `(x) -> ...`. That is why len(params) < 2 backtracks rather than accepting.
+func (p *Parser) tryParseParenLambda() (ast.Node, bool, error) {
+	if p.cur.Kind != int('(') {
+		return nil, false, nil
+	}
+	saved := p.save()
+	start := p.cur.Loc.Start
+	p.advance() // consume '('
+
+	var params []string
+	for {
+		if !p.isExprIdentToken() {
+			p.restore(saved)
+			return nil, false, nil
+		}
+		params = append(params, p.advance().Str)
+		if p.cur.Kind != int(',') {
+			break
+		}
+		p.advance() // consume ','
+	}
+	if len(params) < 2 || p.cur.Kind != int(')') {
+		p.restore(saved)
+		return nil, false, nil
+	}
+	p.advance() // consume ')'
+	if p.cur.Kind != tokArrow {
+		p.restore(saved)
+		return nil, false, nil
+	}
+	p.advance() // consume '->'
+
+	// Past the arrow the shape is unambiguous, so a bad body is a real error
+	// rather than a reason to backtrack.
+	body, err := p.parseExpr()
+	if err != nil {
+		return nil, false, err
+	}
+	return &ast.LambdaExpr{
+		Params: params,
+		Body:   body,
+		Loc:    ast.Loc{Start: start, End: ast.NodeLoc(body).End},
+	}, true, nil
+}
+
 // parseFuncArgList parses a function-call argument list. Unlike a plain
 // expression list it also accepts a lambda (`x -> body`), which the grammar
 // permits only here, as an argument to a higher-order array function. Keeping
@@ -743,17 +797,23 @@ func (p *Parser) parseWindowFrameBound() (string, ast.Node, error) {
 func (p *Parser) parseFuncArgList() ([]ast.Node, error) {
 	var list []ast.Node
 	for {
-		expr, err := p.parseExpr()
+		lam, ok, err := p.tryParseParenLambda()
 		if err != nil {
 			return nil, err
 		}
-		if p.cur.Kind == tokArrow {
-			expr, err = p.parseLambdaExpr(expr)
+		if !ok {
+			lam, err = p.parseExpr()
 			if err != nil {
 				return nil, err
 			}
+			if p.cur.Kind == tokArrow {
+				lam, err = p.parseLambdaExpr(lam)
+				if err != nil {
+					return nil, err
+				}
+			}
 		}
-		list = append(list, expr)
+		list = append(list, lam)
 		if p.cur.Kind != int(',') {
 			break
 		}
@@ -1176,11 +1236,6 @@ func lambdaParams(n ast.Node) ([]string, bool) {
 			return nil, false
 		}
 		return []string{v.Name.Parts[0]}, true
-	case *ast.ParenExpr:
-		// `(x) -> ...`. The multi-parameter form `(x, y) -> ...` is not
-		// supported: a parenthesized list is not an expression here, so the
-		// parameters never reach this point as a single node.
-		return lambdaParams(v.Expr)
 	}
 	return nil, false
 }

--- a/doris/parser/expr.go
+++ b/doris/parser/expr.go
@@ -316,6 +316,22 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 			Loc:   tok.Loc,
 		}, nil
 
+	case tokHexLiteral:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitHex,
+			Value: tok.Str,
+			Loc:   tok.Loc,
+		}, nil
+
+	case tokBitLiteral:
+		tok := p.advance()
+		return &ast.Literal{
+			Kind:  ast.LitBit,
+			Value: tok.Str,
+			Loc:   tok.Loc,
+		}, nil
+
 	case kwTRUE:
 		tok := p.advance()
 		return &ast.Literal{
@@ -343,6 +359,31 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 	case int('('):
 		return p.parseParenExprOrSubquery()
 
+	case int('{'):
+		// Untyped map constructor: { k: v, ... }.
+		return p.finishMapLiteral(p.cur.Loc.Start)
+
+	case int('['):
+		// Untyped array constructor: [ e, ... ].
+		return p.finishArrayLiteral(p.cur.Loc.Start)
+
+	case kwBINARY:
+		// BINARY <expr> cast-to-binary operator. The operand is a
+		// booleanExpression: it spans comparisons/predicates but stops below
+		// AND/OR/NOT, so `BINARY a = 'x'` is BINARY(a = 'x') while
+		// `BINARY a AND b` is (BINARY a) AND b.
+		start := p.cur.Loc
+		p.advance()
+		operand, err := p.parseExprPrec(bpNot + 1)
+		if err != nil {
+			return nil, err
+		}
+		return &ast.UnaryExpr{
+			Op:   ast.UnaryBinary,
+			Expr: operand,
+			Loc:  ast.Loc{Start: start.Start, End: ast.NodeLoc(operand).End},
+		}, nil
+
 	case kwCASE:
 		return p.parseCaseExpr()
 
@@ -352,11 +393,27 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 	case kwTRY_CAST:
 		return p.parseCastExpr(true)
 
+	case kwCONVERT:
+		// CONVERT is non-reserved, so only treat it specially when applied.
+		if p.peekNext().Kind == int('(') {
+			return p.parseConvertExpr()
+		}
+		return p.parseIdentExpr()
+
+	case kwEXTRACT:
+		return p.parseExtractExpr()
+
 	// Nilary functions: CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP,
 	// CURRENT_USER, SESSION_USER, LOCALTIME, LOCALTIMESTAMP.
 	case kwCURRENT_DATE, kwCURRENT_TIME, kwCURRENT_TIMESTAMP,
 		kwCURRENT_USER, kwSESSION_USER, kwLOCALTIME, kwLOCALTIMESTAMP:
 		return p.parseNilaryFunction()
+
+	case tokDoubleAt:
+		return p.parseVariableRef(true)
+
+	case int('@'):
+		return p.parseVariableRef(false)
 
 	case tokPlaceholder:
 		tok := p.advance()
@@ -367,6 +424,15 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 		}, nil
 
 	default:
+		// A reserved keyword that the grammar still allows as a function name,
+		// but only when it is immediately applied: `TRIM(s)` is a call,
+		// `LEFT JOIN` is not.
+		if isFunctionNameKeyword(p.cur.Kind) && p.peekNext().Kind == int('(') {
+			tok := p.advance()
+			name := &ast.ObjectName{Parts: []string{strings.ToUpper(tok.Str)}, Loc: tok.Loc}
+			return p.parseFuncCall(name)
+		}
+
 		// Identifier-based: column ref or function call.
 		if p.isExprIdentToken() {
 			return p.parseIdentExpr()
@@ -374,6 +440,20 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 
 		return nil, p.syntaxErrorAtCur()
 	}
+}
+
+// isFunctionNameKeyword reports whether kind is a reserved keyword that is
+// nonetheless usable as a function name. It mirrors the grammar's
+// functionNameIdentifier rule; without it `IF(a,1,2)`, `LEFT(s,2)`, `TRIM(s)`
+// and `DATABASE()` all fail to parse even though the engine accepts them.
+func isFunctionNameKeyword(kind TokenKind) bool {
+	switch kind {
+	case kwADD, kwCONNECTION_ID, kwCURRENT_CATALOG, kwCURRENT_USER, kwDATABASE,
+		kwIF, kwLEFT, kwLIKE, kwPASSWORD, kwREGEXP, kwRIGHT, kwSCHEMA,
+		kwSESSION_USER, kwTRIM, kwUSER:
+		return true
+	}
+	return false
 }
 
 // isExprIdentToken reports whether the current token is usable as an identifier
@@ -441,11 +521,22 @@ func (p *Parser) parseFuncCall(name *ast.ObjectName) (*ast.FuncCallExpr, error) 
 	}
 
 	if p.cur.Kind != int(')') {
-		args, err := p.parseExprList()
+		args, err := p.parseFuncArgList()
 		if err != nil {
 			return nil, err
 		}
 		fc.Args = args
+
+		// Trailing USING charset, as in CHAR(65 USING utf8). parseExprList
+		// stops at USING because it is not a comma, so it is consumed here.
+		if p.cur.Kind == kwUSING {
+			p.advance() // consume USING
+			charset, ok := p.identOrKeywordToken()
+			if !ok {
+				return nil, p.syntaxErrorAtCur()
+			}
+			fc.Using = strings.ToUpper(charset.Str)
+		}
 
 		// Optional ORDER BY within aggregate functions (e.g., GROUP_CONCAT)
 		if p.cur.Kind == kwORDER {
@@ -642,6 +733,33 @@ func (p *Parser) parseWindowFrameBound() (string, ast.Node, error) {
 			return "", nil, &ParseError{Loc: p.cur.Loc, Msg: "expected PRECEDING or FOLLOWING in window frame bound"}
 		}
 	}
+}
+
+// parseFuncArgList parses a function-call argument list. Unlike a plain
+// expression list it also accepts a lambda (`x -> body`), which the grammar
+// permits only here, as an argument to a higher-order array function. Keeping
+// lambdas scoped to this position means a stray `->` anywhere else stays a
+// syntax error — matching the engine, which has no `->` JSON operator.
+func (p *Parser) parseFuncArgList() ([]ast.Node, error) {
+	var list []ast.Node
+	for {
+		expr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if p.cur.Kind == tokArrow {
+			expr, err = p.parseLambdaExpr(expr)
+			if err != nil {
+				return nil, err
+			}
+		}
+		list = append(list, expr)
+		if p.cur.Kind != int(',') {
+			break
+		}
+		p.advance() // consume ','
+	}
+	return list, nil
 }
 
 // parseExprList parses a comma-separated list of expressions.
@@ -890,6 +1008,302 @@ func (p *Parser) parseCastExpr(tryCast bool) (*ast.CastExpr, error) {
 	}, nil
 }
 
+// parseExtractExpr parses EXTRACT(unit FROM expr).
+//
+// EXTRACT is a reserved keyword, so without a production for it the whole
+// statement fails to parse at the EXTRACT token.
+func (p *Parser) parseExtractExpr() (ast.Node, error) {
+	extractTok := p.advance() // consume EXTRACT
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	unit, err := p.parseExtractUnit()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwFROM); err != nil {
+		return nil, err
+	}
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &ast.ExtractExpr{
+		Expr: expr,
+		Unit: unit,
+		Loc:  ast.Loc{Start: extractTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseExtractUnit parses the unit of EXTRACT(unit FROM expr).
+//
+// The grammar takes an identifier, which covers plain identifiers (DAYOFWEEK,
+// DOY, ...) and the non-reserved unit keywords (YEAR, MONTH, WEEK, ...). The
+// compound units DAY_HOUR, DAY_SECOND and MINUTE_SECOND lex as reserved
+// keywords, so they are accepted explicitly.
+func (p *Parser) parseExtractUnit() (string, error) {
+	switch p.cur.Kind {
+	case kwDAY_HOUR, kwDAY_SECOND, kwMINUTE_SECOND:
+		tok := p.advance()
+		return strings.ToUpper(tok.Str), nil
+	default:
+		if p.isExprIdentToken() {
+			tok := p.advance()
+			return strings.ToUpper(tok.Str), nil
+		}
+		return "", &ParseError{
+			Loc: p.cur.Loc,
+			Msg: fmt.Sprintf("expected EXTRACT unit, got %q", p.cur.Str),
+		}
+	}
+}
+
+// finishMapLiteral parses the { key: value, ... } body of a map constructor.
+func (p *Parser) finishMapLiteral(start int) (ast.Node, error) {
+	lit := &ast.MapLiteral{}
+
+	if _, err := p.expect(int('{')); err != nil {
+		return nil, err
+	}
+	if p.cur.Kind != int('}') {
+		entry, err := p.parseMapEntry()
+		if err != nil {
+			return nil, err
+		}
+		lit.Entries = append(lit.Entries, entry)
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			entry, err = p.parseMapEntry()
+			if err != nil {
+				return nil, err
+			}
+			lit.Entries = append(lit.Entries, entry)
+		}
+	}
+	closeTok, err := p.expect(int('}'))
+	if err != nil {
+		return nil, err
+	}
+	lit.Loc = ast.Loc{Start: start, End: closeTok.Loc.End}
+	return lit, nil
+}
+
+// parseMapEntry parses one `key: value` pair of a map constructor.
+func (p *Parser) parseMapEntry() (*ast.MapEntry, error) {
+	key, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(int(':')); err != nil {
+		return nil, err
+	}
+	value, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.MapEntry{
+		Key:   key,
+		Value: value,
+		Loc:   ast.Loc{Start: ast.NodeLoc(key).Start, End: ast.NodeLoc(value).End},
+	}, nil
+}
+
+// finishArrayLiteral parses an array constructor body starting at '['.
+func (p *Parser) finishArrayLiteral(start int) (ast.Node, error) {
+	lit := &ast.ArrayLiteral{}
+
+	if _, err := p.expect(int('[')); err != nil {
+		return nil, err
+	}
+	if p.cur.Kind != int(']') {
+		el, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		lit.Elements = append(lit.Elements, el)
+		for p.cur.Kind == int(',') {
+			p.advance() // consume ','
+			el, err = p.parseExpr()
+			if err != nil {
+				return nil, err
+			}
+			lit.Elements = append(lit.Elements, el)
+		}
+	}
+	closeTok, err := p.expect(int(']'))
+	if err != nil {
+		return nil, err
+	}
+	lit.Loc = ast.Loc{Start: start, End: closeTok.Loc.End}
+	return lit, nil
+}
+
+// parseLambdaExpr parses `params -> body`, given the already-parsed expression
+// to the left of the arrow.
+func (p *Parser) parseLambdaExpr(left ast.Node) (ast.Node, error) {
+	arrowTok := p.advance() // consume '->'
+
+	params, ok := lambdaParams(left)
+	if !ok {
+		return nil, &ParseError{
+			Loc: arrowTok.Loc,
+			Msg: "invalid lambda parameter list before '->'",
+		}
+	}
+	body, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.LambdaExpr{
+		Params: params,
+		Body:   body,
+		Loc:    ast.Loc{Start: ast.NodeLoc(left).Start, End: ast.NodeLoc(body).End},
+	}, nil
+}
+
+// lambdaParams extracts parameter names from the expression left of '->'. The
+// parameters parse as ordinary column references (`x`, or `(x, y)` as a
+// parenthesized row), so they are reinterpreted here rather than lexed
+// specially.
+func lambdaParams(n ast.Node) ([]string, bool) {
+	switch v := n.(type) {
+	case *ast.ColumnRef:
+		if v.Name == nil || len(v.Name.Parts) != 1 {
+			return nil, false
+		}
+		return []string{v.Name.Parts[0]}, true
+	case *ast.ParenExpr:
+		// `(x) -> ...`. The multi-parameter form `(x, y) -> ...` is not
+		// supported: a parenthesized list is not an expression here, so the
+		// parameters never reach this point as a single node.
+		return lambdaParams(v.Expr)
+	}
+	return nil, false
+}
+
+// parseGroupingElementCall parses a reserved-keyword grouping element such as
+// CUBE(a, b) as a function call, keeping GROUP BY items uniform with ROLLUP and
+// GROUPING SETS (both non-reserved, so they already take the expression path).
+func (p *Parser) parseGroupingElementCall() (*ast.FuncCallExpr, error) {
+	tok := p.advance()
+	name := &ast.ObjectName{Parts: []string{strings.ToUpper(tok.Str)}, Loc: tok.Loc}
+	return p.parseFuncCall(name)
+}
+
+// parseConvertExpr parses the two CONVERT forms:
+//
+//	CONVERT(expr USING charset)  -- transcoding; kept as a CONVERT call
+//	CONVERT(expr, type)          -- CAST spelled differently, so it becomes a CastExpr
+func (p *Parser) parseConvertExpr() (ast.Node, error) {
+	convertTok := p.advance() // consume CONVERT
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.cur.Kind == kwUSING {
+		p.advance() // consume USING
+		charset, ok := p.identOrKeywordToken()
+		if !ok {
+			return nil, p.syntaxErrorAtCur()
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		return &ast.FuncCallExpr{
+			Name:  &ast.ObjectName{Parts: []string{"CONVERT"}, Loc: convertTok.Loc},
+			Args:  []ast.Node{expr},
+			Using: strings.ToUpper(charset.Str),
+			Loc:   ast.Loc{Start: convertTok.Loc.Start, End: closeTok.Loc.End},
+		}, nil
+	}
+
+	if _, err := p.expect(int(',')); err != nil {
+		return nil, err
+	}
+	typeName, err := p.parseConvertTargetType()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &ast.CastExpr{
+		Expr:     expr,
+		TypeName: typeName,
+		Loc:      ast.Loc{Start: convertTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseConvertTargetType parses the target type of CONVERT(expr, type). It
+// additionally accepts SIGNED / UNSIGNED [INTEGER], which are cast-only type
+// names rather than column types and so are unknown to parseDataType.
+func (p *Parser) parseConvertTargetType() (*ast.TypeName, error) {
+	switch p.cur.Kind {
+	case kwSIGNED, kwUNSIGNED:
+		tok := p.advance()
+		tn := &ast.TypeName{Name: strings.ToUpper(tok.Str), Loc: tok.Loc}
+		if p.cur.Kind == kwINTEGER || p.cur.Kind == kwINT {
+			end := p.advance()
+			tn.Loc.End = end.Loc.End
+		}
+		return tn, nil
+	}
+	return p.parseDataType()
+}
+
+// parseVariableRef parses a system variable (@@name, @@scope.name) or a
+// user-defined variable (@name).
+func (p *Parser) parseVariableRef(system bool) (ast.Node, error) {
+	atTok := p.advance() // consume '@@' or '@'
+
+	first, ok := p.identOrKeywordToken()
+	if !ok {
+		return nil, p.syntaxErrorAtCur()
+	}
+	v := &ast.VariableRef{
+		System: system,
+		Name:   first.Str,
+		Loc:    ast.Loc{Start: atTok.Loc.Start, End: first.Loc.End},
+	}
+	// @@session.x / @@global.x — the scope qualifier only exists for system
+	// variables.
+	if system && p.cur.Kind == int('.') {
+		p.advance() // consume '.'
+		second, ok := p.identOrKeywordToken()
+		if !ok {
+			return nil, p.syntaxErrorAtCur()
+		}
+		v.Scope = strings.ToUpper(v.Name)
+		v.Name = second.Str
+		v.Loc.End = second.Loc.End
+	}
+	return v, nil
+}
+
+// identOrKeywordToken accepts any identifier- or keyword-shaped token, for
+// positions where there is no ambiguity: after an @ / @@ prefix, or after
+// USING. Scope names (SESSION, GLOBAL), charset names and many variable names
+// are themselves keywords.
+func (p *Parser) identOrKeywordToken() (Token, bool) {
+	switch {
+	case p.cur.Kind == tokIdent || p.cur.Kind == tokQuotedIdent:
+		return p.advance(), true
+	case p.cur.Kind >= 700: // any keyword
+		return p.advance(), true
+	}
+	return Token{}, false
+}
+
 // parseNilaryFunction parses zero-argument keyword functions like
 // CURRENT_DATE, CURRENT_TIMESTAMP, etc.
 func (p *Parser) parseNilaryFunction() (ast.Node, error) {
@@ -907,6 +1321,14 @@ func (p *Parser) parseNilaryFunction() (ast.Node, error) {
 	}
 	if p.cur.Kind == int('(') {
 		p.advance() // consume '('
+		// Optional fractional-seconds precision: CURRENT_TIMESTAMP(3).
+		if p.cur.Kind != int(')') {
+			args, err := p.parseExprList()
+			if err != nil {
+				return nil, err
+			}
+			fc.Args = args
+		}
 		closeTok, err := p.expect(int(')'))
 		if err != nil {
 			return nil, err

--- a/doris/parser/expr_test.go
+++ b/doris/parser/expr_test.go
@@ -1621,3 +1621,61 @@ func TestStmtGroupByCube(t *testing.T) {
 		}
 	}
 }
+
+func TestExprLambdaMultiParameter(t *testing.T) {
+	node := mustParseExpr(t, "array_map((x, y) -> x + y, a, b)")
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	lam, ok := fc.Args[0].(*ast.LambdaExpr)
+	if !ok {
+		t.Fatalf("args[0] = %T, want *ast.LambdaExpr", fc.Args[0])
+	}
+	if len(lam.Params) != 2 || lam.Params[0] != "x" || lam.Params[1] != "y" {
+		t.Errorf("params = %v, want [x y]", lam.Params)
+	}
+}
+
+func TestExprLambdaSingleParameterMustBeBare(t *testing.T) {
+	// The engine accepts `x -> ...` and `(x, y) -> ...` but rejects `(x) -> ...`.
+	if _, err := parseExprFrom("array_map((x) -> x + 1, arr)"); err == nil {
+		t.Error("(x) -> ... parsed, want syntax error")
+	}
+	// An ordinary parenthesized argument must be unaffected by the speculative
+	// lambda parse.
+	mustParseExpr(t, "foo((a + b), c)")
+	mustParseExpr(t, "foo((a), b)")
+}
+
+func TestExprTrailingUsingIsCharOnly(t *testing.T) {
+	// CHAR takes a trailing USING on the generic call path; CONVERT has its own
+	// production. Every other function must reject it, as the engine does.
+	mustParseExpr(t, "CHAR(65 USING utf8)")
+	mustParseExpr(t, "CHAR(65, 66 USING utf8)")
+	mustParseExpr(t, "CONVERT(s USING utf8)")
+	for _, input := range []string{"SUM(a USING utf8)", "foo(a USING utf8)"} {
+		if _, err := parseExprFrom(input); err == nil {
+			t.Errorf("parseExpr(%q) = nil error, want syntax error", input)
+		}
+	}
+}
+
+func TestStmtGroupByCubeIsWholeSpecification(t *testing.T) {
+	// The engine rejects a grouping list after CUBE. Accepting it here would
+	// silently discard everything past the comma.
+	for _, sql := range []string{
+		"SELECT a, b, SUM(c) FROM t GROUP BY CUBE(a), b",
+		"SELECT a, SUM(b) FROM t GROUP BY CUBE(a), CUBE(b)",
+	} {
+		if _, errs := Parse(sql); len(errs) == 0 {
+			t.Errorf("Parse(%q) succeeded, want syntax error", sql)
+		}
+	}
+}
+
+func TestUnaryBinaryRenders(t *testing.T) {
+	if got := ast.UnaryBinary.String(); got != "BINARY" {
+		t.Errorf("UnaryBinary.String() = %q, want BINARY", got)
+	}
+}

--- a/doris/parser/expr_test.go
+++ b/doris/parser/expr_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bytebase/omni/doris/ast"
@@ -1263,5 +1264,360 @@ func TestExprParseSuccess(t *testing.T) {
 				t.Errorf("parseExpr(%q) returned nil", tt.input)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EXTRACT expressions
+// ---------------------------------------------------------------------------
+
+func TestExprExtractUnits(t *testing.T) {
+	// Every unit documented for EXTRACT: plain identifiers, non-reserved unit
+	// keywords, and the compound units that lex as reserved keywords.
+	units := []string{
+		"YEAR", "QUARTER", "MONTH", "WEEK", "DAY", "HOUR", "MINUTE", "SECOND",
+		"YEAR_MONTH", "DAY_HOUR", "DAY_MINUTE", "DAY_SECOND", "DAY_MICROSECOND",
+		"HOUR_MINUTE", "HOUR_SECOND", "HOUR_MICROSECOND",
+		"MINUTE_SECOND", "MINUTE_MICROSECOND", "SECOND_MICROSECOND",
+		"DAYOFWEEK", "DOW", "DAYOFYEAR", "DOY",
+	}
+	for _, unit := range units {
+		t.Run(unit, func(t *testing.T) {
+			node := mustParseExpr(t, "EXTRACT("+unit+" FROM d)")
+			ex, ok := node.(*ast.ExtractExpr)
+			if !ok {
+				t.Fatalf("expected *ast.ExtractExpr, got %T", node)
+			}
+			if ex.Unit != unit {
+				t.Errorf("unit = %q, want %q", ex.Unit, unit)
+			}
+			if _, ok := ex.Expr.(*ast.ColumnRef); !ok {
+				t.Errorf("expr = %T, want *ast.ColumnRef", ex.Expr)
+			}
+		})
+	}
+}
+
+func TestExprExtractUnitNormalized(t *testing.T) {
+	node := mustParseExpr(t, "extract(year from d)")
+	ex, ok := node.(*ast.ExtractExpr)
+	if !ok {
+		t.Fatalf("expected *ast.ExtractExpr, got %T", node)
+	}
+	if ex.Unit != "YEAR" {
+		t.Errorf("unit = %q, want YEAR", ex.Unit)
+	}
+}
+
+func TestExprExtractNestedFuncCall(t *testing.T) {
+	node := mustParseExpr(t, "EXTRACT(YEAR FROM MONTHS_ADD(NOW(), -1))")
+	ex, ok := node.(*ast.ExtractExpr)
+	if !ok {
+		t.Fatalf("expected *ast.ExtractExpr, got %T", node)
+	}
+	fc, ok := ex.Expr.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expr = %T, want *ast.FuncCallExpr", ex.Expr)
+	}
+	if got := fc.Name.Parts[len(fc.Name.Parts)-1]; got != "MONTHS_ADD" {
+		t.Errorf("func name = %q, want MONTHS_ADD", got)
+	}
+}
+
+func TestExprExtractInsideCTEStatement(t *testing.T) {
+	// The reported shape: EXTRACT inside a CTE body, spread over several lines.
+	sql := `WITH c AS (
+  SELECT year_num
+  FROM currency_record
+  WHERE year_num = EXTRACT(
+    YEAR
+    FROM
+      MONTHS_ADD(NOW(), -1)
+  )
+)
+SELECT * FROM c`
+	file, errs := Parse(sql)
+	if len(errs) > 0 {
+		t.Fatalf("Parse returned errors: %v", errs)
+	}
+	if len(file.Stmts) != 1 {
+		t.Fatalf("Stmts len = %d, want 1", len(file.Stmts))
+	}
+	if _, ok := file.Stmts[0].(*ast.SelectStmt); !ok {
+		t.Fatalf("stmt = %T, want *ast.SelectStmt", file.Stmts[0])
+	}
+}
+
+func TestExprExtractSyntaxErrors(t *testing.T) {
+	for _, input := range []string{
+		"EXTRACT(YEAR d)",     // missing FROM
+		"EXTRACT(FROM d)",     // missing unit
+		"EXTRACT(YEAR FROM)",  // missing source expression
+		"EXTRACT YEAR FROM d", // missing parentheses
+	} {
+		if _, err := parseExprFrom(input); err == nil {
+			t.Errorf("parseExpr(%q) = nil error, want syntax error", input)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reserved keywords usable as function names (functionNameIdentifier)
+// ---------------------------------------------------------------------------
+
+func TestExprFunctionNameKeywords(t *testing.T) {
+	tests := []struct {
+		input string
+		name  string
+		args  int
+	}{
+		{"TRIM(s)", "TRIM", 1},
+		{"TRIM(s, 'x')", "TRIM", 2},
+		{"LEFT(s, 2)", "LEFT", 2},
+		{"RIGHT(s, 2)", "RIGHT", 2},
+		{"IF(a, 1, 2)", "IF", 3},
+		{"DATABASE()", "DATABASE", 0},
+		{"SCHEMA()", "SCHEMA", 0},
+		{"ADD(1, 2)", "ADD", 2},
+		{"REGEXP(1)", "REGEXP", 1},
+		{"LIKE(1)", "LIKE", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			node := mustParseExpr(t, tt.input)
+			fc, ok := node.(*ast.FuncCallExpr)
+			if !ok {
+				t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+			}
+			if got := fc.Name.Parts[len(fc.Name.Parts)-1]; !strings.EqualFold(got, tt.name) {
+				t.Errorf("name = %q, want %q", got, tt.name)
+			}
+			if len(fc.Args) != tt.args {
+				t.Errorf("args = %d, want %d", len(fc.Args), tt.args)
+			}
+		})
+	}
+}
+
+func TestExprFunctionNameKeywordRequiresCall(t *testing.T) {
+	// The keyword is only a function name when directly applied — `LEFT JOIN`
+	// must still parse as a join, and a bare `LEFT` is still not an identifier.
+	if _, errs := Parse("SELECT * FROM a LEFT JOIN b ON a.x = b.x"); len(errs) > 0 {
+		t.Errorf("LEFT JOIN broke: %v", errs)
+	}
+	if _, errs := Parse("SELECT * FROM a RIGHT JOIN b ON a.x = b.x"); len(errs) > 0 {
+		t.Errorf("RIGHT JOIN broke: %v", errs)
+	}
+	if _, errs := Parse("SELECT LEFT FROM t"); len(errs) == 0 {
+		t.Error("bare LEFT as a column parsed, want syntax error")
+	}
+}
+
+func TestExprNilaryFunctionPrecision(t *testing.T) {
+	for _, input := range []string{
+		"CURRENT_TIMESTAMP(3)", "CURRENT_TIME(3)", "LOCALTIME(3)", "LOCALTIMESTAMP(3)",
+	} {
+		t.Run(input, func(t *testing.T) {
+			node := mustParseExpr(t, input)
+			fc, ok := node.(*ast.FuncCallExpr)
+			if !ok {
+				t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+			}
+			if len(fc.Args) != 1 {
+				t.Fatalf("args = %d, want 1", len(fc.Args))
+			}
+		})
+	}
+	// The bare and empty-paren forms must keep working.
+	for _, input := range []string{"CURRENT_TIMESTAMP", "CURRENT_DATE()"} {
+		node := mustParseExpr(t, input)
+		if fc, ok := node.(*ast.FuncCallExpr); !ok || len(fc.Args) != 0 {
+			t.Errorf("%s = %T with args, want a zero-arg FuncCallExpr", input, node)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Literals: hex, bit, array, map
+// ---------------------------------------------------------------------------
+
+func TestExprHexAndBitLiterals(t *testing.T) {
+	hex := mustParseExpr(t, "x'1f'")
+	if lit, ok := hex.(*ast.Literal); !ok || lit.Kind != ast.LitHex {
+		t.Errorf("x'1f' = %T (%v), want LitHex literal", hex, hex)
+	}
+	bit := mustParseExpr(t, "b'101'")
+	if lit, ok := bit.(*ast.Literal); !ok || lit.Kind != ast.LitBit {
+		t.Errorf("b'101' = %T, want LitBit literal", bit)
+	}
+}
+
+func TestExprArrayLiteral(t *testing.T) {
+	node := mustParseExpr(t, "[1, 2, 3]")
+	lit, ok := node.(*ast.ArrayLiteral)
+	if !ok {
+		t.Fatalf("expected *ast.ArrayLiteral, got %T", node)
+	}
+	if len(lit.Elements) != 3 {
+		t.Errorf("elements = %d, want 3", len(lit.Elements))
+	}
+	if empty, ok := mustParseExpr(t, "[]").(*ast.ArrayLiteral); !ok || len(empty.Elements) != 0 {
+		t.Error("[] did not parse as an empty array literal")
+	}
+}
+
+func TestExprMapLiteral(t *testing.T) {
+	node := mustParseExpr(t, "{'a': 1, 'b': 2}")
+	lit, ok := node.(*ast.MapLiteral)
+	if !ok {
+		t.Fatalf("expected *ast.MapLiteral, got %T", node)
+	}
+	if len(lit.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(lit.Entries))
+	}
+	if lit.Entries[0].Key == nil || lit.Entries[0].Value == nil {
+		t.Error("first entry has a nil key or value")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Session and user variables
+// ---------------------------------------------------------------------------
+
+func TestExprVariableRef(t *testing.T) {
+	tests := []struct {
+		input  string
+		name   string
+		scope  string
+		system bool
+	}{
+		{"@@version_comment", "version_comment", "", true},
+		{"@@session.query_timeout", "query_timeout", "SESSION", true},
+		{"@@global.query_timeout", "query_timeout", "GLOBAL", true},
+		{"@uservar", "uservar", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			node := mustParseExpr(t, tt.input)
+			v, ok := node.(*ast.VariableRef)
+			if !ok {
+				t.Fatalf("expected *ast.VariableRef, got %T", node)
+			}
+			if !strings.EqualFold(v.Name, tt.name) || v.Scope != tt.scope || v.System != tt.system {
+				t.Errorf("got {Name:%q Scope:%q System:%v}, want {%q %q %v}",
+					v.Name, v.Scope, v.System, tt.name, tt.scope, tt.system)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Lambdas
+// ---------------------------------------------------------------------------
+
+func TestExprLambdaInFunctionArg(t *testing.T) {
+	node := mustParseExpr(t, "array_map(x -> x + 1, arr)")
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if len(fc.Args) != 2 {
+		t.Fatalf("args = %d, want 2", len(fc.Args))
+	}
+	lam, ok := fc.Args[0].(*ast.LambdaExpr)
+	if !ok {
+		t.Fatalf("args[0] = %T, want *ast.LambdaExpr", fc.Args[0])
+	}
+	if len(lam.Params) != 1 || lam.Params[0] != "x" {
+		t.Errorf("params = %v, want [x]", lam.Params)
+	}
+	if _, ok := lam.Body.(*ast.BinaryExpr); !ok {
+		t.Errorf("body = %T, want *ast.BinaryExpr", lam.Body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CONVERT / USING charset / BINARY
+// ---------------------------------------------------------------------------
+
+func TestExprConvertUsing(t *testing.T) {
+	node := mustParseExpr(t, "CONVERT(s USING utf8)")
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if fc.Using != "UTF8" {
+		t.Errorf("Using = %q, want UTF8", fc.Using)
+	}
+	if len(fc.Args) != 1 {
+		t.Errorf("args = %d, want 1", len(fc.Args))
+	}
+}
+
+func TestExprConvertToType(t *testing.T) {
+	// CONVERT(expr, type) is CAST spelled differently.
+	node := mustParseExpr(t, "CONVERT(s, SIGNED)")
+	cast, ok := node.(*ast.CastExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CastExpr, got %T", node)
+	}
+	if cast.TypeName == nil || cast.TypeName.Name != "SIGNED" {
+		t.Errorf("type = %+v, want SIGNED", cast.TypeName)
+	}
+}
+
+func TestExprCharUsing(t *testing.T) {
+	node := mustParseExpr(t, "CHAR(65 USING utf8)")
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if fc.Using != "UTF8" {
+		t.Errorf("Using = %q, want UTF8", fc.Using)
+	}
+}
+
+func TestExprBinaryOperator(t *testing.T) {
+	node := mustParseExpr(t, "BINARY s")
+	un, ok := node.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.UnaryExpr, got %T", node)
+	}
+	if un.Op != ast.UnaryBinary {
+		t.Errorf("op = %v, want UnaryBinary", un.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Statement-level: optimizer hints, GROUP BY CUBE
+// ---------------------------------------------------------------------------
+
+func TestStmtOptimizerHintIsSkipped(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT /*+ SET_VAR(query_timeout = 100) */ 1",
+		"SELECT /*+ SET_VAR(a = 1) */ /* ordinary comment */ 1",
+		"SELECT /*+ SET_VAR(a = 1) */ a FROM t WHERE a > 1",
+	} {
+		file, errs := Parse(sql)
+		if len(errs) > 0 {
+			t.Errorf("Parse(%q) errors: %v", sql, errs)
+			continue
+		}
+		if len(file.Stmts) != 1 {
+			t.Errorf("Parse(%q) produced %d statements, want 1", sql, len(file.Stmts))
+		}
+	}
+}
+
+func TestStmtGroupByCube(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT a, SUM(b) FROM t GROUP BY CUBE(a)",
+		"SELECT a, SUM(b) FROM t GROUP BY CUBE(a, c)",
+		"SELECT a, SUM(b) FROM t GROUP BY ROLLUP(a)",
+		"SELECT a, SUM(b) FROM t GROUP BY GROUPING SETS ((a), ())",
+	} {
+		if _, errs := Parse(sql); len(errs) > 0 {
+			t.Errorf("Parse(%q) errors: %v", sql, errs)
+		}
 	}
 }

--- a/doris/parser/parser.go
+++ b/doris/parser/parser.go
@@ -57,6 +57,46 @@ func (p *Parser) advance() Token {
 	return p.prev
 }
 
+// parserCheckpoint snapshots the parser + lexer position so a speculative parse
+// can be rolled back. It is a bounded backtracking primitive for prefix-
+// ambiguous grammar — `(x, y) -> ...` is a lambda parameter list, `(x + y)` is
+// a parenthesized expression, and the two are only told apart at the arrow.
+// It is NOT safe across input-rewriting lexer paths (conditional comments),
+// which do not occur inside the constructs it is used for.
+type parserCheckpoint struct {
+	cur, prev, nextBuf Token
+	hasNext            bool
+	lexPos, lexStart   int
+	errLen, lexErrLen  int
+}
+
+// save captures the current parser state.
+func (p *Parser) save() parserCheckpoint {
+	return parserCheckpoint{
+		cur:       p.cur,
+		prev:      p.prev,
+		nextBuf:   p.nextBuf,
+		hasNext:   p.hasNext,
+		lexPos:    p.lexer.pos,
+		lexStart:  p.lexer.start,
+		errLen:    len(p.errors),
+		lexErrLen: len(p.lexer.errors),
+	}
+}
+
+// restore rolls the parser + lexer back to a saved checkpoint, discarding any
+// tokens consumed and errors collected since.
+func (p *Parser) restore(c parserCheckpoint) {
+	p.cur = c.cur
+	p.prev = c.prev
+	p.nextBuf = c.nextBuf
+	p.hasNext = c.hasNext
+	p.lexer.pos = c.lexPos
+	p.lexer.start = c.lexStart
+	p.errors = p.errors[:c.errLen]
+	p.lexer.errors = p.lexer.errors[:c.lexErrLen]
+}
+
 // peek returns the current token without consuming it.
 func (p *Parser) peek() Token {
 	return p.cur

--- a/doris/parser/parser.go
+++ b/doris/parser/parser.go
@@ -26,6 +26,24 @@ type Parser struct {
 	errors     []ParseError // collected errors for best-effort mode
 }
 
+// nextToken returns the next token from the lexer, transparently skipping
+// optimizer-hint spans (/*+ ... */). Hints carry no syntax of their own that
+// any production needs to see, so skipping them here keeps every production
+// hint-agnostic instead of threading an optional hint through each one.
+func (p *Parser) nextToken() Token {
+	tok := p.lexer.NextToken()
+	for tok.Kind == tokHintStart {
+		for tok.Kind != tokHintEnd && tok.Kind != tokEOF {
+			tok = p.lexer.NextToken()
+		}
+		if tok.Kind == tokEOF {
+			return tok
+		}
+		tok = p.lexer.NextToken()
+	}
+	return tok
+}
+
 // advance consumes the current token and moves to the next one.
 // Returns the token that was just consumed (the new "previous" token).
 func (p *Parser) advance() Token {
@@ -34,7 +52,7 @@ func (p *Parser) advance() Token {
 		p.cur = p.nextBuf
 		p.hasNext = false
 	} else {
-		p.cur = p.lexer.NextToken()
+		p.cur = p.nextToken()
 	}
 	return p.prev
 }
@@ -49,7 +67,7 @@ func (p *Parser) peek() Token {
 // token following the current position.
 func (p *Parser) peekNext() Token {
 	if !p.hasNext {
-		p.nextBuf = p.lexer.NextToken()
+		p.nextBuf = p.nextToken()
 		p.hasNext = true
 	}
 	return p.nextBuf

--- a/doris/parser/select.go
+++ b/doris/parser/select.go
@@ -838,6 +838,13 @@ func (p *Parser) parseGroupByClause() ([]ast.Node, error) {
 		if err != nil {
 			return nil, err
 		}
+		// CUBE(...) is the entire grouping specification — the engine rejects
+		// both `GROUP BY CUBE(a), b` and `GROUP BY CUBE(a), CUBE(b)`. Without
+		// this check, returning here would silently discard everything after
+		// the comma and hand downstream analysis an incomplete GROUP BY.
+		if p.cur.Kind == int(',') {
+			return nil, p.syntaxErrorAtCur()
+		}
 		return []ast.Node{fc}, nil
 	}
 

--- a/doris/parser/select.go
+++ b/doris/parser/select.go
@@ -831,6 +831,16 @@ func (p *Parser) parseGroupByClause() ([]ast.Node, error) {
 		return nil, err
 	}
 
+	// CUBE is a reserved keyword, so `GROUP BY CUBE(a, b)` cannot reach the
+	// ordinary expression path the way ROLLUP and GROUPING SETS do.
+	if p.cur.Kind == kwCUBE && p.peekNext().Kind == int('(') {
+		fc, err := p.parseGroupingElementCall()
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Node{fc}, nil
+	}
+
 	return p.parseExprList()
 }
 

--- a/starrocks/analysis/query_span.go
+++ b/starrocks/analysis/query_span.go
@@ -467,11 +467,36 @@ func renderColumnName(expr ast.Node) string {
 
 // collectColumnRefs returns every ColumnRef directly mentioned in expr.
 func collectColumnRefs(expr ast.Node) []ColumnRef {
+	return collectColumnRefsScoped(expr, nil)
+}
+
+// collectColumnRefsScoped collects direct column references, skipping any name
+// bound by an enclosing lambda. In array_map(x -> x + bonus, scores) the
+// parameter x is local to the lambda and is not a column of any table, so
+// reporting it would feed a nonexistent column into lineage and masking.
+func collectColumnRefsScoped(expr ast.Node, bound map[string]bool) []ColumnRef {
 	var refs []ColumnRef
 	ast.Inspect(expr, func(n ast.Node) bool {
 		switch node := n.(type) {
+		case *ast.LambdaExpr:
+			// Inspect has no post-order hook to pop a scope with, so recurse
+			// into the body with the widened binding set instead.
+			inner := make(map[string]bool, len(bound)+len(node.Params))
+			for name := range bound {
+				inner[name] = true
+			}
+			for _, param := range node.Params {
+				inner[strings.ToLower(param)] = true
+			}
+			refs = append(refs, collectColumnRefsScoped(node.Body, inner)...)
+			return false
 		case *ast.ColumnRef:
 			if node.Name == nil || len(node.Name.Parts) == 0 {
+				return false
+			}
+			// Only an unqualified name can be a lambda parameter; `t.x` is a
+			// column even when a parameter happens to be called x.
+			if len(node.Name.Parts) == 1 && bound[strings.ToLower(node.Name.Parts[0])] {
 				return false
 			}
 			refs = append(refs, columnRefFromObjectName(node.Name))

--- a/starrocks/analysis/query_span_test.go
+++ b/starrocks/analysis/query_span_test.go
@@ -493,3 +493,49 @@ func TestGetQuerySpan_IntersectOuterOrderBySubquery(t *testing.T) {
 		}
 	}
 }
+
+func TestGetQuerySpan_ExtractSourceColumns(t *testing.T) {
+	// EXTRACT(unit FROM col) must expose col as a source column so masking and
+	// lineage see through the expression.
+	span, err := GetQuerySpan("SELECT EXTRACT(YEAR FROM created_at) AS y FROM t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.Results) != 1 {
+		t.Fatalf("Results len = %d, want 1 (%+v)", len(span.Results), span.Results)
+	}
+	r := span.Results[0]
+	if r.Name != "y" {
+		t.Errorf("Results[0].Name = %q, want y", r.Name)
+	}
+	want := []ColumnRef{{Column: "created_at"}}
+	if len(r.SourceColumns) != len(want) {
+		t.Fatalf("SourceColumns = %+v, want %+v", r.SourceColumns, want)
+	}
+	for i, w := range want {
+		if r.SourceColumns[i] != w {
+			t.Errorf("SourceColumns[%d] = %+v, want %+v", i, r.SourceColumns[i], w)
+		}
+	}
+}
+
+func TestGetQuerySpan_LambdaAndArraySourceColumns(t *testing.T) {
+	// Columns referenced inside a lambda body and inside an array literal must
+	// still reach lineage — the walker has to descend into both node types.
+	span, err := GetQuerySpan("SELECT array_map(x -> x + bonus, scores) AS adj FROM t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.Results) != 1 {
+		t.Fatalf("Results len = %d, want 1 (%+v)", len(span.Results), span.Results)
+	}
+	got := map[string]bool{}
+	for _, sc := range span.Results[0].SourceColumns {
+		got[sc.Column] = true
+	}
+	for _, want := range []string{"bonus", "scores"} {
+		if !got[want] {
+			t.Errorf("SourceColumns %+v missing %q", span.Results[0].SourceColumns, want)
+		}
+	}
+}

--- a/starrocks/analysis/query_span_test.go
+++ b/starrocks/analysis/query_span_test.go
@@ -519,23 +519,57 @@ func TestGetQuerySpan_ExtractSourceColumns(t *testing.T) {
 	}
 }
 
-func TestGetQuerySpan_LambdaAndArraySourceColumns(t *testing.T) {
-	// Columns referenced inside a lambda body and inside an array literal must
-	// still reach lineage — the walker has to descend into both node types.
-	span, err := GetQuerySpan("SELECT array_map(x -> x + bonus, scores) AS adj FROM t")
-	if err != nil {
-		t.Fatalf("GetQuerySpan returned error: %v", err)
+func TestGetQuerySpan_LambdaSourceColumns(t *testing.T) {
+	// Columns referenced inside a lambda body must reach lineage, but the
+	// lambda's own parameters must not: they are local bindings, not columns,
+	// and reporting one would feed a nonexistent column to masking.
+	tests := []struct {
+		name    string
+		sql     string
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "single parameter",
+			sql:     "SELECT array_map(x -> x + bonus, scores) AS adj FROM t",
+			want:    []string{"bonus", "scores"},
+			notWant: []string{"x"},
+		},
+		{
+			name:    "multiple parameters",
+			sql:     "SELECT array_map((x, y) -> x + y + bonus, a, b) AS adj FROM t",
+			want:    []string{"bonus", "a", "b"},
+			notWant: []string{"x", "y"},
+		},
+		{
+			name: "qualified name is a column even when it shadows a parameter",
+			sql:  "SELECT array_map(x -> t.x + bonus, scores) AS adj FROM t",
+			want: []string{"x", "bonus", "scores"},
+		},
 	}
-	if len(span.Results) != 1 {
-		t.Fatalf("Results len = %d, want 1 (%+v)", len(span.Results), span.Results)
-	}
-	got := map[string]bool{}
-	for _, sc := range span.Results[0].SourceColumns {
-		got[sc.Column] = true
-	}
-	for _, want := range []string{"bonus", "scores"} {
-		if !got[want] {
-			t.Errorf("SourceColumns %+v missing %q", span.Results[0].SourceColumns, want)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			span, err := GetQuerySpan(tt.sql)
+			if err != nil {
+				t.Fatalf("GetQuerySpan returned error: %v", err)
+			}
+			if len(span.Results) != 1 {
+				t.Fatalf("Results len = %d, want 1 (%+v)", len(span.Results), span.Results)
+			}
+			got := map[string]bool{}
+			for _, sc := range span.Results[0].SourceColumns {
+				got[sc.Column] = true
+			}
+			for _, want := range tt.want {
+				if !got[want] {
+					t.Errorf("SourceColumns %+v missing %q", span.Results[0].SourceColumns, want)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if got[notWant] {
+					t.Errorf("SourceColumns %+v contains lambda parameter %q", span.Results[0].SourceColumns, notWant)
+				}
+			}
+		})
 	}
 }

--- a/starrocks/ast/exprnodes.go
+++ b/starrocks/ast/exprnodes.go
@@ -238,6 +238,7 @@ type FuncCallExpr struct {
 	Star     bool   // COUNT(*)
 	OrderBy  []*OrderByItem // optional ORDER BY in aggregate (GROUP_CONCAT)
 	Separator string // optional SEPARATOR value for GROUP_CONCAT
+	Using     string // optional USING charset, as in CONVERT(x USING utf8)
 	IgnoreNulls bool // IGNORE NULLS null-treatment (FIRST_VALUE/LAST_VALUE/LEAD/LAG)
 	Over     *WindowSpec // optional OVER (...) window specification
 	Loc      Loc
@@ -289,6 +290,47 @@ type CastExpr struct {
 func (n *CastExpr) Tag() NodeTag { return T_CastExpr }
 
 var _ Node = (*CastExpr)(nil)
+
+// ExtractExpr represents EXTRACT(unit FROM expr).
+//
+// The grammar takes the unit as an identifier
+// (EXTRACT '(' field=identifier FROM source=valueExpression ')'), so Unit holds
+// the upper-cased source text rather than a closed enum.
+type ExtractExpr struct {
+	Expr Node
+	Unit string // e.g., "YEAR", "MONTH", "DAY_HOUR"
+	Loc  Loc
+}
+
+func (n *ExtractExpr) Tag() NodeTag { return T_ExtractExpr }
+
+var _ Node = (*ExtractExpr)(nil)
+
+// VariableRef represents a system variable (@@name, @@session.name,
+// @@global.name) or a user-defined variable (@name). It is deliberately not a
+// ColumnRef so that lineage and masking do not mistake it for a column.
+type VariableRef struct {
+	Name   string // variable name, without the @/@@ prefix and scope qualifier
+	Scope  string // "SESSION" or "GLOBAL"; empty when unqualified
+	System bool   // true for @@ (system) variables, false for @ (user) variables
+	Loc    Loc
+}
+
+func (n *VariableRef) Tag() NodeTag { return T_VariableRef }
+
+var _ Node = (*VariableRef)(nil)
+
+// LambdaExpr represents a lambda passed to a higher-order array function:
+// `x -> x + 1` or `(x, y) -> x + y`.
+type LambdaExpr struct {
+	Params []string
+	Body   Node
+	Loc    Loc
+}
+
+func (n *LambdaExpr) Tag() NodeTag { return T_LambdaExpr }
+
+var _ Node = (*LambdaExpr)(nil)
 
 // CaseExpr represents CASE [operand] WHEN...THEN...ELSE...END.
 type CaseExpr struct {

--- a/starrocks/ast/exprnodes.go
+++ b/starrocks/ast/exprnodes.go
@@ -238,7 +238,6 @@ type FuncCallExpr struct {
 	Star     bool   // COUNT(*)
 	OrderBy  []*OrderByItem // optional ORDER BY in aggregate (GROUP_CONCAT)
 	Separator string // optional SEPARATOR value for GROUP_CONCAT
-	Using     string // optional USING charset, as in CONVERT(x USING utf8)
 	IgnoreNulls bool // IGNORE NULLS null-treatment (FIRST_VALUE/LAST_VALUE/LEAD/LAG)
 	Over     *WindowSpec // optional OVER (...) window specification
 	Loc      Loc

--- a/starrocks/ast/loc.go
+++ b/starrocks/ast/loc.go
@@ -54,6 +54,12 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *CastExpr:
 		return v.Loc
+	case *ExtractExpr:
+		return v.Loc
+	case *VariableRef:
+		return v.Loc
+	case *LambdaExpr:
+		return v.Loc
 	case *CaseExpr:
 		return v.Loc
 	case *WhenClause:

--- a/starrocks/ast/nodetags.go
+++ b/starrocks/ast/nodetags.go
@@ -86,6 +86,15 @@ const (
 	// T_CastExpr is the tag for *CastExpr (CAST/TRY_CAST).
 	T_CastExpr
 
+	// T_ExtractExpr is the tag for *ExtractExpr (EXTRACT(unit FROM expr)).
+	T_ExtractExpr
+
+	// T_VariableRef is the tag for *VariableRef (@@var / @var).
+	T_VariableRef
+
+	// T_LambdaExpr is the tag for *LambdaExpr (x -> body).
+	T_LambdaExpr
+
 	// T_CaseExpr is the tag for *CaseExpr (CASE...END).
 	T_CaseExpr
 
@@ -671,6 +680,12 @@ func (t NodeTag) String() string {
 		return "FuncCallExpr"
 	case T_CastExpr:
 		return "CastExpr"
+	case T_ExtractExpr:
+		return "ExtractExpr"
+	case T_VariableRef:
+		return "VariableRef"
+	case T_LambdaExpr:
+		return "LambdaExpr"
 	case T_CaseExpr:
 		return "CaseExpr"
 	case T_WhenClause:

--- a/starrocks/ast/walk_children.go
+++ b/starrocks/ast/walk_children.go
@@ -103,6 +103,12 @@ func walkChildren(v Visitor, node Node) {
 	case *CastExpr:
 		Walk(v, n.Expr)
 		Walk(v, n.TypeName)
+	case *ExtractExpr:
+		Walk(v, n.Expr)
+	case *VariableRef:
+		// leaf
+	case *LambdaExpr:
+		Walk(v, n.Body)
 	case *CaseExpr:
 		if n.Operand != nil {
 			Walk(v, n.Operand)

--- a/starrocks/parser/expr.go
+++ b/starrocks/parser/expr.go
@@ -664,9 +664,12 @@ func (p *Parser) parseFuncCall(name *ast.ObjectName) (*ast.FuncCallExpr, error) 
 			}
 		}
 
-		// Trailing USING charset, as in CHAR(65 USING utf8). parseExprList
-		// stops at USING because it is not a comma, so it is consumed here.
-		if p.cur.Kind == kwUSING {
+		// Trailing USING charset, as in CHAR(65 USING utf8): the argument
+		// parser stops at USING because it is not a comma. Only CHAR takes it
+		// on this generic path — CONVERT has its own production, and the engine
+		// rejects the clause on anything else (`SUM(a USING utf8)` is a syntax
+		// error), so it must not be consumed for arbitrary function names.
+		if funcName == "CHAR" && p.cur.Kind == kwUSING {
 			p.advance() // consume USING
 			charset, ok := p.identOrKeywordToken()
 			if !ok {
@@ -909,6 +912,57 @@ func (p *Parser) parseWindowFrameBound() (string, ast.Node, error) {
 	}
 }
 
+// tryParseParenLambda speculatively parses the parenthesized multi-parameter
+// lambda form `(x, y) -> body`, rolling the parser back and reporting ok=false
+// when the input turns out to be an ordinary parenthesized expression.
+//
+// The grammar requires at least two parameters in this form; a single
+// parameter must be written bare (`x -> ...`), and the engine rejects
+// `(x) -> ...`. That is why len(params) < 2 backtracks rather than accepting.
+func (p *Parser) tryParseParenLambda() (ast.Node, bool, error) {
+	if p.cur.Kind != int('(') {
+		return nil, false, nil
+	}
+	saved := p.save()
+	start := p.cur.Loc.Start
+	p.advance() // consume '('
+
+	var params []string
+	for {
+		if !p.isExprIdentToken() {
+			p.restore(saved)
+			return nil, false, nil
+		}
+		params = append(params, p.advance().Str)
+		if p.cur.Kind != int(',') {
+			break
+		}
+		p.advance() // consume ','
+	}
+	if len(params) < 2 || p.cur.Kind != int(')') {
+		p.restore(saved)
+		return nil, false, nil
+	}
+	p.advance() // consume ')'
+	if p.cur.Kind != tokArrow {
+		p.restore(saved)
+		return nil, false, nil
+	}
+	p.advance() // consume '->'
+
+	// Past the arrow the shape is unambiguous, so a bad body is a real error
+	// rather than a reason to backtrack.
+	body, err := p.parseExpr()
+	if err != nil {
+		return nil, false, err
+	}
+	return &ast.LambdaExpr{
+		Params: params,
+		Body:   body,
+		Loc:    ast.Loc{Start: start, End: ast.NodeLoc(body).End},
+	}, true, nil
+}
+
 // parseFuncArgList parses a function-call argument list. Unlike a plain
 // expression list it also accepts a lambda (`x -> body`), which the grammar
 // permits only here, as an argument to a higher-order array function. Keeping
@@ -917,17 +971,23 @@ func (p *Parser) parseWindowFrameBound() (string, ast.Node, error) {
 func (p *Parser) parseFuncArgList() ([]ast.Node, error) {
 	var list []ast.Node
 	for {
-		expr, err := p.parseExpr()
+		lam, ok, err := p.tryParseParenLambda()
 		if err != nil {
 			return nil, err
 		}
-		if p.cur.Kind == tokArrow {
-			expr, err = p.parseLambdaExpr(expr)
+		if !ok {
+			lam, err = p.parseExpr()
 			if err != nil {
 				return nil, err
 			}
+			if p.cur.Kind == tokArrow {
+				lam, err = p.parseLambdaExpr(lam)
+				if err != nil {
+					return nil, err
+				}
+			}
 		}
-		list = append(list, expr)
+		list = append(list, lam)
 		if p.cur.Kind != int(',') {
 			break
 		}
@@ -1270,11 +1330,6 @@ func lambdaParams(n ast.Node) ([]string, bool) {
 			return nil, false
 		}
 		return []string{v.Name.Parts[0]}, true
-	case *ast.ParenExpr:
-		// `(x) -> ...`. The multi-parameter form `(x, y) -> ...` is not
-		// supported: a parenthesized list is not an expression here, so the
-		// parameters never reach this point as a single node.
-		return lambdaParams(v.Expr)
 	}
 	return nil, false
 }

--- a/starrocks/parser/expr.go
+++ b/starrocks/parser/expr.go
@@ -413,6 +413,10 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 		}
 		return p.parseIdentExpr()
 
+	case int('{'):
+		// Untyped map constructor: { k: v, ... }.
+		return p.finishMapLiteral(p.cur.Loc.Start, nil)
+
 	case int('['):
 		// Untyped array constructor: [ e, ... ].
 		return p.finishArrayLiteral(p.cur.Loc.Start, nil)
@@ -426,11 +430,27 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 	case kwTRY_CAST:
 		return p.parseCastExpr(true)
 
+	case kwCONVERT:
+		// CONVERT is non-reserved, so only treat it specially when applied.
+		if p.peekNext().Kind == int('(') {
+			return p.parseConvertExpr()
+		}
+		return p.parseIdentExpr()
+
+	case kwEXTRACT:
+		return p.parseExtractExpr()
+
 	// Nilary functions: CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP,
 	// CURRENT_USER, SESSION_USER, LOCALTIME, LOCALTIMESTAMP.
 	case kwCURRENT_DATE, kwCURRENT_TIME, kwCURRENT_TIMESTAMP,
 		kwCURRENT_USER, kwSESSION_USER, kwLOCALTIME, kwLOCALTIMESTAMP:
 		return p.parseNilaryFunction()
+
+	case tokDoubleAt:
+		return p.parseVariableRef(true)
+
+	case int('@'):
+		return p.parseVariableRef(false)
 
 	case tokPlaceholder:
 		tok := p.advance()
@@ -441,6 +461,15 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 		}, nil
 
 	default:
+		// A reserved keyword that the grammar still allows as a function name,
+		// but only when it is immediately applied: `TRIM(s)` is a call,
+		// `LEFT JOIN` is not.
+		if isFunctionNameKeyword(p.cur.Kind) && p.peekNext().Kind == int('(') {
+			tok := p.advance()
+			name := &ast.ObjectName{Parts: []string{strings.ToUpper(tok.Str)}, Loc: tok.Loc}
+			return p.parseFuncCall(name)
+		}
+
 		// Identifier-based: column ref or function call.
 		if p.isExprIdentToken() {
 			return p.parseIdentExpr()
@@ -448,6 +477,20 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 
 		return nil, p.syntaxErrorAtCur()
 	}
+}
+
+// isFunctionNameKeyword reports whether kind is a reserved keyword that is
+// nonetheless usable as a function name. It mirrors the grammar's
+// functionNameIdentifier rule; without it `IF(a,1,2)`, `LEFT(s,2)`, `TRIM(s)`
+// and `DATABASE()` all fail to parse even though the engine accepts them.
+func isFunctionNameKeyword(kind TokenKind) bool {
+	switch kind {
+	case kwADD, kwCONNECTION_ID, kwCURRENT_CATALOG, kwCURRENT_USER, kwDATABASE,
+		kwIF, kwLEFT, kwLIKE, kwPASSWORD, kwREGEXP, kwRIGHT, kwSCHEMA,
+		kwSESSION_USER, kwTRIM, kwUSER:
+		return true
+	}
+	return false
 }
 
 // isExprIdentToken reports whether the current token is usable as an identifier
@@ -599,7 +642,7 @@ func (p *Parser) parseFuncCall(name *ast.ObjectName) (*ast.FuncCallExpr, error) 
 	}
 
 	if p.cur.Kind != int(')') {
-		args, err := p.parseExprList()
+		args, err := p.parseFuncArgList()
 		if err != nil {
 			return nil, err
 		}
@@ -619,6 +662,17 @@ func (p *Parser) parseFuncCall(name *ast.ObjectName) (*ast.FuncCallExpr, error) 
 				}
 				fc.Args = append(fc.Args, arg)
 			}
+		}
+
+		// Trailing USING charset, as in CHAR(65 USING utf8). parseExprList
+		// stops at USING because it is not a comma, so it is consumed here.
+		if p.cur.Kind == kwUSING {
+			p.advance() // consume USING
+			charset, ok := p.identOrKeywordToken()
+			if !ok {
+				return nil, p.syntaxErrorAtCur()
+			}
+			fc.Using = strings.ToUpper(charset.Str)
 		}
 
 		// Optional ORDER BY within aggregate functions (e.g., GROUP_CONCAT)
@@ -853,6 +907,33 @@ func (p *Parser) parseWindowFrameBound() (string, ast.Node, error) {
 			return "", nil, &ParseError{Loc: p.cur.Loc, Msg: "expected PRECEDING or FOLLOWING in window frame bound"}
 		}
 	}
+}
+
+// parseFuncArgList parses a function-call argument list. Unlike a plain
+// expression list it also accepts a lambda (`x -> body`), which the grammar
+// permits only here, as an argument to a higher-order array function. Keeping
+// lambdas scoped to this position means a stray `->` anywhere else stays a
+// syntax error — matching the engine, which has no `->` JSON operator.
+func (p *Parser) parseFuncArgList() ([]ast.Node, error) {
+	var list []ast.Node
+	for {
+		expr, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if p.cur.Kind == tokArrow {
+			expr, err = p.parseLambdaExpr(expr)
+			if err != nil {
+				return nil, err
+			}
+		}
+		list = append(list, expr)
+		if p.cur.Kind != int(',') {
+			break
+		}
+		p.advance() // consume ','
+	}
+	return list, nil
 }
 
 // parseExprList parses a comma-separated list of expressions.
@@ -1101,6 +1182,222 @@ func (p *Parser) parseCastExpr(tryCast bool) (*ast.CastExpr, error) {
 	}, nil
 }
 
+// parseExtractExpr parses EXTRACT(unit FROM expr).
+//
+// EXTRACT is a reserved keyword, so without a production for it the whole
+// statement fails to parse at the EXTRACT token.
+func (p *Parser) parseExtractExpr() (ast.Node, error) {
+	extractTok := p.advance() // consume EXTRACT
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	unit, err := p.parseExtractUnit()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(kwFROM); err != nil {
+		return nil, err
+	}
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &ast.ExtractExpr{
+		Expr: expr,
+		Unit: unit,
+		Loc:  ast.Loc{Start: extractTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseExtractUnit parses the unit of EXTRACT(unit FROM expr).
+//
+// The grammar takes an identifier, which covers plain identifiers (DAYOFWEEK,
+// DOY, ...) and the non-reserved unit keywords (YEAR, MONTH, WEEK, ...). The
+// compound units DAY_HOUR, DAY_SECOND and MINUTE_SECOND lex as reserved
+// keywords, so they are accepted explicitly.
+func (p *Parser) parseExtractUnit() (string, error) {
+	switch p.cur.Kind {
+	case kwDAY_HOUR, kwDAY_SECOND, kwMINUTE_SECOND:
+		tok := p.advance()
+		return strings.ToUpper(tok.Str), nil
+	default:
+		if p.isExprIdentToken() {
+			tok := p.advance()
+			return strings.ToUpper(tok.Str), nil
+		}
+		return "", &ParseError{
+			Loc: p.cur.Loc,
+			Msg: fmt.Sprintf("expected EXTRACT unit, got %q", p.cur.Str),
+		}
+	}
+}
+
+// parseLambdaExpr parses `params -> body`, given the already-parsed expression
+// to the left of the arrow.
+func (p *Parser) parseLambdaExpr(left ast.Node) (ast.Node, error) {
+	arrowTok := p.advance() // consume '->'
+
+	params, ok := lambdaParams(left)
+	if !ok {
+		return nil, &ParseError{
+			Loc: arrowTok.Loc,
+			Msg: "invalid lambda parameter list before '->'",
+		}
+	}
+	body, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return &ast.LambdaExpr{
+		Params: params,
+		Body:   body,
+		Loc:    ast.Loc{Start: ast.NodeLoc(left).Start, End: ast.NodeLoc(body).End},
+	}, nil
+}
+
+// lambdaParams extracts parameter names from the expression left of '->'. The
+// parameters parse as ordinary column references (`x`, or `(x, y)` as a
+// parenthesized row), so they are reinterpreted here rather than lexed
+// specially.
+func lambdaParams(n ast.Node) ([]string, bool) {
+	switch v := n.(type) {
+	case *ast.ColumnRef:
+		if v.Name == nil || len(v.Name.Parts) != 1 {
+			return nil, false
+		}
+		return []string{v.Name.Parts[0]}, true
+	case *ast.ParenExpr:
+		// `(x) -> ...`. The multi-parameter form `(x, y) -> ...` is not
+		// supported: a parenthesized list is not an expression here, so the
+		// parameters never reach this point as a single node.
+		return lambdaParams(v.Expr)
+	}
+	return nil, false
+}
+
+// parseGroupingElementCall parses a reserved-keyword grouping element such as
+// CUBE(a, b) as a function call, keeping GROUP BY items uniform with ROLLUP and
+// GROUPING SETS (both non-reserved, so they already take the expression path).
+func (p *Parser) parseGroupingElementCall() (*ast.FuncCallExpr, error) {
+	tok := p.advance()
+	name := &ast.ObjectName{Parts: []string{strings.ToUpper(tok.Str)}, Loc: tok.Loc}
+	return p.parseFuncCall(name)
+}
+
+// parseConvertExpr parses the two CONVERT forms:
+//
+//	CONVERT(expr USING charset)  -- transcoding; kept as a CONVERT call
+//	CONVERT(expr, type)          -- CAST spelled differently, so it becomes a CastExpr
+func (p *Parser) parseConvertExpr() (ast.Node, error) {
+	convertTok := p.advance() // consume CONVERT
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.cur.Kind == kwUSING {
+		p.advance() // consume USING
+		charset, ok := p.identOrKeywordToken()
+		if !ok {
+			return nil, p.syntaxErrorAtCur()
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		return &ast.FuncCallExpr{
+			Name:  &ast.ObjectName{Parts: []string{"CONVERT"}, Loc: convertTok.Loc},
+			Args:  []ast.Node{expr},
+			Using: strings.ToUpper(charset.Str),
+			Loc:   ast.Loc{Start: convertTok.Loc.Start, End: closeTok.Loc.End},
+		}, nil
+	}
+
+	if _, err := p.expect(int(',')); err != nil {
+		return nil, err
+	}
+	typeName, err := p.parseConvertTargetType()
+	if err != nil {
+		return nil, err
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	return &ast.CastExpr{
+		Expr:     expr,
+		TypeName: typeName,
+		Loc:      ast.Loc{Start: convertTok.Loc.Start, End: closeTok.Loc.End},
+	}, nil
+}
+
+// parseConvertTargetType parses the target type of CONVERT(expr, type). It
+// additionally accepts SIGNED / UNSIGNED [INTEGER], which are cast-only type
+// names rather than column types and so are unknown to parseDataType.
+func (p *Parser) parseConvertTargetType() (*ast.TypeName, error) {
+	switch p.cur.Kind {
+	case kwSIGNED, kwUNSIGNED:
+		tok := p.advance()
+		tn := &ast.TypeName{Name: strings.ToUpper(tok.Str), Loc: tok.Loc}
+		if p.cur.Kind == kwINTEGER || p.cur.Kind == kwINT {
+			end := p.advance()
+			tn.Loc.End = end.Loc.End
+		}
+		return tn, nil
+	}
+	return p.parseDataType()
+}
+
+// parseVariableRef parses a system variable (@@name, @@scope.name) or a
+// user-defined variable (@name).
+func (p *Parser) parseVariableRef(system bool) (ast.Node, error) {
+	atTok := p.advance() // consume '@@' or '@'
+
+	first, ok := p.identOrKeywordToken()
+	if !ok {
+		return nil, p.syntaxErrorAtCur()
+	}
+	v := &ast.VariableRef{
+		System: system,
+		Name:   first.Str,
+		Loc:    ast.Loc{Start: atTok.Loc.Start, End: first.Loc.End},
+	}
+	// @@session.x / @@global.x — the scope qualifier only exists for system
+	// variables.
+	if system && p.cur.Kind == int('.') {
+		p.advance() // consume '.'
+		second, ok := p.identOrKeywordToken()
+		if !ok {
+			return nil, p.syntaxErrorAtCur()
+		}
+		v.Scope = strings.ToUpper(v.Name)
+		v.Name = second.Str
+		v.Loc.End = second.Loc.End
+	}
+	return v, nil
+}
+
+// identOrKeywordToken accepts any identifier- or keyword-shaped token, for
+// positions where there is no ambiguity: after an @ / @@ prefix, or after
+// USING. Scope names (SESSION, GLOBAL), charset names and many variable names
+// are themselves keywords.
+func (p *Parser) identOrKeywordToken() (Token, bool) {
+	switch {
+	case p.cur.Kind == tokIdent || p.cur.Kind == tokQuotedIdent:
+		return p.advance(), true
+	case p.cur.Kind >= 700: // any keyword
+		return p.advance(), true
+	}
+	return Token{}, false
+}
+
 // parseNilaryFunction parses zero-argument keyword functions like
 // CURRENT_DATE, CURRENT_TIMESTAMP, etc.
 func (p *Parser) parseNilaryFunction() (ast.Node, error) {
@@ -1118,6 +1415,14 @@ func (p *Parser) parseNilaryFunction() (ast.Node, error) {
 	}
 	if p.cur.Kind == int('(') {
 		p.advance() // consume '('
+		// Optional fractional-seconds precision: CURRENT_TIMESTAMP(3).
+		if p.cur.Kind != int(')') {
+			args, err := p.parseExprList()
+			if err != nil {
+				return nil, err
+			}
+			fc.Args = args
+		}
 		closeTok, err := p.expect(int(')'))
 		if err != nil {
 			return nil, err

--- a/starrocks/parser/expr.go
+++ b/starrocks/parser/expr.go
@@ -413,10 +413,6 @@ func (p *Parser) parsePrimaryExpr() (ast.Node, error) {
 		}
 		return p.parseIdentExpr()
 
-	case int('{'):
-		// Untyped map constructor: { k: v, ... }.
-		return p.finishMapLiteral(p.cur.Loc.Start, nil)
-
 	case int('['):
 		// Untyped array constructor: [ e, ... ].
 		return p.finishArrayLiteral(p.cur.Loc.Start, nil)
@@ -662,20 +658,6 @@ func (p *Parser) parseFuncCall(name *ast.ObjectName) (*ast.FuncCallExpr, error) 
 				}
 				fc.Args = append(fc.Args, arg)
 			}
-		}
-
-		// Trailing USING charset, as in CHAR(65 USING utf8): the argument
-		// parser stops at USING because it is not a comma. Only CHAR takes it
-		// on this generic path — CONVERT has its own production, and the engine
-		// rejects the clause on anything else (`SUM(a USING utf8)` is a syntax
-		// error), so it must not be consumed for arbitrary function names.
-		if funcName == "CHAR" && p.cur.Kind == kwUSING {
-			p.advance() // consume USING
-			charset, ok := p.identOrKeywordToken()
-			if !ok {
-				return nil, p.syntaxErrorAtCur()
-			}
-			fc.Using = strings.ToUpper(charset.Str)
 		}
 
 		// Optional ORDER BY within aggregate functions (e.g., GROUP_CONCAT)
@@ -1330,6 +1312,10 @@ func lambdaParams(n ast.Node) ([]string, bool) {
 			return nil, false
 		}
 		return []string{v.Name.Parts[0]}, true
+	case *ast.ParenExpr:
+		// `(x) -> ...`. Unlike Doris, this engine accepts the parenthesized
+		// form with a single parameter as well as the bare one.
+		return lambdaParams(v.Expr)
 	}
 	return nil, false
 }
@@ -1343,10 +1329,9 @@ func (p *Parser) parseGroupingElementCall() (*ast.FuncCallExpr, error) {
 	return p.parseFuncCall(name)
 }
 
-// parseConvertExpr parses the two CONVERT forms:
-//
-//	CONVERT(expr USING charset)  -- transcoding; kept as a CONVERT call
-//	CONVERT(expr, type)          -- CAST spelled differently, so it becomes a CastExpr
+// parseConvertExpr parses CONVERT(expr, type), which is CAST spelled
+// differently and so becomes a CastExpr. The transcoding form
+// CONVERT(expr USING charset) is not accepted by this engine.
 func (p *Parser) parseConvertExpr() (ast.Node, error) {
 	convertTok := p.advance() // consume CONVERT
 	if _, err := p.expect(int('(')); err != nil {
@@ -1355,24 +1340,6 @@ func (p *Parser) parseConvertExpr() (ast.Node, error) {
 	expr, err := p.parseExpr()
 	if err != nil {
 		return nil, err
-	}
-
-	if p.cur.Kind == kwUSING {
-		p.advance() // consume USING
-		charset, ok := p.identOrKeywordToken()
-		if !ok {
-			return nil, p.syntaxErrorAtCur()
-		}
-		closeTok, err := p.expect(int(')'))
-		if err != nil {
-			return nil, err
-		}
-		return &ast.FuncCallExpr{
-			Name:  &ast.ObjectName{Parts: []string{"CONVERT"}, Loc: convertTok.Loc},
-			Args:  []ast.Node{expr},
-			Using: strings.ToUpper(charset.Str),
-			Loc:   ast.Loc{Start: convertTok.Loc.Start, End: closeTok.Loc.End},
-		}, nil
 	}
 
 	if _, err := p.expect(int(',')); err != nil {
@@ -1470,13 +1437,20 @@ func (p *Parser) parseNilaryFunction() (ast.Node, error) {
 	}
 	if p.cur.Kind == int('(') {
 		p.advance() // consume '('
-		// Optional fractional-seconds precision: CURRENT_TIMESTAMP(3).
+		// Only CURRENT_TIMESTAMP takes a fractional-seconds precision, and only
+		// one. The rest are strictly nilary: the engine rejects CURRENT_TIME(3),
+		// LOCALTIME(3), CURRENT_DATE(1) and CURRENT_USER(1, 2) alike. Parsing a
+		// single expression also rejects CURRENT_TIMESTAMP(foo, bar), since the
+		// closing paren is then expected at the comma.
 		if p.cur.Kind != int(')') {
-			args, err := p.parseExprList()
+			if name != "CURRENT_TIMESTAMP" {
+				return nil, p.syntaxErrorAtCur()
+			}
+			arg, err := p.parseExpr()
 			if err != nil {
 				return nil, err
 			}
-			fc.Args = args
+			fc.Args = []ast.Node{arg}
 		}
 		closeTok, err := p.expect(int(')'))
 		if err != nil {

--- a/starrocks/parser/expr_test.go
+++ b/starrocks/parser/expr_test.go
@@ -1621,3 +1621,61 @@ func TestStmtGroupByCube(t *testing.T) {
 		}
 	}
 }
+
+func TestExprLambdaMultiParameter(t *testing.T) {
+	node := mustParseExpr(t, "array_map((x, y) -> x + y, a, b)")
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	lam, ok := fc.Args[0].(*ast.LambdaExpr)
+	if !ok {
+		t.Fatalf("args[0] = %T, want *ast.LambdaExpr", fc.Args[0])
+	}
+	if len(lam.Params) != 2 || lam.Params[0] != "x" || lam.Params[1] != "y" {
+		t.Errorf("params = %v, want [x y]", lam.Params)
+	}
+}
+
+func TestExprLambdaSingleParameterMustBeBare(t *testing.T) {
+	// The engine accepts `x -> ...` and `(x, y) -> ...` but rejects `(x) -> ...`.
+	if _, err := parseExprFrom("array_map((x) -> x + 1, arr)"); err == nil {
+		t.Error("(x) -> ... parsed, want syntax error")
+	}
+	// An ordinary parenthesized argument must be unaffected by the speculative
+	// lambda parse.
+	mustParseExpr(t, "foo((a + b), c)")
+	mustParseExpr(t, "foo((a), b)")
+}
+
+func TestExprTrailingUsingIsCharOnly(t *testing.T) {
+	// CHAR takes a trailing USING on the generic call path; CONVERT has its own
+	// production. Every other function must reject it, as the engine does.
+	mustParseExpr(t, "CHAR(65 USING utf8)")
+	mustParseExpr(t, "CHAR(65, 66 USING utf8)")
+	mustParseExpr(t, "CONVERT(s USING utf8)")
+	for _, input := range []string{"SUM(a USING utf8)", "foo(a USING utf8)"} {
+		if _, err := parseExprFrom(input); err == nil {
+			t.Errorf("parseExpr(%q) = nil error, want syntax error", input)
+		}
+	}
+}
+
+func TestStmtGroupByCubeIsWholeSpecification(t *testing.T) {
+	// The engine rejects a grouping list after CUBE. Accepting it here would
+	// silently discard everything past the comma.
+	for _, sql := range []string{
+		"SELECT a, b, SUM(c) FROM t GROUP BY CUBE(a), b",
+		"SELECT a, SUM(b) FROM t GROUP BY CUBE(a), CUBE(b)",
+	} {
+		if _, errs := Parse(sql); len(errs) == 0 {
+			t.Errorf("Parse(%q) succeeded, want syntax error", sql)
+		}
+	}
+}
+
+func TestUnaryBinaryRenders(t *testing.T) {
+	if got := ast.UnaryBinary.String(); got != "BINARY" {
+		t.Errorf("UnaryBinary.String() = %q, want BINARY", got)
+	}
+}

--- a/starrocks/parser/expr_test.go
+++ b/starrocks/parser/expr_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bytebase/omni/starrocks/ast"
@@ -1263,5 +1264,360 @@ func TestExprParseSuccess(t *testing.T) {
 				t.Errorf("parseExpr(%q) returned nil", tt.input)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EXTRACT expressions
+// ---------------------------------------------------------------------------
+
+func TestExprExtractUnits(t *testing.T) {
+	// Every unit documented for EXTRACT: plain identifiers, non-reserved unit
+	// keywords, and the compound units that lex as reserved keywords.
+	units := []string{
+		"YEAR", "QUARTER", "MONTH", "WEEK", "DAY", "HOUR", "MINUTE", "SECOND",
+		"YEAR_MONTH", "DAY_HOUR", "DAY_MINUTE", "DAY_SECOND", "DAY_MICROSECOND",
+		"HOUR_MINUTE", "HOUR_SECOND", "HOUR_MICROSECOND",
+		"MINUTE_SECOND", "MINUTE_MICROSECOND", "SECOND_MICROSECOND",
+		"DAYOFWEEK", "DOW", "DAYOFYEAR", "DOY",
+	}
+	for _, unit := range units {
+		t.Run(unit, func(t *testing.T) {
+			node := mustParseExpr(t, "EXTRACT("+unit+" FROM d)")
+			ex, ok := node.(*ast.ExtractExpr)
+			if !ok {
+				t.Fatalf("expected *ast.ExtractExpr, got %T", node)
+			}
+			if ex.Unit != unit {
+				t.Errorf("unit = %q, want %q", ex.Unit, unit)
+			}
+			if _, ok := ex.Expr.(*ast.ColumnRef); !ok {
+				t.Errorf("expr = %T, want *ast.ColumnRef", ex.Expr)
+			}
+		})
+	}
+}
+
+func TestExprExtractUnitNormalized(t *testing.T) {
+	node := mustParseExpr(t, "extract(year from d)")
+	ex, ok := node.(*ast.ExtractExpr)
+	if !ok {
+		t.Fatalf("expected *ast.ExtractExpr, got %T", node)
+	}
+	if ex.Unit != "YEAR" {
+		t.Errorf("unit = %q, want YEAR", ex.Unit)
+	}
+}
+
+func TestExprExtractNestedFuncCall(t *testing.T) {
+	node := mustParseExpr(t, "EXTRACT(YEAR FROM MONTHS_ADD(NOW(), -1))")
+	ex, ok := node.(*ast.ExtractExpr)
+	if !ok {
+		t.Fatalf("expected *ast.ExtractExpr, got %T", node)
+	}
+	fc, ok := ex.Expr.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expr = %T, want *ast.FuncCallExpr", ex.Expr)
+	}
+	if got := fc.Name.Parts[len(fc.Name.Parts)-1]; got != "MONTHS_ADD" {
+		t.Errorf("func name = %q, want MONTHS_ADD", got)
+	}
+}
+
+func TestExprExtractInsideCTEStatement(t *testing.T) {
+	// The reported shape: EXTRACT inside a CTE body, spread over several lines.
+	sql := `WITH c AS (
+  SELECT year_num
+  FROM currency_record
+  WHERE year_num = EXTRACT(
+    YEAR
+    FROM
+      MONTHS_ADD(NOW(), -1)
+  )
+)
+SELECT * FROM c`
+	file, errs := Parse(sql)
+	if len(errs) > 0 {
+		t.Fatalf("Parse returned errors: %v", errs)
+	}
+	if len(file.Stmts) != 1 {
+		t.Fatalf("Stmts len = %d, want 1", len(file.Stmts))
+	}
+	if _, ok := file.Stmts[0].(*ast.SelectStmt); !ok {
+		t.Fatalf("stmt = %T, want *ast.SelectStmt", file.Stmts[0])
+	}
+}
+
+func TestExprExtractSyntaxErrors(t *testing.T) {
+	for _, input := range []string{
+		"EXTRACT(YEAR d)",     // missing FROM
+		"EXTRACT(FROM d)",     // missing unit
+		"EXTRACT(YEAR FROM)",  // missing source expression
+		"EXTRACT YEAR FROM d", // missing parentheses
+	} {
+		if _, err := parseExprFrom(input); err == nil {
+			t.Errorf("parseExpr(%q) = nil error, want syntax error", input)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reserved keywords usable as function names (functionNameIdentifier)
+// ---------------------------------------------------------------------------
+
+func TestExprFunctionNameKeywords(t *testing.T) {
+	tests := []struct {
+		input string
+		name  string
+		args  int
+	}{
+		{"TRIM(s)", "TRIM", 1},
+		{"TRIM(s, 'x')", "TRIM", 2},
+		{"LEFT(s, 2)", "LEFT", 2},
+		{"RIGHT(s, 2)", "RIGHT", 2},
+		{"IF(a, 1, 2)", "IF", 3},
+		{"DATABASE()", "DATABASE", 0},
+		{"SCHEMA()", "SCHEMA", 0},
+		{"ADD(1, 2)", "ADD", 2},
+		{"REGEXP(1)", "REGEXP", 1},
+		{"LIKE(1)", "LIKE", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			node := mustParseExpr(t, tt.input)
+			fc, ok := node.(*ast.FuncCallExpr)
+			if !ok {
+				t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+			}
+			if got := fc.Name.Parts[len(fc.Name.Parts)-1]; !strings.EqualFold(got, tt.name) {
+				t.Errorf("name = %q, want %q", got, tt.name)
+			}
+			if len(fc.Args) != tt.args {
+				t.Errorf("args = %d, want %d", len(fc.Args), tt.args)
+			}
+		})
+	}
+}
+
+func TestExprFunctionNameKeywordRequiresCall(t *testing.T) {
+	// The keyword is only a function name when directly applied — `LEFT JOIN`
+	// must still parse as a join, and a bare `LEFT` is still not an identifier.
+	if _, errs := Parse("SELECT * FROM a LEFT JOIN b ON a.x = b.x"); len(errs) > 0 {
+		t.Errorf("LEFT JOIN broke: %v", errs)
+	}
+	if _, errs := Parse("SELECT * FROM a RIGHT JOIN b ON a.x = b.x"); len(errs) > 0 {
+		t.Errorf("RIGHT JOIN broke: %v", errs)
+	}
+	if _, errs := Parse("SELECT LEFT FROM t"); len(errs) == 0 {
+		t.Error("bare LEFT as a column parsed, want syntax error")
+	}
+}
+
+func TestExprNilaryFunctionPrecision(t *testing.T) {
+	for _, input := range []string{
+		"CURRENT_TIMESTAMP(3)", "CURRENT_TIME(3)", "LOCALTIME(3)", "LOCALTIMESTAMP(3)",
+	} {
+		t.Run(input, func(t *testing.T) {
+			node := mustParseExpr(t, input)
+			fc, ok := node.(*ast.FuncCallExpr)
+			if !ok {
+				t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+			}
+			if len(fc.Args) != 1 {
+				t.Fatalf("args = %d, want 1", len(fc.Args))
+			}
+		})
+	}
+	// The bare and empty-paren forms must keep working.
+	for _, input := range []string{"CURRENT_TIMESTAMP", "CURRENT_DATE()"} {
+		node := mustParseExpr(t, input)
+		if fc, ok := node.(*ast.FuncCallExpr); !ok || len(fc.Args) != 0 {
+			t.Errorf("%s = %T with args, want a zero-arg FuncCallExpr", input, node)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Literals: hex, bit, array, map
+// ---------------------------------------------------------------------------
+
+func TestExprHexAndBitLiterals(t *testing.T) {
+	hex := mustParseExpr(t, "x'1f'")
+	if lit, ok := hex.(*ast.Literal); !ok || lit.Kind != ast.LitHex {
+		t.Errorf("x'1f' = %T (%v), want LitHex literal", hex, hex)
+	}
+	bit := mustParseExpr(t, "b'101'")
+	if lit, ok := bit.(*ast.Literal); !ok || lit.Kind != ast.LitBit {
+		t.Errorf("b'101' = %T, want LitBit literal", bit)
+	}
+}
+
+func TestExprArrayLiteral(t *testing.T) {
+	node := mustParseExpr(t, "[1, 2, 3]")
+	lit, ok := node.(*ast.ArrayLiteral)
+	if !ok {
+		t.Fatalf("expected *ast.ArrayLiteral, got %T", node)
+	}
+	if len(lit.Elements) != 3 {
+		t.Errorf("elements = %d, want 3", len(lit.Elements))
+	}
+	if empty, ok := mustParseExpr(t, "[]").(*ast.ArrayLiteral); !ok || len(empty.Elements) != 0 {
+		t.Error("[] did not parse as an empty array literal")
+	}
+}
+
+func TestExprMapLiteral(t *testing.T) {
+	node := mustParseExpr(t, "{'a': 1, 'b': 2}")
+	lit, ok := node.(*ast.MapLiteral)
+	if !ok {
+		t.Fatalf("expected *ast.MapLiteral, got %T", node)
+	}
+	if len(lit.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(lit.Entries))
+	}
+	if lit.Entries[0].Key == nil || lit.Entries[0].Value == nil {
+		t.Error("first entry has a nil key or value")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Session and user variables
+// ---------------------------------------------------------------------------
+
+func TestExprVariableRef(t *testing.T) {
+	tests := []struct {
+		input  string
+		name   string
+		scope  string
+		system bool
+	}{
+		{"@@version_comment", "version_comment", "", true},
+		{"@@session.query_timeout", "query_timeout", "SESSION", true},
+		{"@@global.query_timeout", "query_timeout", "GLOBAL", true},
+		{"@uservar", "uservar", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			node := mustParseExpr(t, tt.input)
+			v, ok := node.(*ast.VariableRef)
+			if !ok {
+				t.Fatalf("expected *ast.VariableRef, got %T", node)
+			}
+			if !strings.EqualFold(v.Name, tt.name) || v.Scope != tt.scope || v.System != tt.system {
+				t.Errorf("got {Name:%q Scope:%q System:%v}, want {%q %q %v}",
+					v.Name, v.Scope, v.System, tt.name, tt.scope, tt.system)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Lambdas
+// ---------------------------------------------------------------------------
+
+func TestExprLambdaInFunctionArg(t *testing.T) {
+	node := mustParseExpr(t, "array_map(x -> x + 1, arr)")
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if len(fc.Args) != 2 {
+		t.Fatalf("args = %d, want 2", len(fc.Args))
+	}
+	lam, ok := fc.Args[0].(*ast.LambdaExpr)
+	if !ok {
+		t.Fatalf("args[0] = %T, want *ast.LambdaExpr", fc.Args[0])
+	}
+	if len(lam.Params) != 1 || lam.Params[0] != "x" {
+		t.Errorf("params = %v, want [x]", lam.Params)
+	}
+	if _, ok := lam.Body.(*ast.BinaryExpr); !ok {
+		t.Errorf("body = %T, want *ast.BinaryExpr", lam.Body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CONVERT / USING charset / BINARY
+// ---------------------------------------------------------------------------
+
+func TestExprConvertUsing(t *testing.T) {
+	node := mustParseExpr(t, "CONVERT(s USING utf8)")
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if fc.Using != "UTF8" {
+		t.Errorf("Using = %q, want UTF8", fc.Using)
+	}
+	if len(fc.Args) != 1 {
+		t.Errorf("args = %d, want 1", len(fc.Args))
+	}
+}
+
+func TestExprConvertToType(t *testing.T) {
+	// CONVERT(expr, type) is CAST spelled differently.
+	node := mustParseExpr(t, "CONVERT(s, SIGNED)")
+	cast, ok := node.(*ast.CastExpr)
+	if !ok {
+		t.Fatalf("expected *ast.CastExpr, got %T", node)
+	}
+	if cast.TypeName == nil || cast.TypeName.Name != "SIGNED" {
+		t.Errorf("type = %+v, want SIGNED", cast.TypeName)
+	}
+}
+
+func TestExprCharUsing(t *testing.T) {
+	node := mustParseExpr(t, "CHAR(65 USING utf8)")
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if fc.Using != "UTF8" {
+		t.Errorf("Using = %q, want UTF8", fc.Using)
+	}
+}
+
+func TestExprBinaryOperator(t *testing.T) {
+	node := mustParseExpr(t, "BINARY s")
+	un, ok := node.(*ast.UnaryExpr)
+	if !ok {
+		t.Fatalf("expected *ast.UnaryExpr, got %T", node)
+	}
+	if un.Op != ast.UnaryBinary {
+		t.Errorf("op = %v, want UnaryBinary", un.Op)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Statement-level: optimizer hints, GROUP BY CUBE
+// ---------------------------------------------------------------------------
+
+func TestStmtOptimizerHintIsSkipped(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT /*+ SET_VAR(query_timeout = 100) */ 1",
+		"SELECT /*+ SET_VAR(a = 1) */ /* ordinary comment */ 1",
+		"SELECT /*+ SET_VAR(a = 1) */ a FROM t WHERE a > 1",
+	} {
+		file, errs := Parse(sql)
+		if len(errs) > 0 {
+			t.Errorf("Parse(%q) errors: %v", sql, errs)
+			continue
+		}
+		if len(file.Stmts) != 1 {
+			t.Errorf("Parse(%q) produced %d statements, want 1", sql, len(file.Stmts))
+		}
+	}
+}
+
+func TestStmtGroupByCube(t *testing.T) {
+	for _, sql := range []string{
+		"SELECT a, SUM(b) FROM t GROUP BY CUBE(a)",
+		"SELECT a, SUM(b) FROM t GROUP BY CUBE(a, c)",
+		"SELECT a, SUM(b) FROM t GROUP BY ROLLUP(a)",
+		"SELECT a, SUM(b) FROM t GROUP BY GROUPING SETS ((a), ())",
+	} {
+		if _, errs := Parse(sql); len(errs) > 0 {
+			t.Errorf("Parse(%q) errors: %v", sql, errs)
+		}
 	}
 }

--- a/starrocks/parser/expr_test.go
+++ b/starrocks/parser/expr_test.go
@@ -1414,22 +1414,26 @@ func TestExprFunctionNameKeywordRequiresCall(t *testing.T) {
 }
 
 func TestExprNilaryFunctionPrecision(t *testing.T) {
+	// CURRENT_TIMESTAMP is the only one of these that takes a fractional-seconds
+	// precision; the engine rejects an argument on any of the others.
+	node := mustParseExpr(t, "CURRENT_TIMESTAMP(3)")
+	fc, ok := node.(*ast.FuncCallExpr)
+	if !ok {
+		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
+	}
+	if len(fc.Args) != 1 {
+		t.Fatalf("args = %d, want 1", len(fc.Args))
+	}
 	for _, input := range []string{
-		"CURRENT_TIMESTAMP(3)", "CURRENT_TIME(3)", "LOCALTIME(3)", "LOCALTIMESTAMP(3)",
+		"CURRENT_TIME(3)", "LOCALTIME(3)", "LOCALTIMESTAMP(3)",
+		"CURRENT_DATE(1)", "CURRENT_USER(1, 2)", "CURRENT_TIMESTAMP(foo, bar)",
 	} {
-		t.Run(input, func(t *testing.T) {
-			node := mustParseExpr(t, input)
-			fc, ok := node.(*ast.FuncCallExpr)
-			if !ok {
-				t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
-			}
-			if len(fc.Args) != 1 {
-				t.Fatalf("args = %d, want 1", len(fc.Args))
-			}
-		})
+		if _, err := parseExprFrom(input); err == nil {
+			t.Errorf("parseExpr(%q) = nil error, want syntax error", input)
+		}
 	}
 	// The bare and empty-paren forms must keep working.
-	for _, input := range []string{"CURRENT_TIMESTAMP", "CURRENT_DATE()"} {
+	for _, input := range []string{"CURRENT_TIMESTAMP", "CURRENT_DATE()", "CURRENT_TIME()"} {
 		node := mustParseExpr(t, input)
 		if fc, ok := node.(*ast.FuncCallExpr); !ok || len(fc.Args) != 0 {
 			t.Errorf("%s = %T with args, want a zero-arg FuncCallExpr", input, node)
@@ -1467,7 +1471,11 @@ func TestExprArrayLiteral(t *testing.T) {
 }
 
 func TestExprMapLiteral(t *testing.T) {
-	node := mustParseExpr(t, "{'a': 1, 'b': 2}")
+	// This engine requires the MAP prefix; a bare `{...}` is a syntax error.
+	if _, err := parseExprFrom("{'a': 1}"); err == nil {
+		t.Error("bare {'a': 1} parsed, want syntax error")
+	}
+	node := mustParseExpr(t, "map{'a': 1, 'b': 2}")
 	lit, ok := node.(*ast.MapLiteral)
 	if !ok {
 		t.Fatalf("expected *ast.MapLiteral, got %T", node)
@@ -1540,17 +1548,10 @@ func TestExprLambdaInFunctionArg(t *testing.T) {
 // CONVERT / USING charset / BINARY
 // ---------------------------------------------------------------------------
 
-func TestExprConvertUsing(t *testing.T) {
-	node := mustParseExpr(t, "CONVERT(s USING utf8)")
-	fc, ok := node.(*ast.FuncCallExpr)
-	if !ok {
-		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
-	}
-	if fc.Using != "UTF8" {
-		t.Errorf("Using = %q, want UTF8", fc.Using)
-	}
-	if len(fc.Args) != 1 {
-		t.Errorf("args = %d, want 1", len(fc.Args))
+func TestExprConvertUsingIsRejected(t *testing.T) {
+	// Unlike Doris, this engine has no CONVERT(expr USING charset) form.
+	if _, err := parseExprFrom("CONVERT(s USING utf8)"); err == nil {
+		t.Error("CONVERT(s USING utf8) parsed, want syntax error")
 	}
 }
 
@@ -1566,14 +1567,13 @@ func TestExprConvertToType(t *testing.T) {
 	}
 }
 
-func TestExprCharUsing(t *testing.T) {
-	node := mustParseExpr(t, "CHAR(65 USING utf8)")
-	fc, ok := node.(*ast.FuncCallExpr)
-	if !ok {
-		t.Fatalf("expected *ast.FuncCallExpr, got %T", node)
-	}
-	if fc.Using != "UTF8" {
-		t.Errorf("Using = %q, want UTF8", fc.Using)
+func TestExprCharUsingIsRejected(t *testing.T) {
+	// The trailing USING clause is not accepted on any function here.
+	mustParseExpr(t, "CHAR(65)")
+	for _, input := range []string{"CHAR(65 USING utf8)", "SUM(a USING utf8)", "foo(a USING utf8)"} {
+		if _, err := parseExprFrom(input); err == nil {
+			t.Errorf("parseExpr(%q) = nil error, want syntax error", input)
+		}
 	}
 }
 
@@ -1637,28 +1637,13 @@ func TestExprLambdaMultiParameter(t *testing.T) {
 	}
 }
 
-func TestExprLambdaSingleParameterMustBeBare(t *testing.T) {
-	// The engine accepts `x -> ...` and `(x, y) -> ...` but rejects `(x) -> ...`.
-	if _, err := parseExprFrom("array_map((x) -> x + 1, arr)"); err == nil {
-		t.Error("(x) -> ... parsed, want syntax error")
-	}
+func TestExprLambdaSingleParameterParenthesized(t *testing.T) {
+	// Unlike Doris, this engine accepts the parenthesized single-parameter form.
+	mustParseExpr(t, "array_map((x) -> x + 1, arr)")
 	// An ordinary parenthesized argument must be unaffected by the speculative
 	// lambda parse.
 	mustParseExpr(t, "foo((a + b), c)")
 	mustParseExpr(t, "foo((a), b)")
-}
-
-func TestExprTrailingUsingIsCharOnly(t *testing.T) {
-	// CHAR takes a trailing USING on the generic call path; CONVERT has its own
-	// production. Every other function must reject it, as the engine does.
-	mustParseExpr(t, "CHAR(65 USING utf8)")
-	mustParseExpr(t, "CHAR(65, 66 USING utf8)")
-	mustParseExpr(t, "CONVERT(s USING utf8)")
-	for _, input := range []string{"SUM(a USING utf8)", "foo(a USING utf8)"} {
-		if _, err := parseExprFrom(input); err == nil {
-			t.Errorf("parseExpr(%q) = nil error, want syntax error", input)
-		}
-	}
 }
 
 func TestStmtGroupByCubeIsWholeSpecification(t *testing.T) {

--- a/starrocks/parser/parser.go
+++ b/starrocks/parser/parser.go
@@ -26,6 +26,24 @@ type Parser struct {
 	errors     []ParseError // collected errors for best-effort mode
 }
 
+// nextToken returns the next token from the lexer, transparently skipping
+// optimizer-hint spans (/*+ ... */). Hints carry no syntax of their own that
+// any production needs to see, so skipping them here keeps every production
+// hint-agnostic instead of threading an optional hint through each one.
+func (p *Parser) nextToken() Token {
+	tok := p.lexer.NextToken()
+	for tok.Kind == tokHintStart {
+		for tok.Kind != tokHintEnd && tok.Kind != tokEOF {
+			tok = p.lexer.NextToken()
+		}
+		if tok.Kind == tokEOF {
+			return tok
+		}
+		tok = p.lexer.NextToken()
+	}
+	return tok
+}
+
 // advance consumes the current token and moves to the next one.
 // Returns the token that was just consumed (the new "previous" token).
 func (p *Parser) advance() Token {
@@ -34,7 +52,7 @@ func (p *Parser) advance() Token {
 		p.cur = p.nextBuf
 		p.hasNext = false
 	} else {
-		p.cur = p.lexer.NextToken()
+		p.cur = p.nextToken()
 	}
 	return p.prev
 }
@@ -88,7 +106,7 @@ func (p *Parser) restore(c parserCheckpoint) {
 // token following the current position.
 func (p *Parser) peekNext() Token {
 	if !p.hasNext {
-		p.nextBuf = p.lexer.NextToken()
+		p.nextBuf = p.nextToken()
 		p.hasNext = true
 	}
 	return p.nextBuf

--- a/starrocks/parser/select.go
+++ b/starrocks/parser/select.go
@@ -1227,6 +1227,13 @@ func (p *Parser) parseGroupByClause() ([]ast.Node, error) {
 		if err != nil {
 			return nil, err
 		}
+		// CUBE(...) is the entire grouping specification — the engine rejects
+		// both `GROUP BY CUBE(a), b` and `GROUP BY CUBE(a), CUBE(b)`. Without
+		// this check, returning here would silently discard everything after
+		// the comma and hand downstream analysis an incomplete GROUP BY.
+		if p.cur.Kind == int(',') {
+			return nil, p.syntaxErrorAtCur()
+		}
 		return []ast.Node{fc}, nil
 	}
 

--- a/starrocks/parser/select.go
+++ b/starrocks/parser/select.go
@@ -1220,6 +1220,16 @@ func (p *Parser) parseGroupByClause() ([]ast.Node, error) {
 		return nil, err
 	}
 
+	// CUBE is a reserved keyword, so `GROUP BY CUBE(a, b)` cannot reach the
+	// ordinary expression path the way ROLLUP and GROUPING SETS do.
+	if p.cur.Kind == kwCUBE && p.peekNext().Kind == int('(') {
+		fc, err := p.parseGroupingElementCall()
+		if err != nil {
+			return nil, err
+		}
+		return []ast.Node{fc}, nil
+	}
+
 	return p.parseExprList()
 }
 

--- a/starrocks/parser/starrocks_syntax_conformance_test.go
+++ b/starrocks/parser/starrocks_syntax_conformance_test.go
@@ -1,0 +1,91 @@
+package parser
+
+import "testing"
+
+// TestStarRocksSyntaxConformance is the container-grounded conformance matrix
+// for the expression and clause forms added alongside the Doris work. The
+// StarRocks fork carries the same parser changes, but StarRocks is a different
+// engine with its own grammar, so its acceptance has to be proven against
+// StarRocks rather than inferred from the Doris run.
+func TestStarRocksSyntaxConformance(t *testing.T) {
+	c := startStarRocks(t)
+
+	cases := []struct {
+		name       string
+		sql        string
+		wantAccept bool
+	}{
+		// EXTRACT.
+		{"extract_year", "SELECT EXTRACT(YEAR FROM NOW())", true},
+		{"extract_month", "SELECT EXTRACT(MONTH FROM NOW())", true},
+		{"extract_in_cte", "WITH c AS (SELECT EXTRACT(YEAR FROM NOW()) y) SELECT * FROM c", true},
+
+		// Reserved keywords usable as function names.
+		{"trim", "SELECT TRIM('  x  ')", true},
+		{"left", "SELECT LEFT('abc', 2)", true},
+		{"right", "SELECT RIGHT('abc', 2)", true},
+		{"if", "SELECT IF(1, 2, 3)", true},
+		{"database", "SELECT DATABASE()", true},
+		{"schema", "SELECT SCHEMA()", true},
+		{"user", "SELECT USER()", true},
+		{"session_user", "SELECT SESSION_USER()", true},
+		{"current_user", "SELECT CURRENT_USER()", true},
+		{"connection_id", "SELECT CONNECTION_ID()", true},
+
+		// Nilary datetime functions. Unlike Doris, only CURRENT_TIMESTAMP takes
+		// a fractional-seconds precision here; the rest are strictly nilary.
+		{"current_timestamp_precision", "SELECT CURRENT_TIMESTAMP(3)", true},
+		{"current_time_precision", "SELECT CURRENT_TIME(3)", false},
+		{"localtime_precision", "SELECT LOCALTIME(3)", false},
+		{"localtimestamp_precision", "SELECT LOCALTIMESTAMP(3)", false},
+		{"current_date_arg", "SELECT CURRENT_DATE(1)", false},
+		{"current_user_args", "SELECT CURRENT_USER(1, 2)", false},
+		{"current_timestamp_junk_args", "SELECT CURRENT_TIMESTAMP(foo, bar)", false},
+		{"current_date_parens", "SELECT CURRENT_DATE()", true},
+		{"current_time_parens", "SELECT CURRENT_TIME()", true},
+
+		// Literals.
+		{"hex_literal", "SELECT x'1f'", true},
+		{"bit_literal", "SELECT b'101'", true},
+		{"array_literal", "SELECT [1, 2, 3]", true},
+		// A map constructor requires the MAP prefix here; bare braces are not a
+		// literal.
+		{"map_literal_prefixed", "SELECT map{'a': 1}", true},
+		{"map_literal_typed", "SELECT map<varchar,int>{'a': 1}", true},
+		{"map_literal_bare", "SELECT {'a': 1}", false},
+
+		// Session and user variables.
+		{"system_var", "SELECT @@version_comment", true},
+		{"system_var_session_scope", "SELECT @@session.query_timeout", true},
+		{"user_var", "SELECT @uservar", true},
+
+		// Lambdas.
+		{"lambda_array_map", "SELECT array_map(x -> x + 1, [1, 2, 3])", true},
+		{"lambda_multi_param", "SELECT array_map((x, y) -> x + y, [1, 2], [3, 4])", true},
+		// Unlike Doris, the parenthesized single-parameter form is accepted.
+		{"lambda_single_param_parenthesized", "SELECT array_map((x) -> x + 1, [1, 2])", true},
+
+		// Optimizer hints.
+		{"set_var_hint", "SELECT /*+ SET_VAR(query_timeout = 100) */ 1", true},
+
+		// CONVERT / USING / BINARY. This engine has no USING charset clause at
+		// all — not on CONVERT, not on CHAR — though it keeps CONVERT(x, type).
+		{"convert_to_type", "SELECT CONVERT('1', SIGNED)", true},
+		{"convert_using", "SELECT CONVERT('abc' USING utf8)", false},
+		{"char_plain", "SELECT CHAR(65)", true},
+		{"char_using", "SELECT CHAR(65 USING utf8)", false},
+		{"using_on_aggregate", "SELECT SUM(a USING utf8) FROM t", false},
+		{"binary_operator", "SELECT BINARY 'abc'", true},
+
+		// Forms the parser deliberately still rejects.
+		{"substring_from", "SELECT SUBSTRING('abcdef' FROM 2)", false},
+		{"trim_both_from", "SELECT TRIM(BOTH 'x' FROM 'xax')", false},
+		{"position_in", "SELECT POSITION('b' IN 'abc')", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c.assertParity(t, tc.sql, tc.wantAccept)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A customer could not run a valid read-only Doris query in Bytebase's SQL editor. The hand-written Doris parser has no production for `EXTRACT(unit FROM expr)`, so the whole statement died at that token with `syntax error at or near EXTRACT`. It is a regression from the ANTLR → omni switch: the previous parser accepted the query.

`EXTRACT` turned out to be one instance of a class. A differential sweep — every omni rejection re-run through the engine — found nine more.

## Method, and why it changed the answer

I first used the Apache Doris ANTLR grammar as the oracle, then re-checked everything against a live **Apache Doris 3.1.4** container. The two disagree, and the grammar is ahead of the shipping engine:

```
SUBSTRING('abcdef' FROM 2 [FOR 3])      mismatched input 'FROM'
TRIM(BOTH|LEADING|TRAILING 'x' FROM s)  mismatched input ''x''
TRIM(' ' FROM s)                        mismatched input
POSITION('b' IN 'abc')                  no viable alternative at input 'IN'
SELECT VALUES(a)                        mismatched input
a = ANY / > ALL / = SOME (subquery)     extraneous input 'ALL'
```

Trusting the grammar file would have shipped six productions making the parser **more permissive than the engine**. They are deliberately left rejected, and the conformance matrix has a negative arm asserting they stay rejected, so they are not "fixed" later from the grammar.

## What this closes

| Area | Now parses |
|---|---|
| `functionNameIdentifier` | `TRIM(s)`, `LEFT(s,2)`, `RIGHT(s,2)`, `IF(a,1,2)`, `DATABASE()`, + 10 more reserved keywords usable as function names |
| Nilary datetime + precision | `CURRENT_TIMESTAMP(3)`, `CURRENT_TIME(3)`, `LOCALTIME(3)`, `LOCALTIMESTAMP(3)` |
| Literals | `x'1f'`, `b'101'`, `[1,2,3]`, `{'a':1}` |
| Variables | `@@version`, `@@session.x`, `@@global.x`, `@x` |
| Lambdas | `array_map(x -> x + 1, arr)` |
| Optimizer hints | `/*+ SET_VAR(query_timeout = 100) */` |
| Grouping | `GROUP BY CUBE(a)` |
| Conversion | `CONVERT(x USING utf8)`, `CONVERT(x, SIGNED)`, `CHAR(65 USING utf8)`, `BINARY x` |
| Date parts | `EXTRACT(unit FROM expr)`, incl. compound units `DAY_HOUR`, `DAY_SECOND`, `MINUTE_SECOND` |

Two decisions worth a reviewer's attention:

- **Variables parse to a dedicated `VariableRef`, not a `ColumnRef`**, so `analysis` lineage and downstream masking cannot mistake `@@version` for a column.
- **Lambdas are scoped to function-argument position.** My first attempt made `->` a general infix operator, which turned `SELECT j->'$.a'` into a `LambdaExpr`. The engine has no `->` JSON operator at all, so a stray `->` must stay a syntax error.

## Testing

- **Doris conformance: 50/50, zero mismatches** against a live container, via the new `doris/parser/doris_container_test.go` harness (modeled on `starrocks_container_test.go`, `-short`-gated like it).
- Corpus parity with the engine: **56/57**.
- Keyword sweep before/after: rejections of keywords as function names drop 187 → 172, exactly the 15-keyword set; column, qualified-column, alias and table positions are **unchanged** — the change does not widen identifier acceptance.
- Full `go test -short ./doris/... ./starrocks/...` green; gofmt baseline unchanged.

Two harness notes for whoever touches it next: `SKIP_CHECK_ULIMIT=true` is `start_be.sh`'s own escape hatch for the `vm.max_map_count`/swap preflight (neither is settable from inside a container, so don't patch the s6 unit), and Doris codes parse **and** semantic errors alike as MySQL 1105 — the oracle has to discriminate on the ANTLR message fragments, not the error code.

## Not in this PR

- **`VALUES (1,2),(3,4)`** as a standalone query — the one remaining parity gap. Needs a new statement node plus a matching change in bytebase's read-only classification, or the editor flips from "syntax error" to "not read-only".
## Review round (ef866f98, a3778c31)

Five of the seven review findings held up and are fixed: the `GROUP BY CUBE` silent truncation, lambda parameters leaking into lineage, multi-parameter lambdas, `USING` being consumed for any function name, and the missing `UnaryBinary` string. Two are declined with engine evidence, in the threads: Doris accepts arbitrary arguments on the nilary datetime functions, and it accepts unterminated hints (and unterminated block comments) — tightening either would move the parser away from the engine, not toward it.

**StarRocks conformance is now done**, and the fork was *not* interchangeable with Doris. A live StarRocks 3.4.10 run found five divergences, each now handled dialect-specifically and pinned in a new 43-case matrix:

| | Doris | StarRocks |
|---|---|---|
| precision arg on `CURRENT_TIME`/`LOCALTIME`/`CURRENT_DATE`/`CURRENT_USER` | accepted | **rejected** (only `CURRENT_TIMESTAMP`) |
| bare `{'a':1}` map constructor | accepted | **rejected** (needs `map{...}`) |
| `(x) -> ...` single-param parenthesized lambda | **rejected** | accepted |
| `CONVERT(x USING cs)` | accepted | **rejected** |
| `CHAR(n USING cs)` | accepted | **rejected** |

Doris matrix is now 59 cases, StarRocks 43, both 0 mismatches against live containers.

## Follow-up found along the way

`SELECT j->'$.a' FROM t` parses to a bare `*ast.ColumnRef` — the parser **silently swallows** `->'$.a'`, and Doris rejects that SQL outright. So omni accepts a statement the engine won't run *and* hands downstream a truncated AST. Predates this change; filing separately.

