### PR TITLE
doris/starrocks: close the parser gaps hidden by the trailing-token swallow (BYT-10084)

### DIFF
--- a/doris/analysis/query_span.go
+++ b/doris/analysis/query_span.go
@@ -401,7 +401,7 @@ func (w *spanWalker) makeColumnInfo(item *ast.SelectItem) ColumnInfo {
 		}
 		return info
 	}
-	if item.Alias != "" {
+	if item.Aliased {
 		info.Name = item.Alias
 	} else if item.Expr != nil {
 		info.Name = renderColumnName(item.Expr)

--- a/doris/analysis/query_span.go
+++ b/doris/analysis/query_span.go
@@ -272,7 +272,18 @@ func (w *spanWalker) visitFromItem(node ast.Node) {
 // trying to re-parse the text and, if it's a SELECT/set-op, recurse into it
 // instead of treating it as a physical table.
 func (w *spanWalker) visitTableRef(ref *ast.TableRef) {
-	if ref == nil || ref.Name == nil || len(ref.Name.Parts) == 0 {
+	if ref == nil {
+		return
+	}
+	// A table-valued function is not a physical table access. Mirror the
+	// StarRocks TableFunctionRef handling: walk the call's arguments for
+	// lineage and record no table — authorization would otherwise be asked
+	// about a nonexistent table named BACKENDS or numbers.
+	if ref.Func != nil {
+		w.walkExpr(ref.Func)
+		return
+	}
+	if ref.Name == nil || len(ref.Name.Parts) == 0 {
 		return
 	}
 

--- a/doris/analysis/query_span_test.go
+++ b/doris/analysis/query_span_test.go
@@ -442,3 +442,15 @@ func TestGetQuerySpan_SubscriptKeepsTableAccess(t *testing.T) {
 		t.Errorf("SourceColumns %+v missing secret_col", span.Results[0].SourceColumns)
 	}
 }
+
+func TestGetQuerySpan_EmptyStringAlias(t *testing.T) {
+	// SELECT c AS '' names the result column with the explicit empty alias;
+	// it must not fall back to the expression name.
+	span, err := GetQuerySpan("SELECT c AS '' FROM t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.Results) != 1 || span.Results[0].Name != "" {
+		t.Fatalf("Results = %+v, want one column named \"\"", span.Results)
+	}
+}

--- a/doris/analysis/query_span_test.go
+++ b/doris/analysis/query_span_test.go
@@ -454,3 +454,15 @@ func TestGetQuerySpan_EmptyStringAlias(t *testing.T) {
 		t.Fatalf("Results = %+v, want one column named \"\"", span.Results)
 	}
 }
+
+func TestGetQuerySpan_QualifiedSubscriptKeepsTableAccess(t *testing.T) {
+	// The qualified twin of the subscript fail-open: the select-item fast
+	// path used to bypass the expression parser for t.col and drop the rest.
+	span, err := GetQuerySpan("SELECT t.secret_col[1] FROM sensitive_table t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.AccessTables) != 1 || span.AccessTables[0].Table != "sensitive_table" {
+		t.Fatalf("AccessTables = %+v, want [sensitive_table]", span.AccessTables)
+	}
+}

--- a/doris/analysis/query_span_test.go
+++ b/doris/analysis/query_span_test.go
@@ -46,17 +46,17 @@ func TestGetQuerySpan_Basics(t *testing.T) {
 			wantResults: []string{"a"},
 		},
 		{
-			name:       "qualified table",
-			sql:        "SELECT * FROM db.t",
-			wantType:   QueryTypeSelect,
-			wantTables: []tableSig{{Database: "db", Table: "t"}},
+			name:        "qualified table",
+			sql:         "SELECT * FROM db.t",
+			wantType:    QueryTypeSelect,
+			wantTables:  []tableSig{{Database: "db", Table: "t"}},
 			wantResults: []string{"*"},
 		},
 		{
-			name:       "three-part table name",
-			sql:        "SELECT * FROM catalog1.db1.t1",
-			wantType:   QueryTypeSelect,
-			wantTables: []tableSig{{Database: "db1", Table: "t1"}},
+			name:        "three-part table name",
+			sql:         "SELECT * FROM catalog1.db1.t1",
+			wantType:    QueryTypeSelect,
+			wantTables:  []tableSig{{Database: "db1", Table: "t1"}},
 			wantResults: []string{"*"},
 		},
 		{
@@ -417,5 +417,28 @@ func TestGetQuerySpan_LambdaSourceColumns(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGetQuerySpan_SubscriptKeepsTableAccess(t *testing.T) {
+	// Before BYT-10084 the parser silently dropped everything after `[`, so
+	// this query lost its FROM clause and the span reported no table access —
+	// a fail-open blind spot for masking.
+	span, err := GetQuerySpan("SELECT secret_col[1] FROM sensitive_table")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.AccessTables) != 1 || span.AccessTables[0].Table != "sensitive_table" {
+		t.Fatalf("AccessTables = %+v, want [sensitive_table]", span.AccessTables)
+	}
+	if len(span.Results) != 1 {
+		t.Fatalf("Results = %+v, want one column", span.Results)
+	}
+	got := map[string]bool{}
+	for _, sc := range span.Results[0].SourceColumns {
+		got[sc.Column] = true
+	}
+	if !got["secret_col"] {
+		t.Errorf("SourceColumns %+v missing secret_col", span.Results[0].SourceColumns)
 	}
 }

--- a/doris/analysis/query_span_test.go
+++ b/doris/analysis/query_span_test.go
@@ -466,3 +466,15 @@ func TestGetQuerySpan_QualifiedSubscriptKeepsTableAccess(t *testing.T) {
 		t.Fatalf("AccessTables = %+v, want [sensitive_table]", span.AccessTables)
 	}
 }
+
+func TestGetQuerySpan_TableFunctionIsNotTableAccess(t *testing.T) {
+	// A table-valued function is not a physical table: BACKENDS() must not
+	// surface as an accessed table for authorization or lineage.
+	span, err := GetQuerySpan("SELECT * FROM BACKENDS()")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.AccessTables) != 0 {
+		t.Fatalf("AccessTables = %+v, want none for a table function", span.AccessTables)
+	}
+}

--- a/doris/ast/exprnodes.go
+++ b/doris/ast/exprnodes.go
@@ -12,30 +12,30 @@ type BinaryOp int
 const (
 	// Logical operators.
 	BinOr  BinaryOp = iota // OR, ||
-	BinAnd                  // AND, &&
-	BinXor                  // XOR
+	BinAnd                 // AND, &&
+	BinXor                 // XOR
 
 	// Comparison operators.
-	BinEq        // =
-	BinNe        // <> or !=
-	BinLt        // <
-	BinGt        // >
-	BinLe        // <=
-	BinGe        // >=
+	BinEq         // =
+	BinNe         // <> or !=
+	BinLt         // <
+	BinGt         // >
+	BinLe         // <=
+	BinGe         // >=
 	BinNullSafeEq // <=>
 
 	// Arithmetic operators.
-	BinAdd // +
-	BinSub // -
-	BinMul // *
-	BinDiv // /
-	BinMod // % or MOD
+	BinAdd    // +
+	BinSub    // -
+	BinMul    // *
+	BinDiv    // /
+	BinMod    // % or MOD
 	BinIntDiv // DIV
 
 	// Bitwise operators.
-	BinBitOr  // |
-	BinBitAnd // &
-	BinBitXor // ^
+	BinBitOr      // |
+	BinBitAnd     // &
+	BinBitXor     // ^
 	BinShiftLeft  // <<
 	BinShiftRight // >>
 )
@@ -95,10 +95,10 @@ type UnaryOp int
 
 const (
 	UnaryMinus  UnaryOp = iota // -
-	UnaryPlus                   // +
-	UnaryBitNot                 // ~
-	UnaryNot                    // NOT
-	UnaryBinary                 // BINARY
+	UnaryPlus                  // +
+	UnaryBitNot                // ~
+	UnaryNot                   // NOT
+	UnaryBinary                // BINARY
 )
 
 // String returns the SQL text form of the unary operator.
@@ -138,7 +138,7 @@ type CaseKind int
 
 const (
 	CaseSearched CaseKind = iota // CASE WHEN ...
-	CaseSimple                    // CASE operand WHEN ...
+	CaseSimple                   // CASE operand WHEN ...
 )
 
 // ---------------------------------------------------------------------------
@@ -170,10 +170,10 @@ var _ Node = (*UnaryExpr)(nil)
 
 // IsExpr represents expr IS [NOT] NULL / TRUE / FALSE.
 type IsExpr struct {
-	Expr    Node
-	Not     bool
-	IsWhat  string // "NULL", "TRUE", "FALSE"
-	Loc     Loc
+	Expr   Node
+	Not    bool
+	IsWhat string // "NULL", "TRUE", "FALSE"
+	Loc    Loc
 }
 
 func (n *IsExpr) Tag() NodeTag { return T_IsExpr }
@@ -195,10 +195,10 @@ var _ Node = (*BetweenExpr)(nil)
 
 // InExpr represents expr [NOT] IN (values...) or expr [NOT] IN (subquery).
 type InExpr struct {
-	Expr     Node
-	Values   []Node // list of values; for subquery, contains one SubqueryExpr
-	Not      bool
-	Loc      Loc
+	Expr   Node
+	Values []Node // list of values; for subquery, contains one SubqueryExpr
+	Not    bool
+	Loc    Loc
 }
 
 func (n *InExpr) Tag() NodeTag { return T_InExpr }
@@ -232,15 +232,15 @@ var _ Node = (*RegexpExpr)(nil)
 
 // FuncCallExpr represents a function call: name(args...).
 type FuncCallExpr struct {
-	Name     *ObjectName
-	Args     []Node
-	Distinct bool   // COUNT(DISTINCT x)
-	Star     bool   // COUNT(*)
-	OrderBy  []*OrderByItem // optional ORDER BY in aggregate (GROUP_CONCAT)
-	Separator string // optional SEPARATOR value for GROUP_CONCAT
-	Using     string // optional USING charset, as in CONVERT(x USING utf8)
-	Over     *WindowSpec // optional OVER (...) window specification
-	Loc      Loc
+	Name      *ObjectName
+	Args      []Node
+	Distinct  bool           // COUNT(DISTINCT x)
+	Star      bool           // COUNT(*)
+	OrderBy   []*OrderByItem // optional ORDER BY in aggregate (GROUP_CONCAT)
+	Separator string         // optional SEPARATOR value for GROUP_CONCAT
+	Using     string         // optional USING charset, as in CONVERT(x USING utf8)
+	Over      *WindowSpec    // optional OVER (...) window specification
+	Loc       Loc
 }
 
 func (n *FuncCallExpr) Tag() NodeTag { return T_FuncCallExpr }
@@ -363,12 +363,49 @@ func (n *MapEntry) Tag() NodeTag { return T_MapEntry }
 
 var _ Node = (*MapEntry)(nil)
 
+// ElementAtExpr represents collection element access: value[index]
+// (grammar: elementAt). Applies to array, map and struct values alike.
+type ElementAtExpr struct {
+	Value Node
+	Index Node
+	Loc   Loc
+}
+
+func (n *ElementAtExpr) Tag() NodeTag { return T_ElementAtExpr }
+
+var _ Node = (*ElementAtExpr)(nil)
+
+// ArraySliceExpr represents an array slice: value[begin : end]
+// (grammar: arraySlice). End is nil for the open-ended form value[begin:].
+type ArraySliceExpr struct {
+	Value Node
+	Begin Node
+	End   Node // nil when omitted: value[begin:]
+	Loc   Loc
+}
+
+func (n *ArraySliceExpr) Tag() NodeTag { return T_ArraySliceExpr }
+
+var _ Node = (*ArraySliceExpr)(nil)
+
+// GroupingSetsExpr represents GROUP BY GROUPING SETS ((a, b), (a), ()).
+// Each set is one parenthesized expression list; the empty set () is a nil
+// entry. Like CUBE, GROUPING SETS is the entire grouping specification.
+type GroupingSetsExpr struct {
+	Sets [][]Node
+	Loc  Loc
+}
+
+func (n *GroupingSetsExpr) Tag() NodeTag { return T_GroupingSetsExpr }
+
+var _ Node = (*GroupingSetsExpr)(nil)
+
 // CaseExpr represents CASE [operand] WHEN...THEN...ELSE...END.
 type CaseExpr struct {
 	Kind    CaseKind
-	Operand Node          // nil for searched CASE
+	Operand Node // nil for searched CASE
 	Whens   []*WhenClause
-	Else    Node          // nil if no ELSE
+	Else    Node // nil if no ELSE
 	Loc     Loc
 }
 
@@ -455,8 +492,8 @@ var _ Node = (*IntervalExpr)(nil)
 // OrderByItem represents an expression with optional ASC/DESC and NULLS FIRST/LAST.
 type OrderByItem struct {
 	Expr       Node
-	Desc       bool   // true for DESC, false for ASC (default)
-	NullsFirst *bool  // nil if not specified; true for NULLS FIRST, false for NULLS LAST
+	Desc       bool  // true for DESC, false for ASC (default)
+	NullsFirst *bool // nil if not specified; true for NULLS FIRST, false for NULLS LAST
 	Loc        Loc
 }
 

--- a/doris/ast/loc.go
+++ b/doris/ast/loc.go
@@ -66,6 +66,12 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *MapEntry:
 		return v.Loc
+	case *ElementAtExpr:
+		return v.Loc
+	case *ArraySliceExpr:
+		return v.Loc
+	case *GroupingSetsExpr:
+		return v.Loc
 	case *CaseExpr:
 		return v.Loc
 	case *WhenClause:

--- a/doris/ast/nodetags.go
+++ b/doris/ast/nodetags.go
@@ -104,6 +104,15 @@ const (
 	// T_MapEntry is the tag for *MapEntry (one k: v pair).
 	T_MapEntry
 
+	// T_ElementAtExpr is the tag for *ElementAtExpr (value[index]).
+	T_ElementAtExpr
+
+	// T_ArraySliceExpr is the tag for *ArraySliceExpr (value[begin:end]).
+	T_ArraySliceExpr
+
+	// T_GroupingSetsExpr is the tag for *GroupingSetsExpr (GROUPING SETS (...)).
+	T_GroupingSetsExpr
+
 	// T_CaseExpr is the tag for *CaseExpr (CASE...END).
 	T_CaseExpr
 
@@ -680,6 +689,12 @@ func (t NodeTag) String() string {
 		return "MapLiteral"
 	case T_MapEntry:
 		return "MapEntry"
+	case T_ElementAtExpr:
+		return "ElementAtExpr"
+	case T_ArraySliceExpr:
+		return "ArraySliceExpr"
+	case T_GroupingSetsExpr:
+		return "GroupingSetsExpr"
 	case T_CaseExpr:
 		return "CaseExpr"
 	case T_WhenClause:

--- a/doris/ast/selectnodes.go
+++ b/doris/ast/selectnodes.go
@@ -83,7 +83,12 @@ var _ Node = (*SelectStmt)(nil)
 type SelectItem struct {
 	Expr  Node   // the expression; for *, this is nil
 	Alias string // optional alias name; empty if absent
-	Star  bool   // true for * or table.*
+
+	// Aliased reports whether an explicit alias was present. It is what
+	// distinguishes the engine-valid empty alias (SELECT c AS '') from no
+	// alias at all — Alias alone cannot, since "" is its absent value.
+	Aliased bool
+	Star    bool // true for * or table.*
 	// For table.*, TableName holds the qualifier ObjectName.
 	TableName *ObjectName
 	// For SELECT * EXCEPT (col1, col2, ...) — list of column names to exclude.

--- a/doris/ast/selectnodes.go
+++ b/doris/ast/selectnodes.go
@@ -50,19 +50,20 @@ var _ Node = (*CTE)(nil)
 //	  [ORDER BY expr [ASC|DESC] [NULLS FIRST|LAST], ...]
 //	  [LIMIT count [OFFSET offset]]
 type SelectStmt struct {
-	With     *WithClause   // optional WITH clause (nil if absent)
-	Distinct bool          // DISTINCT keyword present
-	All      bool          // ALL keyword present (explicit, rarely used)
-	Items    []*SelectItem // SELECT list
-	From     []Node        // FROM clause table references (TableRef or JoinClause)
-	Where    Node          // WHERE expression (nil if absent)
-	GroupBy  []Node        // GROUP BY expressions
-	Having   Node          // HAVING expression (nil if absent)
-	Qualify  Node          // QUALIFY expression (nil if absent)
-	OrderBy  []*OrderByItem // ORDER BY items
-	Limit    Node          // LIMIT expression (nil if absent)
-	Offset   Node          // OFFSET expression (nil if absent)
-	Loc      Loc
+	With              *WithClause    // optional WITH clause (nil if absent)
+	Distinct          bool           // DISTINCT keyword present
+	All               bool           // ALL keyword present (explicit, rarely used)
+	Items             []*SelectItem  // SELECT list
+	From              []Node         // FROM clause table references (TableRef or JoinClause)
+	Where             Node           // WHERE expression (nil if absent)
+	GroupBy           []Node         // GROUP BY expressions
+	GroupByWithRollup bool           // GROUP BY ... WITH ROLLUP
+	Having            Node           // HAVING expression (nil if absent)
+	Qualify           Node           // QUALIFY expression (nil if absent)
+	OrderBy           []*OrderByItem // ORDER BY items
+	Limit             Node           // LIMIT expression (nil if absent)
+	Offset            Node           // OFFSET expression (nil if absent)
+	Loc               Loc
 }
 
 // Tag implements Node.
@@ -108,7 +109,27 @@ var _ Node = (*SelectItem)(nil)
 type TableRef struct {
 	Name  *ObjectName // table name (may be qualified: db.table or catalog.db.table)
 	Alias string      // optional alias; empty if absent
-	Loc   Loc
+
+	// Func is set when the source is a table-valued function such as
+	// BACKENDS() or numbers("number" = "10"); Name mirrors the function name.
+	Func *FuncCallExpr
+
+	// TabletIDs holds TABLET(id, ...) — a physical-tablet restriction that
+	// appears between the table name and the alias.
+	TabletIDs []int64
+
+	// Sample holds TABLESAMPLE(...) [REPEATABLE seed], which follows the alias.
+	Sample *TableSample
+
+	Loc Loc
+}
+
+// TableSample is the TABLESAMPLE(...) [REPEATABLE seed] suffix of a table
+// reference: TABLESAMPLE(1000 ROWS), TABLESAMPLE(20 PERCENT), TABLESAMPLE().
+type TableSample struct {
+	Value Node   // sample size; nil for the bare TABLESAMPLE() form
+	Unit  string // "ROWS" or "PERCENT"; empty when Value is nil
+	Seed  Node   // REPEATABLE seed; nil if absent
 }
 
 // Tag implements Node.

--- a/doris/ast/walk_children.go
+++ b/doris/ast/walk_children.go
@@ -123,6 +123,21 @@ func walkChildren(v Visitor, node Node) {
 	case *MapEntry:
 		Walk(v, n.Key)
 		Walk(v, n.Value)
+	case *ElementAtExpr:
+		Walk(v, n.Value)
+		Walk(v, n.Index)
+	case *ArraySliceExpr:
+		Walk(v, n.Value)
+		Walk(v, n.Begin)
+		if n.End != nil {
+			Walk(v, n.End)
+		}
+	case *GroupingSetsExpr:
+		for _, set := range n.Sets {
+			for _, e := range set {
+				Walk(v, e)
+			}
+		}
 	case *CaseExpr:
 		if n.Operand != nil {
 			Walk(v, n.Operand)
@@ -199,6 +214,17 @@ func walkChildren(v Visitor, node Node) {
 	case *TableRef:
 		if n.Name != nil {
 			Walk(v, n.Name)
+		}
+		if n.Func != nil {
+			Walk(v, n.Func)
+		}
+		if n.Sample != nil {
+			if n.Sample.Value != nil {
+				Walk(v, n.Sample.Value)
+			}
+			if n.Sample.Seed != nil {
+				Walk(v, n.Sample.Seed)
+			}
 		}
 	case *JoinClause:
 		Walk(v, n.Left)

--- a/doris/ast/walk_children.go
+++ b/doris/ast/walk_children.go
@@ -212,11 +212,13 @@ func walkChildren(v Visitor, node Node) {
 			Walk(v, n.TableName)
 		}
 	case *TableRef:
-		if n.Name != nil {
-			Walk(v, n.Name)
-		}
+		// For a table-valued function, Name mirrors Func.Name (the same
+		// *ObjectName); walking both would visit that node twice, so the
+		// bare Name is walked only when there is no Func to cover it.
 		if n.Func != nil {
 			Walk(v, n.Func)
+		} else if n.Name != nil {
+			Walk(v, n.Name)
 		}
 		if n.Sample != nil {
 			if n.Sample.Value != nil {

--- a/doris/parser/doris_container_test.go
+++ b/doris/parser/doris_container_test.go
@@ -295,6 +295,7 @@ func TestDorisSyntaxConformance(t *testing.T) {
 		{"limit_offset_comma", "SELECT * FROM t LIMIT 5, 10", true},
 		{"string_alias", `SELECT (1 + 1) AS "20%"`, true},
 		{"string_alias_single_quoted", "SELECT 1 AS 'x'", true},
+		{"string_alias_empty", "SELECT 1 AS ''", true},
 		{"element_at_literal", "SELECT [1, 2, 3][1]", true},
 		{"element_at_map", "SELECT {'a': 1}['a']", true},
 		{"element_at_column", "SELECT c1[1] FROM t", true},

--- a/doris/parser/doris_container_test.go
+++ b/doris/parser/doris_container_test.go
@@ -299,6 +299,8 @@ func TestDorisSyntaxConformance(t *testing.T) {
 		{"element_at_literal", "SELECT [1, 2, 3][1]", true},
 		{"element_at_map", "SELECT {'a': 1}['a']", true},
 		{"element_at_column", "SELECT c1[1] FROM t", true},
+		{"element_at_qualified", "SELECT t.c1[1] FROM t", true},
+		{"qualified_column_arith", "SELECT t.a + 1 FROM t", true},
 		{"array_slice", "SELECT [1, 2, 3][1:2]", true},
 		{"array_slice_open", "SELECT [1, 2, 3][2:]", true},
 		{"element_at_two_indexes", "SELECT [1, 2][1, 2]", false},

--- a/doris/parser/doris_container_test.go
+++ b/doris/parser/doris_container_test.go
@@ -289,6 +289,26 @@ func TestDorisSyntaxConformance(t *testing.T) {
 		// BINARY operator.
 		{"binary_operator", "SELECT BINARY 'abc'", true},
 
+		// --- Constructs previously hidden by the trailing-token swallow
+		// (BYT-10084): each parsed as a valid prefix and silently dropped the
+		// rest of the statement.
+		{"limit_offset_comma", "SELECT * FROM t LIMIT 5, 10", true},
+		{"string_alias", `SELECT (1 + 1) AS "20%"`, true},
+		{"string_alias_single_quoted", "SELECT 1 AS 'x'", true},
+		{"element_at_literal", "SELECT [1, 2, 3][1]", true},
+		{"element_at_map", "SELECT {'a': 1}['a']", true},
+		{"element_at_column", "SELECT c1[1] FROM t", true},
+		{"array_slice", "SELECT [1, 2, 3][1:2]", true},
+		{"array_slice_open", "SELECT [1, 2, 3][2:]", true},
+		{"element_at_two_indexes", "SELECT [1, 2][1, 2]", false},
+		{"array_slice_no_begin", "SELECT [1, 2][:2]", false},
+		{"group_by_with_rollup", "SELECT a, SUM(b) FROM t GROUP BY a WITH ROLLUP", true},
+		{"grouping_sets_trailing_item", "SELECT a FROM t GROUP BY GROUPING SETS ((a)), b", false},
+		{"from_tvf_backends", "SELECT * FROM BACKENDS()", true},
+		{"tablet_tablesample", "SELECT * FROM t TABLET(10001) TABLESAMPLE(1000 ROWS) REPEATABLE 2", true},
+		{"show_databases_from", "SHOW DATABASES FROM internal", true},
+		{"build_index_partition", "BUILD INDEX index1 ON table1 PARTITION(p1, p2)", true},
+
 		// --- Negative arm: the grammar file allows these, the engine does not.
 		{"substring_from_for", "SELECT SUBSTRING('abcdef' FROM 2 FOR 3)", false},
 		{"substring_from", "SELECT SUBSTRING('abcdef' FROM 2)", false},

--- a/doris/parser/expr.go
+++ b/doris/parser/expr.go
@@ -262,8 +262,58 @@ func (p *Parser) parsePrefixExpr() (ast.Node, error) {
 		return p.parseIntervalExpr()
 
 	default:
-		return p.parsePrimaryExpr()
+		node, err := p.parsePrimaryExpr()
+		if err != nil {
+			return nil, err
+		}
+		return p.parsePostfixSubscripts(node)
 	}
+}
+
+// parsePostfixSubscripts parses any chain of element-access / slice suffixes
+// after a primary expression: m['k'], arr[1][2], arr[1:3], arr[2:]. The
+// grammar (elementAt, arraySlice) applies these to primaryExpression, so they
+// bind tighter than any operator. The index and bounds are valueExpressions —
+// comparisons are allowed but AND/OR/NOT are not, hence bpNot+1.
+func (p *Parser) parsePostfixSubscripts(node ast.Node) (ast.Node, error) {
+	for p.cur.Kind == int('[') {
+		p.advance() // consume '['
+		begin, err := p.parseExprPrec(bpNot + 1)
+		if err != nil {
+			return nil, err
+		}
+		if p.cur.Kind == int(':') {
+			p.advance() // consume ':'
+			var end ast.Node
+			if p.cur.Kind != int(']') {
+				end, err = p.parseExprPrec(bpNot + 1)
+				if err != nil {
+					return nil, err
+				}
+			}
+			closeTok, err := p.expect(int(']'))
+			if err != nil {
+				return nil, err
+			}
+			node = &ast.ArraySliceExpr{
+				Value: node,
+				Begin: begin,
+				End:   end,
+				Loc:   ast.Loc{Start: ast.NodeLoc(node).Start, End: closeTok.Loc.End},
+			}
+			continue
+		}
+		closeTok, err := p.expect(int(']'))
+		if err != nil {
+			return nil, err
+		}
+		node = &ast.ElementAtExpr{
+			Value: node,
+			Index: begin,
+			Loc:   ast.Loc{Start: ast.NodeLoc(node).Start, End: closeTok.Loc.End},
+		}
+	}
+	return node, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/doris/parser/expr_test.go
+++ b/doris/parser/expr_test.go
@@ -1679,3 +1679,57 @@ func TestUnaryBinaryRenders(t *testing.T) {
 		t.Errorf("UnaryBinary.String() = %q, want BINARY", got)
 	}
 }
+
+func TestExprElementAtAndSlice(t *testing.T) {
+	node := mustParseExpr(t, "arr[1]")
+	ea, ok := node.(*ast.ElementAtExpr)
+	if !ok {
+		t.Fatalf("node = %T, want *ast.ElementAtExpr", node)
+	}
+	if _, ok := ea.Value.(*ast.ColumnRef); !ok {
+		t.Errorf("Value = %T, want *ast.ColumnRef", ea.Value)
+	}
+
+	// Access chains left-associate.
+	node = mustParseExpr(t, "m['a']['b']")
+	outer := node.(*ast.ElementAtExpr)
+	if _, ok := outer.Value.(*ast.ElementAtExpr); !ok {
+		t.Errorf("chained access: Value = %T, want *ast.ElementAtExpr", outer.Value)
+	}
+
+	// Element access on an array literal.
+	node = mustParseExpr(t, "[1, 2, 3][1]")
+	ea = node.(*ast.ElementAtExpr)
+	if _, ok := ea.Value.(*ast.ArrayLiteral); !ok {
+		t.Errorf("Value = %T, want *ast.ArrayLiteral", ea.Value)
+	}
+
+	// Slices, closed and open-ended.
+	node = mustParseExpr(t, "arr[1:2]")
+	sl, ok := node.(*ast.ArraySliceExpr)
+	if !ok || sl.Begin == nil || sl.End == nil {
+		t.Fatalf("node = %+v, want slice with both bounds", node)
+	}
+	node = mustParseExpr(t, "arr[2:]")
+	sl = node.(*ast.ArraySliceExpr)
+	if sl.End != nil {
+		t.Errorf("open slice End = %+v, want nil", sl.End)
+	}
+
+	// Subscripts bind tighter than unary minus.
+	node = mustParseExpr(t, "-arr[1]")
+	un, ok := node.(*ast.UnaryExpr)
+	if !ok || un.Op != ast.UnaryMinus {
+		t.Fatalf("node = %T, want unary minus", node)
+	}
+	if _, ok := un.Expr.(*ast.ElementAtExpr); !ok {
+		t.Errorf("operand = %T, want *ast.ElementAtExpr", un.Expr)
+	}
+
+	// The index is a single valueExpression; a slice needs its begin bound.
+	for _, bad := range []string{"SELECT arr[1, 2]", "SELECT arr[:2]", "SELECT arr[]"} {
+		if _, errs := Parse(bad); len(errs) == 0 {
+			t.Errorf("Parse(%q) succeeded, want error", bad)
+		}
+	}
+}

--- a/doris/parser/index.go
+++ b/doris/parser/index.go
@@ -181,19 +181,30 @@ func (p *Parser) parseBuildIndex(startLoc ast.Loc) (ast.Node, error) {
 		return nil, err
 	}
 
-	// Optional PARTITIONS(p1, p2, ...).
+	// Optional partition restriction (grammar: specifiedPartition):
+	// PARTITION p1, PARTITION (p1, p2, ...), or PARTITIONS (p1, p2, ...).
 	var partitions []string
-	if p.cur.Kind == kwPARTITIONS {
+	if p.cur.Kind == kwPARTITIONS || p.cur.Kind == kwPARTITION {
+		singular := p.cur.Kind == kwPARTITION
 		p.advance()
-		if _, err := p.expect(int('(')); err != nil {
-			return nil, err
-		}
-		partitions, err = p.parseIdentifierList()
-		if err != nil {
-			return nil, err
-		}
-		if _, err := p.expect(int(')')); err != nil {
-			return nil, err
+		if singular && p.cur.Kind != int('(') {
+			// PARTITION with a single bare identifier.
+			name, _, err := p.parseIdentifier()
+			if err != nil {
+				return nil, err
+			}
+			partitions = []string{name}
+		} else {
+			if _, err := p.expect(int('(')); err != nil {
+				return nil, err
+			}
+			partitions, err = p.parseIdentifierList()
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(int(')')); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/doris/parser/index_test.go
+++ b/doris/parser/index_test.go
@@ -334,3 +334,29 @@ func TestDropTableNowSupported(t *testing.T) {
 		t.Errorf("expected *ast.DropTableStmt, got %T", file.Stmts[0])
 	}
 }
+
+func TestBuildIndexPartitionForms(t *testing.T) {
+	cases := []struct {
+		sql  string
+		want []string
+	}{
+		{"BUILD INDEX index1 ON table1 PARTITION(p1, p2)", []string{"p1", "p2"}},
+		{"BUILD INDEX index1 ON table1 PARTITION p1", []string{"p1"}},
+		{"BUILD INDEX index1 ON table1 PARTITIONS(p1)", []string{"p1"}},
+	}
+	for _, tc := range cases {
+		file, errs := Parse(tc.sql)
+		if len(errs) != 0 {
+			t.Fatalf("Parse(%q) errors: %v", tc.sql, errs)
+		}
+		n := file.Stmts[0].(*ast.BuildIndexStmt)
+		if len(n.Partitions) != len(tc.want) {
+			t.Fatalf("Parse(%q) Partitions = %v, want %v", tc.sql, n.Partitions, tc.want)
+		}
+		for i := range tc.want {
+			if n.Partitions[i] != tc.want[i] {
+				t.Errorf("Parse(%q) Partitions[%d] = %q, want %q", tc.sql, i, n.Partitions[i], tc.want[i])
+			}
+		}
+	}
+}

--- a/doris/parser/merge.go
+++ b/doris/parser/merge.go
@@ -98,7 +98,7 @@ func (p *Parser) parseMergeSource() (ast.Node, string, error) {
 		if err != nil {
 			return nil, "", err
 		}
-		alias := p.parseOptionalAlias(false)
+		alias, _ := p.parseOptionalAlias(false)
 		return subq, alias, nil
 	}
 
@@ -111,7 +111,7 @@ func (p *Parser) parseMergeSource() (ast.Node, string, error) {
 		Name: name,
 		Loc:  name.Loc,
 	}
-	alias := p.parseOptionalAlias(false)
+	alias, _ := p.parseOptionalAlias(false)
 	if alias != "" {
 		ref.Alias = alias
 		ref.Loc.End = p.prev.Loc.End

--- a/doris/parser/merge.go
+++ b/doris/parser/merge.go
@@ -98,7 +98,7 @@ func (p *Parser) parseMergeSource() (ast.Node, string, error) {
 		if err != nil {
 			return nil, "", err
 		}
-		alias := p.parseOptionalAlias()
+		alias := p.parseOptionalAlias(false)
 		return subq, alias, nil
 	}
 
@@ -111,7 +111,7 @@ func (p *Parser) parseMergeSource() (ast.Node, string, error) {
 		Name: name,
 		Loc:  name.Loc,
 	}
-	alias := p.parseOptionalAlias()
+	alias := p.parseOptionalAlias(false)
 	if alias != "" {
 		ref.Alias = alias
 		ref.Loc.End = p.prev.Loc.End

--- a/doris/parser/select.go
+++ b/doris/parser/select.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"strings"
+
 	"github.com/bytebase/omni/doris/ast"
 )
 
@@ -66,11 +68,12 @@ func (p *Parser) parseSelectStmt() (*ast.SelectStmt, error) {
 
 	// GROUP BY clause
 	if p.cur.Kind == kwGROUP {
-		groupBy, err := p.parseGroupByClause()
+		groupBy, withRollup, err := p.parseGroupByClause()
 		if err != nil {
 			return nil, err
 		}
 		stmt.GroupBy = groupBy
+		stmt.GroupByWithRollup = withRollup
 	}
 
 	// HAVING clause
@@ -323,7 +326,7 @@ func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
 				Expr: fc,
 				Loc:  ast.Loc{Start: startLoc.Start},
 			}
-			alias := p.parseOptionalAlias()
+			alias := p.parseOptionalAlias(true)
 			if alias != "" {
 				item.Alias = alias
 			}
@@ -340,7 +343,7 @@ func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
 			Expr: colRef,
 			Loc:  ast.Loc{Start: startLoc.Start},
 		}
-		alias := p.parseOptionalAlias()
+		alias := p.parseOptionalAlias(true)
 		if alias != "" {
 			item.Alias = alias
 		}
@@ -359,7 +362,7 @@ func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
 		Loc:  ast.Loc{Start: startLoc.Start},
 	}
 
-	alias := p.parseOptionalAlias()
+	alias := p.parseOptionalAlias(true)
 	if alias != "" {
 		item.Alias = alias
 	}
@@ -379,11 +382,18 @@ func (p *Parser) isSelectIdentToken() bool {
 //
 // Alias forms:
 //   - AS identifier
+//   - AS 'string' (SELECT items only: identifierOrText allows AS "20%",
+//     while a table alias is a strictIdentifier and rejects strings)
 //   - identifier (implicit, if not a clause keyword)
-func (p *Parser) parseOptionalAlias() string {
+//
+// stringOK selects between those two grammar rules.
+func (p *Parser) parseOptionalAlias(stringOK bool) string {
 	// Explicit: AS alias
 	if p.cur.Kind == kwAS {
 		p.advance() // consume AS
+		if stringOK && p.cur.Kind == tokString {
+			return p.advance().Str
+		}
 		name, _, err := p.parseAliasIdentifier()
 		if err != nil {
 			return ""
@@ -507,7 +517,7 @@ func (p *Parser) parsePrimarySource() (ast.Node, error) {
 			ref := &ast.TableRef{
 				Loc: ast.Loc{Start: startLoc.Start},
 			}
-			alias := p.parseOptionalAlias()
+			alias := p.parseOptionalAlias(false)
 			if alias != "" {
 				ref.Alias = alias
 			}
@@ -549,7 +559,9 @@ func (p *Parser) parsePrimarySource() (ast.Node, error) {
 	return p.parseTableRef()
 }
 
-// parseTableRef parses one simple table reference: object_name [AS alias].
+// parseTableRef parses one simple table reference with its suffixes, in
+// grammar order (relationPrimary): name — or a table-valued function call —
+// then TABLET(...), then the alias, then TABLESAMPLE(...) [REPEATABLE seed].
 func (p *Parser) parseTableRef() (*ast.TableRef, error) {
 	name, err := p.parseMultipartIdentifier()
 	if err != nil {
@@ -561,13 +573,102 @@ func (p *Parser) parseTableRef() (*ast.TableRef, error) {
 		Loc:  ast.Loc{Start: name.Loc.Start},
 	}
 
-	alias := p.parseOptionalAlias()
+	// Table-valued function: BACKENDS(), numbers("number" = "10"). The grammar
+	// (#tableValuedFunction) takes a single identifier as the function name.
+	if p.cur.Kind == int('(') && len(name.Parts) == 1 {
+		p.advance() // consume '('
+		fc := &ast.FuncCallExpr{
+			Name: name,
+			Loc:  ast.Loc{Start: name.Loc.Start},
+		}
+		if p.cur.Kind != int(')') {
+			args, err := p.parseExprList()
+			if err != nil {
+				return nil, err
+			}
+			fc.Args = args
+		}
+		closeTok, err := p.expect(int(')'))
+		if err != nil {
+			return nil, err
+		}
+		fc.Loc.End = closeTok.Loc.End
+		ref.Func = fc
+	}
+
+	// TABLET(id, ...) sits between the name and the alias (grammar:
+	// tabletList? tableAlias). Only TABLET followed by '(' is the clause.
+	if p.cur.Kind == kwTABLET && p.peekNext().Kind == int('(') {
+		p.advance() // consume TABLET
+		p.advance() // consume '('
+		for {
+			idTok, err := p.expect(tokInt)
+			if err != nil {
+				return nil, err
+			}
+			ref.TabletIDs = append(ref.TabletIDs, idTok.Ival)
+			if p.cur.Kind != int(',') {
+				break
+			}
+			p.advance() // consume ','
+		}
+		if _, err := p.expect(int(')')); err != nil {
+			return nil, err
+		}
+	}
+
+	alias := p.parseOptionalAlias(false)
 	if alias != "" {
 		ref.Alias = alias
 	}
 
+	// TABLESAMPLE(...) [REPEATABLE seed] follows the alias (grammar:
+	// tableAlias sample?).
+	if p.cur.Kind == kwTABLESAMPLE && p.peekNext().Kind == int('(') {
+		sample, err := p.parseTableSample()
+		if err != nil {
+			return nil, err
+		}
+		ref.Sample = sample
+	}
+
 	ref.Loc.End = p.prev.Loc.End
 	return ref, nil
+}
+
+// parseTableSample parses TABLESAMPLE(n ROWS | n PERCENT | ) [REPEATABLE seed].
+// On entry cur is TABLESAMPLE with '(' next.
+func (p *Parser) parseTableSample() (*ast.TableSample, error) {
+	p.advance() // consume TABLESAMPLE
+	p.advance() // consume '('
+
+	sample := &ast.TableSample{}
+	if p.cur.Kind != int(')') {
+		valTok, err := p.expect(tokInt)
+		if err != nil {
+			return nil, err
+		}
+		sample.Value = &ast.Literal{Kind: ast.LitInt, Value: valTok.Str, Loc: valTok.Loc}
+		switch p.cur.Kind {
+		case kwROWS, kwPERCENT:
+			sample.Unit = strings.ToUpper(p.advance().Str)
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+	}
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+
+	if p.cur.Kind == kwREPEATABLE {
+		p.advance() // consume REPEATABLE
+		seedTok, err := p.expect(tokInt)
+		if err != nil {
+			return nil, err
+		}
+		sample.Seed = &ast.Literal{Kind: ast.LitInt, Value: seedTok.Str, Loc: seedTok.Loc}
+	}
+	return sample, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -823,12 +924,14 @@ func (p *Parser) consumeDirectionAndJoin() ast.JoinType {
 // GROUP BY clause
 // ---------------------------------------------------------------------------
 
-// parseGroupByClause parses GROUP BY expr, expr, ...
-// Returns the list of GROUP BY expressions.
-func (p *Parser) parseGroupByClause() ([]ast.Node, error) {
+// parseGroupByClause parses the grouping specification after GROUP BY: a
+// plain expression list (optionally followed by WITH ROLLUP), or exactly one
+// of CUBE(...) / GROUPING SETS (...). Returns the grouping items and whether
+// WITH ROLLUP was present.
+func (p *Parser) parseGroupByClause() ([]ast.Node, bool, error) {
 	p.advance() // consume GROUP
 	if _, err := p.expect(kwBY); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	// CUBE is a reserved keyword, so `GROUP BY CUBE(a, b)` cannot reach the
@@ -836,19 +939,85 @@ func (p *Parser) parseGroupByClause() ([]ast.Node, error) {
 	if p.cur.Kind == kwCUBE && p.peekNext().Kind == int('(') {
 		fc, err := p.parseGroupingElementCall()
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		// CUBE(...) is the entire grouping specification — the engine rejects
 		// both `GROUP BY CUBE(a), b` and `GROUP BY CUBE(a), CUBE(b)`. Without
 		// this check, returning here would silently discard everything after
 		// the comma and hand downstream analysis an incomplete GROUP BY.
 		if p.cur.Kind == int(',') {
-			return nil, p.syntaxErrorAtCur()
+			return nil, false, p.syntaxErrorAtCur()
 		}
-		return []ast.Node{fc}, nil
+		return []ast.Node{fc}, false, nil
 	}
 
-	return p.parseExprList()
+	// GROUPING SETS (...) — like CUBE, the entire grouping specification.
+	// GROUPING alone stays an ordinary identifier (it is non-reserved), so a
+	// column named grouping still groups normally.
+	if p.cur.Kind == kwGROUPING && p.peekNext().Kind == kwSETS {
+		gs, err := p.parseGroupingSets()
+		if err != nil {
+			return nil, false, err
+		}
+		if p.cur.Kind == int(',') {
+			return nil, false, p.syntaxErrorAtCur()
+		}
+		return []ast.Node{gs}, false, nil
+	}
+
+	list, err := p.parseExprList()
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Optional WITH ROLLUP — the grammar allows it only on the plain
+	// expression-list form, not after CUBE / GROUPING SETS.
+	if p.cur.Kind == kwWITH && p.peekNext().Kind == kwROLLUP {
+		p.advance() // consume WITH
+		p.advance() // consume ROLLUP
+		return list, true, nil
+	}
+	return list, false, nil
+}
+
+// parseGroupingSets parses GROUPING SETS ((a, b), (a), ()). On entry cur is
+// GROUPING with SETS next. Every set is itself parenthesized and may be empty.
+func (p *Parser) parseGroupingSets() (ast.Node, error) {
+	startTok := p.advance() // consume GROUPING
+	p.advance()             // consume SETS
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+
+	gs := &ast.GroupingSetsExpr{}
+	for {
+		if _, err := p.expect(int('(')); err != nil {
+			return nil, err
+		}
+		var set []ast.Node
+		if p.cur.Kind != int(')') {
+			exprs, err := p.parseExprList()
+			if err != nil {
+				return nil, err
+			}
+			set = exprs
+		}
+		if _, err := p.expect(int(')')); err != nil {
+			return nil, err
+		}
+		gs.Sets = append(gs.Sets, set)
+		if p.cur.Kind != int(',') {
+			break
+		}
+		p.advance() // consume ','
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	gs.Loc = ast.Loc{Start: startTok.Loc.Start, End: closeTok.Loc.End}
+	return gs, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -866,7 +1035,17 @@ func (p *Parser) parseLimitClause() (ast.Node, ast.Node, error) {
 	}
 
 	var offsetExpr ast.Node
-	if p.cur.Kind == kwOFFSET {
+	switch p.cur.Kind {
+	case int(','):
+		// MySQL form LIMIT offset, row_count: the expression parsed first is
+		// the offset and the one after the comma is the count.
+		p.advance() // consume ','
+		offsetExpr = limitExpr
+		limitExpr, err = p.parseExpr()
+		if err != nil {
+			return nil, nil, err
+		}
+	case kwOFFSET:
 		p.advance() // consume OFFSET
 		offsetExpr, err = p.parseExpr()
 		if err != nil {

--- a/doris/parser/select.go
+++ b/doris/parser/select.go
@@ -326,9 +326,10 @@ func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
 				Expr: fc,
 				Loc:  ast.Loc{Start: startLoc.Start},
 			}
-			alias := p.parseOptionalAlias(true)
-			if alias != "" {
+			alias, aliased := p.parseOptionalAlias(true)
+			if aliased {
 				item.Alias = alias
+				item.Aliased = true
 			}
 			item.Loc.End = p.prev.Loc.End
 			return item, nil
@@ -343,9 +344,10 @@ func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
 			Expr: colRef,
 			Loc:  ast.Loc{Start: startLoc.Start},
 		}
-		alias := p.parseOptionalAlias(true)
-		if alias != "" {
+		alias, aliased := p.parseOptionalAlias(true)
+		if aliased {
 			item.Alias = alias
+			item.Aliased = true
 		}
 		item.Loc.End = p.prev.Loc.End
 		return item, nil
@@ -362,9 +364,10 @@ func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
 		Loc:  ast.Loc{Start: startLoc.Start},
 	}
 
-	alias := p.parseOptionalAlias(true)
-	if alias != "" {
+	alias, aliased := p.parseOptionalAlias(true)
+	if aliased {
 		item.Alias = alias
+		item.Aliased = true
 	}
 
 	item.Loc.End = p.prev.Loc.End
@@ -387,18 +390,22 @@ func (p *Parser) isSelectIdentToken() bool {
 //   - identifier (implicit, if not a clause keyword)
 //
 // stringOK selects between those two grammar rules.
-func (p *Parser) parseOptionalAlias(stringOK bool) string {
+//
+// The second return reports whether an alias was present at all: the empty
+// string alias AS ” is engine-valid and distinct from "no alias", so the
+// value alone cannot carry presence.
+func (p *Parser) parseOptionalAlias(stringOK bool) (string, bool) {
 	// Explicit: AS alias
 	if p.cur.Kind == kwAS {
 		p.advance() // consume AS
 		if stringOK && p.cur.Kind == tokString {
-			return p.advance().Str
+			return p.advance().Str, true
 		}
 		name, _, err := p.parseAliasIdentifier()
 		if err != nil {
-			return ""
+			return "", false
 		}
-		return name
+		return name, true
 	}
 
 	// Implicit alias: current token is an identifier or non-reserved keyword
@@ -406,12 +413,12 @@ func (p *Parser) parseOptionalAlias(stringOK bool) string {
 	if p.isAliasIdentToken() {
 		name, _, err := p.parseAliasIdentifier()
 		if err != nil {
-			return ""
+			return "", false
 		}
-		return name
+		return name, true
 	}
 
-	return ""
+	return "", false
 }
 
 // isAliasIdentToken reports whether the current token can be used as an
@@ -517,7 +524,7 @@ func (p *Parser) parsePrimarySource() (ast.Node, error) {
 			ref := &ast.TableRef{
 				Loc: ast.Loc{Start: startLoc.Start},
 			}
-			alias := p.parseOptionalAlias(false)
+			alias, _ := p.parseOptionalAlias(false)
 			if alias != "" {
 				ref.Alias = alias
 			}
@@ -617,7 +624,7 @@ func (p *Parser) parseTableRef() (*ast.TableRef, error) {
 		}
 	}
 
-	alias := p.parseOptionalAlias(false)
+	alias, _ := p.parseOptionalAlias(false)
 	if alias != "" {
 		ref.Alias = alias
 	}

--- a/doris/parser/select.go
+++ b/doris/parser/select.go
@@ -293,18 +293,19 @@ func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
 		return item, nil
 	}
 
-	// Try to detect table.* pattern:
-	// If we see an identifier followed by '.', it might be table.* or table.col.
-	// We need to check for qualified star: ident.* or ident.ident.*
+	// Qualified star: ident.* or ident.ident.*. This lookahead exists ONLY
+	// for the star form — any other qualified name must go through the
+	// general expression path below, because an expression can continue
+	// after it (t.a + 1, t.arr[1], db.f(1) OVER (...)); returning a bare
+	// ColumnRef here would hand that continuation to the trailing-token
+	// swallow. The multipart identifier is re-parsed after the rollback —
+	// a few tokens, same cost class as the paren-lambda speculation.
 	if p.isSelectIdentToken() && p.peekNext().Kind == int('.') {
-		// Save state to potentially backtrack.
-		// Parse the multipart identifier first, then check for .*
+		saved := p.save()
 		name, err := p.parseMultipartIdentifier()
 		if err != nil {
 			return nil, err
 		}
-
-		// Check for .* after the multipart identifier
 		if p.cur.Kind == int('.') && p.peekNext().Kind == int('*') {
 			p.advance() // consume '.'
 			p.advance() // consume '*'
@@ -314,43 +315,7 @@ func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
 				Loc:       ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End},
 			}, nil
 		}
-
-		// Not a qualified star — the multipart identifier is a column ref or
-		// function call. Check if it's a function call.
-		if p.cur.Kind == int('(') {
-			fc, err := p.parseFuncCall(name)
-			if err != nil {
-				return nil, err
-			}
-			item := &ast.SelectItem{
-				Expr: fc,
-				Loc:  ast.Loc{Start: startLoc.Start},
-			}
-			alias, aliased := p.parseOptionalAlias(true)
-			if aliased {
-				item.Alias = alias
-				item.Aliased = true
-			}
-			item.Loc.End = p.prev.Loc.End
-			return item, nil
-		}
-
-		// Plain column reference — check for alias.
-		colRef := &ast.ColumnRef{
-			Name: name,
-			Loc:  name.Loc,
-		}
-		item := &ast.SelectItem{
-			Expr: colRef,
-			Loc:  ast.Loc{Start: startLoc.Start},
-		}
-		alias, aliased := p.parseOptionalAlias(true)
-		if aliased {
-			item.Alias = alias
-			item.Aliased = true
-		}
-		item.Loc.End = p.prev.Loc.End
-		return item, nil
+		p.restore(saved)
 	}
 
 	// General expression

--- a/doris/parser/select_test.go
+++ b/doris/parser/select_test.go
@@ -644,3 +644,38 @@ func TestSelectTableFunctionNameWalkedOnce(t *testing.T) {
 		t.Errorf("ObjectName visited %d times, want 1", count)
 	}
 }
+
+func TestSelectQualifiedColumnContinuations(t *testing.T) {
+	// A select item starting with a qualified column must flow through the
+	// general expression parser: the old fast path returned a bare ColumnRef
+	// and handed any continuation to the trailing-token swallow.
+	stmt := mustParseSelect(t, "SELECT t.secret_col[1] FROM sensitive_table t")
+	if _, ok := stmt.Items[0].Expr.(*ast.ElementAtExpr); !ok {
+		t.Fatalf("Items[0].Expr = %T, want *ast.ElementAtExpr", stmt.Items[0].Expr)
+	}
+	if len(stmt.From) != 1 {
+		t.Fatal("FROM clause lost after qualified subscript")
+	}
+
+	stmt = mustParseSelect(t, "SELECT t.a + 1 FROM t")
+	if _, ok := stmt.Items[0].Expr.(*ast.BinaryExpr); !ok {
+		t.Fatalf("Items[0].Expr = %T, want *ast.BinaryExpr", stmt.Items[0].Expr)
+	}
+	if len(stmt.From) != 1 {
+		t.Fatal("FROM clause lost after qualified arithmetic")
+	}
+
+	// The plain and star forms keep their shapes.
+	stmt = mustParseSelect(t, "SELECT t.a AS x FROM t")
+	if _, ok := stmt.Items[0].Expr.(*ast.ColumnRef); !ok || stmt.Items[0].Alias != "x" {
+		t.Fatalf("Items[0] = %+v, want aliased ColumnRef", stmt.Items[0])
+	}
+	stmt = mustParseSelect(t, "SELECT t.* FROM t")
+	if !stmt.Items[0].Star || stmt.Items[0].TableName == nil {
+		t.Fatalf("Items[0] = %+v, want qualified star", stmt.Items[0])
+	}
+	stmt = mustParseSelect(t, "SELECT db.f(1) FROM t")
+	if _, ok := stmt.Items[0].Expr.(*ast.FuncCallExpr); !ok {
+		t.Fatalf("Items[0].Expr = %T, want *ast.FuncCallExpr", stmt.Items[0].Expr)
+	}
+}

--- a/doris/parser/select_test.go
+++ b/doris/parser/select_test.go
@@ -480,3 +480,140 @@ func TestSelectLoc(t *testing.T) {
 		t.Errorf("Loc.End = %d, want %d", stmt.Loc.End, len(input))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Constructs previously hidden by the trailing-token swallow (BYT-10084)
+// ---------------------------------------------------------------------------
+
+func TestSelectLimitOffsetComma(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT * FROM tbl LIMIT 5, 10")
+	lit, ok := stmt.Limit.(*ast.Literal)
+	if !ok || lit.Value != "10" {
+		t.Fatalf("Limit = %+v, want literal 10", stmt.Limit)
+	}
+	off, ok := stmt.Offset.(*ast.Literal)
+	if !ok || off.Value != "5" {
+		t.Fatalf("Offset = %+v, want literal 5", stmt.Offset)
+	}
+
+	// The uint64-max count from the legacy corpus must round-trip textually.
+	stmt = mustParseSelect(t, "SELECT * FROM tbl LIMIT 95, 18446744073709551615")
+	lit, ok = stmt.Limit.(*ast.Literal)
+	if !ok || lit.Value != "18446744073709551615" {
+		t.Fatalf("Limit = %+v, want literal 18446744073709551615", stmt.Limit)
+	}
+}
+
+func TestSelectStringAlias(t *testing.T) {
+	// AS "string": the alias used to be dropped together with everything
+	// after it, so the span lost the FROM table.
+	stmt := mustParseSelect(t, `SELECT *, (price * 0.8) AS "20%" FROM tb_book`)
+	if len(stmt.Items) != 2 || stmt.Items[1].Alias != "20%" {
+		t.Fatalf("Items[1].Alias = %+v, want 20%%", stmt.Items)
+	}
+	if len(stmt.From) != 1 {
+		t.Fatalf("From = %+v, want tb_book to survive the alias", stmt.From)
+	}
+
+	stmt = mustParseSelect(t, "SELECT 1 AS 'x'")
+	if stmt.Items[0].Alias != "x" {
+		t.Errorf("Alias = %q, want x", stmt.Items[0].Alias)
+	}
+}
+
+func TestSelectGroupByWithRollup(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a, SUM(b) FROM t GROUP BY a WITH ROLLUP")
+	if !stmt.GroupByWithRollup {
+		t.Error("GroupByWithRollup = false, want true")
+	}
+	if len(stmt.GroupBy) != 1 {
+		t.Errorf("GroupBy len = %d, want 1", len(stmt.GroupBy))
+	}
+
+	stmt = mustParseSelect(t, "SELECT a FROM t GROUP BY a")
+	if stmt.GroupByWithRollup {
+		t.Error("GroupByWithRollup = true, want false")
+	}
+}
+
+func TestSelectGroupByGroupingSets(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a, SUM(b) FROM t GROUP BY GROUPING SETS ((a, b), (a), ())")
+	if len(stmt.GroupBy) != 1 {
+		t.Fatalf("GroupBy len = %d, want 1", len(stmt.GroupBy))
+	}
+	gs, ok := stmt.GroupBy[0].(*ast.GroupingSetsExpr)
+	if !ok {
+		t.Fatalf("GroupBy[0] = %T, want *ast.GroupingSetsExpr", stmt.GroupBy[0])
+	}
+	if len(gs.Sets) != 3 || len(gs.Sets[0]) != 2 || len(gs.Sets[1]) != 1 || len(gs.Sets[2]) != 0 {
+		t.Fatalf("Sets shape = %v, want [2 1 0]", gs.Sets)
+	}
+
+	// Like CUBE, GROUPING SETS is the whole grouping specification.
+	_, errs := Parse("SELECT a FROM t GROUP BY GROUPING SETS ((a)), b")
+	if len(errs) == 0 {
+		t.Error("GROUPING SETS with a trailing item parsed, want error")
+	}
+
+	// A column that happens to be named grouping still groups normally.
+	stmt = mustParseSelect(t, "SELECT grouping FROM t GROUP BY grouping")
+	if _, ok := stmt.GroupBy[0].(*ast.ColumnRef); !ok {
+		t.Errorf("GroupBy[0] = %T, want *ast.ColumnRef", stmt.GroupBy[0])
+	}
+}
+
+func TestSelectFromTableValuedFunction(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT * FROM BACKENDS()")
+	ref, ok := stmt.From[0].(*ast.TableRef)
+	if !ok || ref.Func == nil {
+		t.Fatalf("From[0] = %+v, want TableRef with Func", stmt.From[0])
+	}
+	if len(ref.Func.Name.Parts) != 1 || ref.Func.Name.Parts[0] != "BACKENDS" {
+		t.Errorf("Func.Name = %+v, want BACKENDS", ref.Func.Name)
+	}
+
+	stmt = mustParseSelect(t, `SELECT * FROM numbers("number" = "10") n`)
+	ref = stmt.From[0].(*ast.TableRef)
+	if ref.Func == nil || len(ref.Func.Args) != 1 {
+		t.Fatalf("Func = %+v, want one argument", ref.Func)
+	}
+	if ref.Alias != "n" {
+		t.Errorf("Alias = %q, want n", ref.Alias)
+	}
+}
+
+func TestSelectFromTabletAndTableSample(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT * FROM t1 TABLET(10001) TABLESAMPLE(1000 ROWS) REPEATABLE 2 LIMIT 1000")
+	ref := stmt.From[0].(*ast.TableRef)
+	if len(ref.TabletIDs) != 1 || ref.TabletIDs[0] != 10001 {
+		t.Errorf("TabletIDs = %v, want [10001]", ref.TabletIDs)
+	}
+	if ref.Sample == nil || ref.Sample.Unit != "ROWS" {
+		t.Fatalf("Sample = %+v, want 1000 ROWS", ref.Sample)
+	}
+	if lit, ok := ref.Sample.Value.(*ast.Literal); !ok || lit.Value != "1000" {
+		t.Errorf("Sample.Value = %+v, want 1000", ref.Sample.Value)
+	}
+	if seed, ok := ref.Sample.Seed.(*ast.Literal); !ok || seed.Value != "2" {
+		t.Errorf("Sample.Seed = %+v, want 2", ref.Sample.Seed)
+	}
+	if stmt.Limit == nil {
+		t.Error("LIMIT after the sample clause was lost")
+	}
+
+	stmt = mustParseSelect(t, "SELECT * FROM t TABLESAMPLE(20 PERCENT)")
+	if ref := stmt.From[0].(*ast.TableRef); ref.Sample == nil || ref.Sample.Unit != "PERCENT" {
+		t.Errorf("Sample = %+v, want 20 PERCENT", ref.Sample)
+	}
+
+	stmt = mustParseSelect(t, "SELECT * FROM t TABLESAMPLE()")
+	if ref := stmt.From[0].(*ast.TableRef); ref.Sample == nil || ref.Sample.Value != nil {
+		t.Errorf("Sample = %+v, want empty TABLESAMPLE()", ref.Sample)
+	}
+
+	// TABLET sits before the alias, TABLESAMPLE after it.
+	stmt = mustParseSelect(t, "SELECT * FROM t1 TABLET(1) x TABLESAMPLE(10 ROWS)")
+	if ref := stmt.From[0].(*ast.TableRef); ref.Alias != "x" || len(ref.TabletIDs) != 1 || ref.Sample == nil {
+		t.Errorf("ref = %+v, want tablet+alias+sample", stmt.From[0])
+	}
+}

--- a/doris/parser/select_test.go
+++ b/doris/parser/select_test.go
@@ -519,6 +519,17 @@ func TestSelectStringAlias(t *testing.T) {
 	if stmt.Items[0].Alias != "x" {
 		t.Errorf("Alias = %q, want x", stmt.Items[0].Alias)
 	}
+
+	// The empty alias AS '' is engine-valid and distinct from no alias:
+	// presence is carried by Aliased, not by the string value.
+	stmt = mustParseSelect(t, "SELECT c AS '' FROM t")
+	if !stmt.Items[0].Aliased || stmt.Items[0].Alias != "" {
+		t.Errorf("AS '': Aliased=%v Alias=%q, want true and empty", stmt.Items[0].Aliased, stmt.Items[0].Alias)
+	}
+	stmt = mustParseSelect(t, "SELECT c FROM t")
+	if stmt.Items[0].Aliased {
+		t.Error("unaliased item reports Aliased=true")
+	}
 }
 
 func TestSelectGroupByWithRollup(t *testing.T) {
@@ -615,5 +626,21 @@ func TestSelectFromTabletAndTableSample(t *testing.T) {
 	stmt = mustParseSelect(t, "SELECT * FROM t1 TABLET(1) x TABLESAMPLE(10 ROWS)")
 	if ref := stmt.From[0].(*ast.TableRef); ref.Alias != "x" || len(ref.TabletIDs) != 1 || ref.Sample == nil {
 		t.Errorf("ref = %+v, want tablet+alias+sample", stmt.From[0])
+	}
+}
+
+func TestSelectTableFunctionNameWalkedOnce(t *testing.T) {
+	// TableRef.Name mirrors Func.Name for a table-valued function (same
+	// *ObjectName); the walker must visit it once, not twice.
+	stmt := mustParseSelect(t, "SELECT * FROM BACKENDS()")
+	count := 0
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		if _, ok := n.(*ast.ObjectName); ok {
+			count++
+		}
+		return true
+	})
+	if count != 1 {
+		t.Errorf("ObjectName visited %d times, want 1", count)
 	}
 }

--- a/doris/parser/show.go
+++ b/doris/parser/show.go
@@ -148,11 +148,21 @@ func (p *Parser) parseShowTables(stmt *ast.ShowStmt) (ast.Node, error) {
 	return stmt, nil
 }
 
-// parseShowDatabases parses: SHOW DATABASES [LIKE 'pat'] [WHERE ...]
+// parseShowDatabases parses: SHOW DATABASES [FROM catalog] [LIKE 'pat'] [WHERE ...]
 // On entry, cur == kwDATABASES or kwSCHEMAS.
 func (p *Parser) parseShowDatabases(stmt *ast.ShowStmt) (ast.Node, error) {
 	p.advance() // consume DATABASES/SCHEMAS
 	stmt.Type = "DATABASES"
+
+	// Optional FROM/IN <catalog>: SHOW DATABASES FROM hms_catalog.
+	if p.cur.Kind == kwFROM || p.cur.Kind == kwIN {
+		p.advance() // consume FROM/IN
+		catalog, _, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		stmt.From = catalog
+	}
 
 	p.parseShowLikeWhere(stmt)
 

--- a/doris/parser/show_test.go
+++ b/doris/parser/show_test.go
@@ -469,3 +469,16 @@ func TestShowLocValid(t *testing.T) {
 		t.Errorf("Loc.Start = %d, want 0", n.Loc.Start)
 	}
 }
+
+func TestShowDatabasesFromCatalog(t *testing.T) {
+	for _, sql := range []string{"SHOW DATABASES FROM hms_catalog", "SHOW DATABASES IN hms_catalog"} {
+		file, errs := Parse(sql)
+		if len(errs) != 0 {
+			t.Fatalf("Parse(%q) errors: %v", sql, errs)
+		}
+		n := file.Stmts[0].(*ast.ShowStmt)
+		if n.Type != "DATABASES" || n.From != "hms_catalog" {
+			t.Errorf("Parse(%q) = Type %q From %q, want DATABASES hms_catalog", sql, n.Type, n.From)
+		}
+	}
+}

--- a/doris/parser/split.go
+++ b/doris/parser/split.go
@@ -26,8 +26,8 @@ func (s Segment) Empty() bool {
 type splitState int
 
 const (
-	stateTop      splitState = iota
-	stateInBlock              // inside a BEGIN..END compound block
+	stateTop     splitState = iota
+	stateInBlock            // inside a BEGIN..END compound block
 )
 
 // Split extracts top-level SQL statements from input.
@@ -40,7 +40,7 @@ const (
 // should use NewLexer(input).Errors() directly.
 //
 // Split correctly handles:
-//   - Single-quoted strings with '' and \ escapes
+//   - Single-quoted strings with ” and \ escapes
 //   - Double-quoted strings with "" escapes
 //   - Backtick-quoted identifiers
 //   - X'...' hex literals and B'...' bit literals
@@ -60,23 +60,30 @@ func Split(input string) []Segment {
 	state := stateTop
 	depth := 0
 
-	// We need one-token lookahead after kwBEGIN to disambiguate TCL from
-	// compound block. Use a one-slot buffered lookahead.
-	var pending *Token
+	// We need lookahead after kwBEGIN to disambiguate TCL from a compound
+	// block: one token for most followers, two for BEGIN WITH LABEL (WITH
+	// alone could open a block whose first statement is a CTE). Use a small
+	// buffered queue.
+	var pending []Token
 	nextToken := func() Token {
-		if pending != nil {
-			t := *pending
-			pending = nil
+		if len(pending) > 0 {
+			t := pending[0]
+			pending = pending[1:]
 			return t
 		}
 		return l.NextToken()
 	}
 	peekToken := func() Token {
-		if pending == nil {
-			t := l.NextToken()
-			pending = &t
+		if len(pending) == 0 {
+			pending = append(pending, l.NextToken())
 		}
-		return *pending
+		return pending[0]
+	}
+	peekToken2 := func() Token {
+		for len(pending) < 2 {
+			pending = append(pending, l.NextToken())
+		}
+		return pending[1]
 	}
 
 	// emit creates a Segment covering input[stmtStart:end] — where end is
@@ -104,7 +111,12 @@ func Split(input string) []Segment {
 			switch tok.Kind {
 			case kwBEGIN:
 				next := peekToken()
-				if isDorisTCLBeginFollower(next) {
+				// BEGIN WITH LABEL x is the transaction form. WITH alone does
+				// not decide — a compound block's first statement can be a
+				// CTE — so the LABEL after it is what disambiguates.
+				isTCL := isDorisTCLBeginFollower(next) ||
+					(next.Kind == kwWITH && peekToken2().Kind == kwLABEL)
+				if isTCL {
 					// TCL: BEGIN;, BEGIN TRANSACTION, BEGIN WORK, BEGIN EOF.
 					// Stay in stateTop; the buffered peek will be returned
 					// by the next nextToken() call and handled normally.

--- a/doris/parser/split_test.go
+++ b/doris/parser/split_test.go
@@ -227,3 +227,21 @@ func TestSplit_Mixed(t *testing.T) {
 	}
 	runSplitCases(t, cases)
 }
+
+func TestSplit_BeginWithLabelIsTCL(t *testing.T) {
+	// BEGIN WITH LABEL is the transaction form: the ; after it must split.
+	segs := Split("BEGIN WITH LABEL load_1; COMMIT")
+	if len(segs) != 2 {
+		t.Fatalf("Split returned %d segments, want 2: %+v", len(segs), segs)
+	}
+	if segs[0].Text != "BEGIN WITH LABEL load_1" || segs[1].Text != " COMMIT" {
+		t.Errorf("segments = %q, %q", segs[0].Text, segs[1].Text)
+	}
+
+	// A compound block whose first statement is a CTE must stay one segment:
+	// WITH alone does not make BEGIN a transaction.
+	segs = Split("BEGIN WITH c AS (SELECT 1) SELECT * FROM c; END")
+	if len(segs) != 1 {
+		t.Fatalf("Split returned %d segments, want 1 (compound block): %+v", len(segs), segs)
+	}
+}

--- a/starrocks/analysis/query_span.go
+++ b/starrocks/analysis/query_span.go
@@ -438,7 +438,7 @@ func (w *spanWalker) makeColumnInfo(item *ast.SelectItem) ColumnInfo {
 		}
 		return info
 	}
-	if item.Alias != "" {
+	if item.Aliased {
 		info.Name = item.Alias
 	} else if item.Expr != nil {
 		info.Name = renderColumnName(item.Expr)

--- a/starrocks/analysis/query_span_test.go
+++ b/starrocks/analysis/query_span_test.go
@@ -573,3 +573,26 @@ func TestGetQuerySpan_LambdaSourceColumns(t *testing.T) {
 		})
 	}
 }
+
+func TestGetQuerySpan_SubscriptKeepsTableAccess(t *testing.T) {
+	// Before BYT-10084 the parser silently dropped everything after `[`, so
+	// this query lost its FROM clause and the span reported no table access —
+	// a fail-open blind spot for masking.
+	span, err := GetQuerySpan("SELECT secret_col[1] FROM sensitive_table")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.AccessTables) != 1 || span.AccessTables[0].Table != "sensitive_table" {
+		t.Fatalf("AccessTables = %+v, want [sensitive_table]", span.AccessTables)
+	}
+	if len(span.Results) != 1 {
+		t.Fatalf("Results = %+v, want one column", span.Results)
+	}
+	got := map[string]bool{}
+	for _, sc := range span.Results[0].SourceColumns {
+		got[sc.Column] = true
+	}
+	if !got["secret_col"] {
+		t.Errorf("SourceColumns %+v missing secret_col", span.Results[0].SourceColumns)
+	}
+}

--- a/starrocks/analysis/query_span_test.go
+++ b/starrocks/analysis/query_span_test.go
@@ -608,3 +608,15 @@ func TestGetQuerySpan_EmptyStringAlias(t *testing.T) {
 		t.Fatalf("Results = %+v, want one column named \"\"", span.Results)
 	}
 }
+
+func TestGetQuerySpan_QualifiedSubscriptKeepsTableAccess(t *testing.T) {
+	// The qualified twin of the subscript fail-open: the select-item fast
+	// path used to bypass the expression parser for t.col and drop the rest.
+	span, err := GetQuerySpan("SELECT t.secret_col[1] FROM sensitive_table t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.AccessTables) != 1 || span.AccessTables[0].Table != "sensitive_table" {
+		t.Fatalf("AccessTables = %+v, want [sensitive_table]", span.AccessTables)
+	}
+}

--- a/starrocks/analysis/query_span_test.go
+++ b/starrocks/analysis/query_span_test.go
@@ -596,3 +596,15 @@ func TestGetQuerySpan_SubscriptKeepsTableAccess(t *testing.T) {
 		t.Errorf("SourceColumns %+v missing secret_col", span.Results[0].SourceColumns)
 	}
 }
+
+func TestGetQuerySpan_EmptyStringAlias(t *testing.T) {
+	// SELECT c AS '' names the result column with the explicit empty alias;
+	// it must not fall back to the expression name.
+	span, err := GetQuerySpan("SELECT c AS '' FROM t")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	if len(span.Results) != 1 || span.Results[0].Name != "" {
+		t.Fatalf("Results = %+v, want one column named \"\"", span.Results)
+	}
+}

--- a/starrocks/ast/exprnodes.go
+++ b/starrocks/ast/exprnodes.go
@@ -12,30 +12,30 @@ type BinaryOp int
 const (
 	// Logical operators.
 	BinOr  BinaryOp = iota // OR, ||
-	BinAnd                  // AND, &&
-	BinXor                  // XOR
+	BinAnd                 // AND, &&
+	BinXor                 // XOR
 
 	// Comparison operators.
-	BinEq        // =
-	BinNe        // <> or !=
-	BinLt        // <
-	BinGt        // >
-	BinLe        // <=
-	BinGe        // >=
+	BinEq         // =
+	BinNe         // <> or !=
+	BinLt         // <
+	BinGt         // >
+	BinLe         // <=
+	BinGe         // >=
 	BinNullSafeEq // <=>
 
 	// Arithmetic operators.
-	BinAdd // +
-	BinSub // -
-	BinMul // *
-	BinDiv // /
-	BinMod // % or MOD
+	BinAdd    // +
+	BinSub    // -
+	BinMul    // *
+	BinDiv    // /
+	BinMod    // % or MOD
 	BinIntDiv // DIV
 
 	// Bitwise operators.
-	BinBitOr  // |
-	BinBitAnd // &
-	BinBitXor // ^
+	BinBitOr      // |
+	BinBitAnd     // &
+	BinBitXor     // ^
 	BinShiftLeft  // <<
 	BinShiftRight // >>
 )
@@ -95,10 +95,10 @@ type UnaryOp int
 
 const (
 	UnaryMinus  UnaryOp = iota // -
-	UnaryPlus                   // +
-	UnaryBitNot                 // ~
-	UnaryNot                    // NOT
-	UnaryBinary                 // BINARY (cast-to-binary operator)
+	UnaryPlus                  // +
+	UnaryBitNot                // ~
+	UnaryNot                   // NOT
+	UnaryBinary                // BINARY (cast-to-binary operator)
 )
 
 // String returns the SQL text form of the unary operator.
@@ -138,7 +138,7 @@ type CaseKind int
 
 const (
 	CaseSearched CaseKind = iota // CASE WHEN ...
-	CaseSimple                    // CASE operand WHEN ...
+	CaseSimple                   // CASE operand WHEN ...
 )
 
 // ---------------------------------------------------------------------------
@@ -170,10 +170,10 @@ var _ Node = (*UnaryExpr)(nil)
 
 // IsExpr represents expr IS [NOT] NULL / TRUE / FALSE.
 type IsExpr struct {
-	Expr    Node
-	Not     bool
-	IsWhat  string // "NULL", "TRUE", "FALSE"
-	Loc     Loc
+	Expr   Node
+	Not    bool
+	IsWhat string // "NULL", "TRUE", "FALSE"
+	Loc    Loc
 }
 
 func (n *IsExpr) Tag() NodeTag { return T_IsExpr }
@@ -195,10 +195,10 @@ var _ Node = (*BetweenExpr)(nil)
 
 // InExpr represents expr [NOT] IN (values...) or expr [NOT] IN (subquery).
 type InExpr struct {
-	Expr     Node
-	Values   []Node // list of values; for subquery, contains one SubqueryExpr
-	Not      bool
-	Loc      Loc
+	Expr   Node
+	Values []Node // list of values; for subquery, contains one SubqueryExpr
+	Not    bool
+	Loc    Loc
 }
 
 func (n *InExpr) Tag() NodeTag { return T_InExpr }
@@ -232,15 +232,15 @@ var _ Node = (*RegexpExpr)(nil)
 
 // FuncCallExpr represents a function call: name(args...).
 type FuncCallExpr struct {
-	Name     *ObjectName
-	Args     []Node
-	Distinct bool   // COUNT(DISTINCT x)
-	Star     bool   // COUNT(*)
-	OrderBy  []*OrderByItem // optional ORDER BY in aggregate (GROUP_CONCAT)
-	Separator string // optional SEPARATOR value for GROUP_CONCAT
-	IgnoreNulls bool // IGNORE NULLS null-treatment (FIRST_VALUE/LAST_VALUE/LEAD/LAG)
-	Over     *WindowSpec // optional OVER (...) window specification
-	Loc      Loc
+	Name        *ObjectName
+	Args        []Node
+	Distinct    bool           // COUNT(DISTINCT x)
+	Star        bool           // COUNT(*)
+	OrderBy     []*OrderByItem // optional ORDER BY in aggregate (GROUP_CONCAT)
+	Separator   string         // optional SEPARATOR value for GROUP_CONCAT
+	IgnoreNulls bool           // IGNORE NULLS null-treatment (FIRST_VALUE/LAST_VALUE/LEAD/LAG)
+	Over        *WindowSpec    // optional OVER (...) window specification
+	Loc         Loc
 }
 
 func (n *FuncCallExpr) Tag() NodeTag { return T_FuncCallExpr }
@@ -334,9 +334,9 @@ var _ Node = (*LambdaExpr)(nil)
 // CaseExpr represents CASE [operand] WHEN...THEN...ELSE...END.
 type CaseExpr struct {
 	Kind    CaseKind
-	Operand Node          // nil for searched CASE
+	Operand Node // nil for searched CASE
 	Whens   []*WhenClause
-	Else    Node          // nil if no ELSE
+	Else    Node // nil if no ELSE
 	Loc     Loc
 }
 
@@ -417,6 +417,43 @@ func (n *MapEntry) Tag() NodeTag { return T_MapEntry }
 
 var _ Node = (*MapEntry)(nil)
 
+// ElementAtExpr represents collection element access: value[index]
+// (grammar: elementAt). Applies to array, map and struct values alike.
+type ElementAtExpr struct {
+	Value Node
+	Index Node
+	Loc   Loc
+}
+
+func (n *ElementAtExpr) Tag() NodeTag { return T_ElementAtExpr }
+
+var _ Node = (*ElementAtExpr)(nil)
+
+// ArraySliceExpr represents an array slice: value[begin : end]
+// (grammar: arraySlice). End is nil for the open-ended form value[begin:].
+type ArraySliceExpr struct {
+	Value Node
+	Begin Node
+	End   Node // nil when omitted: value[begin:]
+	Loc   Loc
+}
+
+func (n *ArraySliceExpr) Tag() NodeTag { return T_ArraySliceExpr }
+
+var _ Node = (*ArraySliceExpr)(nil)
+
+// GroupingSetsExpr represents GROUP BY GROUPING SETS ((a, b), (a), ()).
+// Each set is one parenthesized expression list; the empty set () is a nil
+// entry. Like CUBE, GROUPING SETS is the entire grouping specification.
+type GroupingSetsExpr struct {
+	Sets [][]Node
+	Loc  Loc
+}
+
+func (n *GroupingSetsExpr) Tag() NodeTag { return T_GroupingSetsExpr }
+
+var _ Node = (*GroupingSetsExpr)(nil)
+
 // ArrayLiteral represents an array constructor literal:
 //
 //	array<t>[ e, ... ]   (typed)
@@ -468,8 +505,8 @@ var _ Node = (*IntervalExpr)(nil)
 // OrderByItem represents an expression with optional ASC/DESC and NULLS FIRST/LAST.
 type OrderByItem struct {
 	Expr       Node
-	Desc       bool   // true for DESC, false for ASC (default)
-	NullsFirst *bool  // nil if not specified; true for NULLS FIRST, false for NULLS LAST
+	Desc       bool  // true for DESC, false for ASC (default)
+	NullsFirst *bool // nil if not specified; true for NULLS FIRST, false for NULLS LAST
 	Loc        Loc
 }
 

--- a/starrocks/ast/exprnodes.go
+++ b/starrocks/ast/exprnodes.go
@@ -429,19 +429,6 @@ func (n *ElementAtExpr) Tag() NodeTag { return T_ElementAtExpr }
 
 var _ Node = (*ElementAtExpr)(nil)
 
-// ArraySliceExpr represents an array slice: value[begin : end]
-// (grammar: arraySlice). End is nil for the open-ended form value[begin:].
-type ArraySliceExpr struct {
-	Value Node
-	Begin Node
-	End   Node // nil when omitted: value[begin:]
-	Loc   Loc
-}
-
-func (n *ArraySliceExpr) Tag() NodeTag { return T_ArraySliceExpr }
-
-var _ Node = (*ArraySliceExpr)(nil)
-
 // GroupingSetsExpr represents GROUP BY GROUPING SETS ((a, b), (a), ()).
 // Each set is one parenthesized expression list; the empty set () is a nil
 // entry. Like CUBE, GROUPING SETS is the entire grouping specification.

--- a/starrocks/ast/loc.go
+++ b/starrocks/ast/loc.go
@@ -76,8 +76,6 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *ElementAtExpr:
 		return v.Loc
-	case *ArraySliceExpr:
-		return v.Loc
 	case *GroupingSetsExpr:
 		return v.Loc
 	case *ArrayLiteral:

--- a/starrocks/ast/loc.go
+++ b/starrocks/ast/loc.go
@@ -74,6 +74,12 @@ func NodeLoc(n Node) Loc {
 		return v.Loc
 	case *MapEntry:
 		return v.Loc
+	case *ElementAtExpr:
+		return v.Loc
+	case *ArraySliceExpr:
+		return v.Loc
+	case *GroupingSetsExpr:
+		return v.Loc
 	case *ArrayLiteral:
 		return v.Loc
 	case *ParenExpr:

--- a/starrocks/ast/nodetags.go
+++ b/starrocks/ast/nodetags.go
@@ -116,6 +116,15 @@ const (
 	// T_MapEntry is the tag for *MapEntry (one key:value pair in a MapLiteral).
 	T_MapEntry
 
+	// T_ElementAtExpr is the tag for *ElementAtExpr (value[index]).
+	T_ElementAtExpr
+
+	// T_ArraySliceExpr is the tag for *ArraySliceExpr (value[begin:end]).
+	T_ArraySliceExpr
+
+	// T_GroupingSetsExpr is the tag for *GroupingSetsExpr (GROUPING SETS (...)).
+	T_GroupingSetsExpr
+
 	// T_ArrayLiteral is the tag for *ArrayLiteral (array<t>[...] / [...]).
 	T_ArrayLiteral
 
@@ -700,6 +709,12 @@ func (t NodeTag) String() string {
 		return "MapLiteral"
 	case T_MapEntry:
 		return "MapEntry"
+	case T_ElementAtExpr:
+		return "ElementAtExpr"
+	case T_ArraySliceExpr:
+		return "ArraySliceExpr"
+	case T_GroupingSetsExpr:
+		return "GroupingSetsExpr"
 	case T_ArrayLiteral:
 		return "ArrayLiteral"
 	case T_ParenExpr:

--- a/starrocks/ast/nodetags.go
+++ b/starrocks/ast/nodetags.go
@@ -119,9 +119,6 @@ const (
 	// T_ElementAtExpr is the tag for *ElementAtExpr (value[index]).
 	T_ElementAtExpr
 
-	// T_ArraySliceExpr is the tag for *ArraySliceExpr (value[begin:end]).
-	T_ArraySliceExpr
-
 	// T_GroupingSetsExpr is the tag for *GroupingSetsExpr (GROUPING SETS (...)).
 	T_GroupingSetsExpr
 
@@ -711,8 +708,6 @@ func (t NodeTag) String() string {
 		return "MapEntry"
 	case T_ElementAtExpr:
 		return "ElementAtExpr"
-	case T_ArraySliceExpr:
-		return "ArraySliceExpr"
 	case T_GroupingSetsExpr:
 		return "GroupingSetsExpr"
 	case T_ArrayLiteral:

--- a/starrocks/ast/selectnodes.go
+++ b/starrocks/ast/selectnodes.go
@@ -51,21 +51,20 @@ var _ Node = (*CTE)(nil)
 //	  [LIMIT count [OFFSET offset]]
 //	  [INTO OUTFILE ...]
 type SelectStmt struct {
-	With              *WithClause        // optional WITH clause (nil if absent)
-	Distinct          bool               // DISTINCT keyword present
-	All               bool               // ALL keyword present (explicit, rarely used)
-	Items             []*SelectItem      // SELECT list
-	From              []Node             // FROM clause table references (TableRef or JoinClause)
-	Where             Node               // WHERE expression (nil if absent)
-	GroupBy           []Node             // GROUP BY expressions
-	GroupByWithRollup bool               // GROUP BY ... WITH ROLLUP
-	Having            Node               // HAVING expression (nil if absent)
-	Qualify           Node               // QUALIFY expression (nil if absent)
-	OrderBy           []*OrderByItem     // ORDER BY items
-	Limit             Node               // LIMIT expression (nil if absent)
-	Offset            Node               // OFFSET expression (nil if absent)
-	Into              *IntoOutfileClause // INTO OUTFILE clause (nil if absent)
-	Loc               Loc
+	With     *WithClause        // optional WITH clause (nil if absent)
+	Distinct bool               // DISTINCT keyword present
+	All      bool               // ALL keyword present (explicit, rarely used)
+	Items    []*SelectItem      // SELECT list
+	From     []Node             // FROM clause table references (TableRef or JoinClause)
+	Where    Node               // WHERE expression (nil if absent)
+	GroupBy  []Node             // GROUP BY expressions
+	Having   Node               // HAVING expression (nil if absent)
+	Qualify  Node               // QUALIFY expression (nil if absent)
+	OrderBy  []*OrderByItem     // ORDER BY items
+	Limit    Node               // LIMIT expression (nil if absent)
+	Offset   Node               // OFFSET expression (nil if absent)
+	Into     *IntoOutfileClause // INTO OUTFILE clause (nil if absent)
+	Loc      Loc
 }
 
 // IntoOutfileClause represents an INTO OUTFILE clause for exporting query
@@ -135,18 +134,7 @@ type TableRef struct {
 	// appears between the table name and the alias.
 	TabletIDs []int64
 
-	// Sample holds TABLESAMPLE(...) [REPEATABLE seed], which follows the alias.
-	Sample *TableSample
-
 	Loc Loc
-}
-
-// TableSample is the TABLESAMPLE(...) [REPEATABLE seed] suffix of a table
-// reference: TABLESAMPLE(1000 ROWS), TABLESAMPLE(20 PERCENT), TABLESAMPLE().
-type TableSample struct {
-	Value Node   // sample size; nil for the bare TABLESAMPLE() form
-	Unit  string // "ROWS" or "PERCENT"; empty when Value is nil
-	Seed  Node   // REPEATABLE seed; nil if absent
 }
 
 // Tag implements Node.

--- a/starrocks/ast/selectnodes.go
+++ b/starrocks/ast/selectnodes.go
@@ -103,7 +103,12 @@ var _ Node = (*SelectStmt)(nil)
 type SelectItem struct {
 	Expr  Node   // the expression; for *, this is nil
 	Alias string // optional alias name; empty if absent
-	Star  bool   // true for * or table.*
+
+	// Aliased reports whether an explicit alias was present. It is what
+	// distinguishes the engine-valid empty alias (SELECT c AS '') from no
+	// alias at all — Alias alone cannot, since "" is its absent value.
+	Aliased bool
+	Star    bool // true for * or table.*
 	// For table.*, TableName holds the qualifier ObjectName.
 	TableName *ObjectName
 	// For SELECT * EXCEPT (col1, col2, ...) — list of column names to exclude.

--- a/starrocks/ast/selectnodes.go
+++ b/starrocks/ast/selectnodes.go
@@ -51,20 +51,21 @@ var _ Node = (*CTE)(nil)
 //	  [LIMIT count [OFFSET offset]]
 //	  [INTO OUTFILE ...]
 type SelectStmt struct {
-	With     *WithClause        // optional WITH clause (nil if absent)
-	Distinct bool               // DISTINCT keyword present
-	All      bool               // ALL keyword present (explicit, rarely used)
-	Items    []*SelectItem      // SELECT list
-	From     []Node             // FROM clause table references (TableRef or JoinClause)
-	Where    Node               // WHERE expression (nil if absent)
-	GroupBy  []Node             // GROUP BY expressions
-	Having   Node               // HAVING expression (nil if absent)
-	Qualify  Node               // QUALIFY expression (nil if absent)
-	OrderBy  []*OrderByItem     // ORDER BY items
-	Limit    Node               // LIMIT expression (nil if absent)
-	Offset   Node               // OFFSET expression (nil if absent)
-	Into     *IntoOutfileClause // INTO OUTFILE clause (nil if absent)
-	Loc      Loc
+	With              *WithClause        // optional WITH clause (nil if absent)
+	Distinct          bool               // DISTINCT keyword present
+	All               bool               // ALL keyword present (explicit, rarely used)
+	Items             []*SelectItem      // SELECT list
+	From              []Node             // FROM clause table references (TableRef or JoinClause)
+	Where             Node               // WHERE expression (nil if absent)
+	GroupBy           []Node             // GROUP BY expressions
+	GroupByWithRollup bool               // GROUP BY ... WITH ROLLUP
+	Having            Node               // HAVING expression (nil if absent)
+	Qualify           Node               // QUALIFY expression (nil if absent)
+	OrderBy           []*OrderByItem     // ORDER BY items
+	Limit             Node               // LIMIT expression (nil if absent)
+	Offset            Node               // OFFSET expression (nil if absent)
+	Into              *IntoOutfileClause // INTO OUTFILE clause (nil if absent)
+	Loc               Loc
 }
 
 // IntoOutfileClause represents an INTO OUTFILE clause for exporting query
@@ -74,8 +75,8 @@ type SelectStmt struct {
 //	  [FORMAT AS format_type]
 //	  [PROPERTIES ("key" = "value", ...)]
 type IntoOutfileClause struct {
-	Path       string     // file path (S3, HDFS, or local)
-	Format     string     // format type: CSV, PARQUET, ORC, etc. (empty if not specified)
+	Path       string      // file path (S3, HDFS, or local)
+	Format     string      // format type: CSV, PARQUET, ORC, etc. (empty if not specified)
 	Properties []*Property // PROPERTIES key-value pairs
 	Loc        Loc
 }
@@ -129,7 +130,23 @@ var _ Node = (*SelectItem)(nil)
 type TableRef struct {
 	Name  *ObjectName // table name (may be qualified: db.table or catalog.db.table)
 	Alias string      // optional alias; empty if absent
-	Loc   Loc
+
+	// TabletIDs holds TABLET(id, ...) — a physical-tablet restriction that
+	// appears between the table name and the alias.
+	TabletIDs []int64
+
+	// Sample holds TABLESAMPLE(...) [REPEATABLE seed], which follows the alias.
+	Sample *TableSample
+
+	Loc Loc
+}
+
+// TableSample is the TABLESAMPLE(...) [REPEATABLE seed] suffix of a table
+// reference: TABLESAMPLE(1000 ROWS), TABLESAMPLE(20 PERCENT), TABLESAMPLE().
+type TableSample struct {
+	Value Node   // sample size; nil for the bare TABLESAMPLE() form
+	Unit  string // "ROWS" or "PERCENT"; empty when Value is nil
+	Seed  Node   // REPEATABLE seed; nil if absent
 }
 
 // Tag implements Node.

--- a/starrocks/ast/walk_children.go
+++ b/starrocks/ast/walk_children.go
@@ -141,12 +141,6 @@ func walkChildren(v Visitor, node Node) {
 	case *ElementAtExpr:
 		Walk(v, n.Value)
 		Walk(v, n.Index)
-	case *ArraySliceExpr:
-		Walk(v, n.Value)
-		Walk(v, n.Begin)
-		if n.End != nil {
-			Walk(v, n.End)
-		}
 	case *GroupingSetsExpr:
 		for _, set := range n.Sets {
 			for _, e := range set {
@@ -218,14 +212,6 @@ func walkChildren(v Visitor, node Node) {
 	case *TableRef:
 		if n.Name != nil {
 			Walk(v, n.Name)
-		}
-		if n.Sample != nil {
-			if n.Sample.Value != nil {
-				Walk(v, n.Sample.Value)
-			}
-			if n.Sample.Seed != nil {
-				Walk(v, n.Sample.Seed)
-			}
 		}
 	case *InlineTable:
 		for _, row := range n.Rows {

--- a/starrocks/ast/walk_children.go
+++ b/starrocks/ast/walk_children.go
@@ -138,6 +138,21 @@ func walkChildren(v Visitor, node Node) {
 	case *MapEntry:
 		Walk(v, n.Key)
 		Walk(v, n.Value)
+	case *ElementAtExpr:
+		Walk(v, n.Value)
+		Walk(v, n.Index)
+	case *ArraySliceExpr:
+		Walk(v, n.Value)
+		Walk(v, n.Begin)
+		if n.End != nil {
+			Walk(v, n.End)
+		}
+	case *GroupingSetsExpr:
+		for _, set := range n.Sets {
+			for _, e := range set {
+				Walk(v, e)
+			}
+		}
 	case *ArrayLiteral:
 		if n.ElemType != nil {
 			Walk(v, n.ElemType)
@@ -203,6 +218,14 @@ func walkChildren(v Visitor, node Node) {
 	case *TableRef:
 		if n.Name != nil {
 			Walk(v, n.Name)
+		}
+		if n.Sample != nil {
+			if n.Sample.Value != nil {
+				Walk(v, n.Sample.Value)
+			}
+			if n.Sample.Seed != nil {
+				Walk(v, n.Sample.Seed)
+			}
 		}
 	case *InlineTable:
 		for _, row := range n.Rows {

--- a/starrocks/parser/create_table.go
+++ b/starrocks/parser/create_table.go
@@ -586,7 +586,7 @@ func (p *Parser) parseTableConstraint() (*ast.TableConstraint, error) {
 		}
 		tc.Type = ast.ConstraintPrimaryKey
 	case kwUNIQUE:
-		p.advance() // consume UNIQUE
+		p.advance()    // consume UNIQUE
 		p.match(kwKEY) // optional KEY
 		tc.Type = ast.ConstraintUnique
 	default:
@@ -628,7 +628,7 @@ func (p *Parser) parseCreateTableClauses(stmt *ast.CreateTableStmt) error {
 			stmt.Engine = engineName
 			continue
 
-		case kwAGGREGATE, kwUNIQUE, kwDUPLICATE:
+		case kwAGGREGATE, kwUNIQUE, kwDUPLICATE, kwPRIMARY:
 			keyDesc, err := p.parseKeyDesc()
 			if err != nil {
 				return err

--- a/starrocks/parser/create_table_test.go
+++ b/starrocks/parser/create_table_test.go
@@ -968,3 +968,15 @@ func TestCreateTable_LegacyCorpus(t *testing.T) {
 		}
 	}
 }
+
+func TestCreateTablePrimaryKeyDesc(t *testing.T) {
+	// The PRIMARY KEY(...) after the column list used to be silently dropped
+	// together with everything that followed it (BYT-10084).
+	stmt := parseCreateTableStmt(t, "CREATE TABLE pk (id BIGINT, v VARCHAR(64)) PRIMARY KEY(id) DISTRIBUTED BY HASH(id)")
+	if stmt.KeyDesc == nil || stmt.KeyDesc.Type != "PRIMARY" {
+		t.Fatalf("KeyDesc = %+v, want PRIMARY KEY", stmt.KeyDesc)
+	}
+	if len(stmt.KeyDesc.Columns) != 1 || stmt.KeyDesc.Columns[0] != "id" {
+		t.Errorf("KeyDesc.Columns = %v, want [id]", stmt.KeyDesc.Columns)
+	}
+}

--- a/starrocks/parser/expr.go
+++ b/starrocks/parser/expr.go
@@ -279,8 +279,58 @@ func (p *Parser) parsePrefixExpr() (ast.Node, error) {
 		return p.parseIntervalExpr()
 
 	default:
-		return p.parsePrimaryExpr()
+		node, err := p.parsePrimaryExpr()
+		if err != nil {
+			return nil, err
+		}
+		return p.parsePostfixSubscripts(node)
 	}
+}
+
+// parsePostfixSubscripts parses any chain of element-access / slice suffixes
+// after a primary expression: m['k'], arr[1][2], arr[1:3], arr[2:]. The
+// grammar (elementAt, arraySlice) applies these to primaryExpression, so they
+// bind tighter than any operator. The index and bounds are valueExpressions —
+// comparisons are allowed but AND/OR/NOT are not, hence bpNot+1.
+func (p *Parser) parsePostfixSubscripts(node ast.Node) (ast.Node, error) {
+	for p.cur.Kind == int('[') {
+		p.advance() // consume '['
+		begin, err := p.parseExprPrec(bpNot + 1)
+		if err != nil {
+			return nil, err
+		}
+		if p.cur.Kind == int(':') {
+			p.advance() // consume ':'
+			var end ast.Node
+			if p.cur.Kind != int(']') {
+				end, err = p.parseExprPrec(bpNot + 1)
+				if err != nil {
+					return nil, err
+				}
+			}
+			closeTok, err := p.expect(int(']'))
+			if err != nil {
+				return nil, err
+			}
+			node = &ast.ArraySliceExpr{
+				Value: node,
+				Begin: begin,
+				End:   end,
+				Loc:   ast.Loc{Start: ast.NodeLoc(node).Start, End: closeTok.Loc.End},
+			}
+			continue
+		}
+		closeTok, err := p.expect(int(']'))
+		if err != nil {
+			return nil, err
+		}
+		node = &ast.ElementAtExpr{
+			Value: node,
+			Index: begin,
+			Loc:   ast.Loc{Start: ast.NodeLoc(node).Start, End: closeTok.Loc.End},
+		}
+	}
+	return node, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/starrocks/parser/expr.go
+++ b/starrocks/parser/expr.go
@@ -287,38 +287,18 @@ func (p *Parser) parsePrefixExpr() (ast.Node, error) {
 	}
 }
 
-// parsePostfixSubscripts parses any chain of element-access / slice suffixes
-// after a primary expression: m['k'], arr[1][2], arr[1:3], arr[2:]. The
-// grammar (elementAt, arraySlice) applies these to primaryExpression, so they
-// bind tighter than any operator. The index and bounds are valueExpressions —
-// comparisons are allowed but AND/OR/NOT are not, hence bpNot+1.
+// parsePostfixSubscripts parses any chain of element-access suffixes after a
+// primary expression: m['k'], arr[1][2]. Subscripts bind tighter than any
+// operator. The index is a valueExpression — comparisons are allowed but
+// AND/OR/NOT are not, hence bpNot+1. Unlike Doris, the slice form
+// `arr[begin:end]` is engine-rejected here, so a ':' inside the brackets
+// stays a syntax error.
 func (p *Parser) parsePostfixSubscripts(node ast.Node) (ast.Node, error) {
 	for p.cur.Kind == int('[') {
 		p.advance() // consume '['
-		begin, err := p.parseExprPrec(bpNot + 1)
+		index, err := p.parseExprPrec(bpNot + 1)
 		if err != nil {
 			return nil, err
-		}
-		if p.cur.Kind == int(':') {
-			p.advance() // consume ':'
-			var end ast.Node
-			if p.cur.Kind != int(']') {
-				end, err = p.parseExprPrec(bpNot + 1)
-				if err != nil {
-					return nil, err
-				}
-			}
-			closeTok, err := p.expect(int(']'))
-			if err != nil {
-				return nil, err
-			}
-			node = &ast.ArraySliceExpr{
-				Value: node,
-				Begin: begin,
-				End:   end,
-				Loc:   ast.Loc{Start: ast.NodeLoc(node).Start, End: closeTok.Loc.End},
-			}
-			continue
 		}
 		closeTok, err := p.expect(int(']'))
 		if err != nil {
@@ -326,7 +306,7 @@ func (p *Parser) parsePostfixSubscripts(node ast.Node) (ast.Node, error) {
 		}
 		node = &ast.ElementAtExpr{
 			Value: node,
-			Index: begin,
+			Index: index,
 			Loc:   ast.Loc{Start: ast.NodeLoc(node).Start, End: closeTok.Loc.End},
 		}
 	}

--- a/starrocks/parser/expr_test.go
+++ b/starrocks/parser/expr_test.go
@@ -1664,3 +1664,32 @@ func TestUnaryBinaryRenders(t *testing.T) {
 		t.Errorf("UnaryBinary.String() = %q, want BINARY", got)
 	}
 }
+
+func TestExprElementAtAndSlice(t *testing.T) {
+	node := mustParseExpr(t, "arr[1]")
+	if _, ok := node.(*ast.ElementAtExpr); !ok {
+		t.Fatalf("node = %T, want *ast.ElementAtExpr", node)
+	}
+
+	node = mustParseExpr(t, "m['a']['b']")
+	outer := node.(*ast.ElementAtExpr)
+	if _, ok := outer.Value.(*ast.ElementAtExpr); !ok {
+		t.Errorf("chained access: Value = %T, want *ast.ElementAtExpr", outer.Value)
+	}
+
+	node = mustParseExpr(t, "arr[1:2]")
+	sl, ok := node.(*ast.ArraySliceExpr)
+	if !ok || sl.Begin == nil || sl.End == nil {
+		t.Fatalf("node = %+v, want slice with both bounds", node)
+	}
+	node = mustParseExpr(t, "arr[2:]")
+	if sl := node.(*ast.ArraySliceExpr); sl.End != nil {
+		t.Errorf("open slice End = %+v, want nil", sl.End)
+	}
+
+	for _, bad := range []string{"SELECT arr[1, 2]", "SELECT arr[:2]", "SELECT arr[]"} {
+		if _, errs := Parse(bad); len(errs) == 0 {
+			t.Errorf("Parse(%q) succeeded, want error", bad)
+		}
+	}
+}

--- a/starrocks/parser/expr_test.go
+++ b/starrocks/parser/expr_test.go
@@ -1677,17 +1677,9 @@ func TestExprElementAtAndSlice(t *testing.T) {
 		t.Errorf("chained access: Value = %T, want *ast.ElementAtExpr", outer.Value)
 	}
 
-	node = mustParseExpr(t, "arr[1:2]")
-	sl, ok := node.(*ast.ArraySliceExpr)
-	if !ok || sl.Begin == nil || sl.End == nil {
-		t.Fatalf("node = %+v, want slice with both bounds", node)
-	}
-	node = mustParseExpr(t, "arr[2:]")
-	if sl := node.(*ast.ArraySliceExpr); sl.End != nil {
-		t.Errorf("open slice End = %+v, want nil", sl.End)
-	}
-
-	for _, bad := range []string{"SELECT arr[1, 2]", "SELECT arr[:2]", "SELECT arr[]"} {
+	// Unlike Doris, the slice form arr[b:e] is engine-rejected, so ':' inside
+	// the brackets stays a syntax error.
+	for _, bad := range []string{"SELECT arr[1:2]", "SELECT arr[2:]", "SELECT arr[1, 2]", "SELECT arr[:2]", "SELECT arr[]"} {
 		if _, errs := Parse(bad); len(errs) == 0 {
 			t.Errorf("Parse(%q) succeeded, want error", bad)
 		}

--- a/starrocks/parser/index.go
+++ b/starrocks/parser/index.go
@@ -181,30 +181,19 @@ func (p *Parser) parseBuildIndex(startLoc ast.Loc) (ast.Node, error) {
 		return nil, err
 	}
 
-	// Optional partition restriction (grammar: specifiedPartition):
-	// PARTITION p1, PARTITION (p1, p2, ...), or PARTITIONS (p1, p2, ...).
+	// Optional PARTITIONS(p1, p2, ...).
 	var partitions []string
-	if p.cur.Kind == kwPARTITIONS || p.cur.Kind == kwPARTITION {
-		singular := p.cur.Kind == kwPARTITION
+	if p.cur.Kind == kwPARTITIONS {
 		p.advance()
-		if singular && p.cur.Kind != int('(') {
-			// PARTITION with a single bare identifier.
-			name, _, err := p.parseIdentifier()
-			if err != nil {
-				return nil, err
-			}
-			partitions = []string{name}
-		} else {
-			if _, err := p.expect(int('(')); err != nil {
-				return nil, err
-			}
-			partitions, err = p.parseIdentifierList()
-			if err != nil {
-				return nil, err
-			}
-			if _, err := p.expect(int(')')); err != nil {
-				return nil, err
-			}
+		if _, err := p.expect(int('(')); err != nil {
+			return nil, err
+		}
+		partitions, err = p.parseIdentifierList()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(int(')')); err != nil {
+			return nil, err
 		}
 	}
 

--- a/starrocks/parser/index.go
+++ b/starrocks/parser/index.go
@@ -181,19 +181,30 @@ func (p *Parser) parseBuildIndex(startLoc ast.Loc) (ast.Node, error) {
 		return nil, err
 	}
 
-	// Optional PARTITIONS(p1, p2, ...).
+	// Optional partition restriction (grammar: specifiedPartition):
+	// PARTITION p1, PARTITION (p1, p2, ...), or PARTITIONS (p1, p2, ...).
 	var partitions []string
-	if p.cur.Kind == kwPARTITIONS {
+	if p.cur.Kind == kwPARTITIONS || p.cur.Kind == kwPARTITION {
+		singular := p.cur.Kind == kwPARTITION
 		p.advance()
-		if _, err := p.expect(int('(')); err != nil {
-			return nil, err
-		}
-		partitions, err = p.parseIdentifierList()
-		if err != nil {
-			return nil, err
-		}
-		if _, err := p.expect(int(')')); err != nil {
-			return nil, err
+		if singular && p.cur.Kind != int('(') {
+			// PARTITION with a single bare identifier.
+			name, _, err := p.parseIdentifier()
+			if err != nil {
+				return nil, err
+			}
+			partitions = []string{name}
+		} else {
+			if _, err := p.expect(int('(')); err != nil {
+				return nil, err
+			}
+			partitions, err = p.parseIdentifierList()
+			if err != nil {
+				return nil, err
+			}
+			if _, err := p.expect(int(')')); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/starrocks/parser/index_test.go
+++ b/starrocks/parser/index_test.go
@@ -334,24 +334,3 @@ func TestDropTableNowSupported(t *testing.T) {
 		t.Errorf("expected *ast.DropTableStmt, got %T", file.Stmts[0])
 	}
 }
-
-func TestBuildIndexPartitionForms(t *testing.T) {
-	cases := []struct {
-		sql  string
-		want int
-	}{
-		{"BUILD INDEX index1 ON table1 PARTITION(p1, p2)", 2},
-		{"BUILD INDEX index1 ON table1 PARTITION p1", 1},
-		{"BUILD INDEX index1 ON table1 PARTITIONS(p1)", 1},
-	}
-	for _, tc := range cases {
-		file, errs := Parse(tc.sql)
-		if len(errs) != 0 {
-			t.Fatalf("Parse(%q) errors: %v", tc.sql, errs)
-		}
-		n := file.Stmts[0].(*ast.BuildIndexStmt)
-		if len(n.Partitions) != tc.want {
-			t.Errorf("Parse(%q) Partitions = %v, want %d names", tc.sql, n.Partitions, tc.want)
-		}
-	}
-}

--- a/starrocks/parser/index_test.go
+++ b/starrocks/parser/index_test.go
@@ -334,3 +334,24 @@ func TestDropTableNowSupported(t *testing.T) {
 		t.Errorf("expected *ast.DropTableStmt, got %T", file.Stmts[0])
 	}
 }
+
+func TestBuildIndexPartitionForms(t *testing.T) {
+	cases := []struct {
+		sql  string
+		want int
+	}{
+		{"BUILD INDEX index1 ON table1 PARTITION(p1, p2)", 2},
+		{"BUILD INDEX index1 ON table1 PARTITION p1", 1},
+		{"BUILD INDEX index1 ON table1 PARTITIONS(p1)", 1},
+	}
+	for _, tc := range cases {
+		file, errs := Parse(tc.sql)
+		if len(errs) != 0 {
+			t.Fatalf("Parse(%q) errors: %v", tc.sql, errs)
+		}
+		n := file.Stmts[0].(*ast.BuildIndexStmt)
+		if len(n.Partitions) != tc.want {
+			t.Errorf("Parse(%q) Partitions = %v, want %d names", tc.sql, n.Partitions, tc.want)
+		}
+	}
+}

--- a/starrocks/parser/merge.go
+++ b/starrocks/parser/merge.go
@@ -98,7 +98,7 @@ func (p *Parser) parseMergeSource() (ast.Node, string, error) {
 		if err != nil {
 			return nil, "", err
 		}
-		alias := p.parseOptionalAlias(false)
+		alias, _ := p.parseOptionalAlias(false)
 		return subq, alias, nil
 	}
 
@@ -111,7 +111,7 @@ func (p *Parser) parseMergeSource() (ast.Node, string, error) {
 		Name: name,
 		Loc:  name.Loc,
 	}
-	alias := p.parseOptionalAlias(false)
+	alias, _ := p.parseOptionalAlias(false)
 	if alias != "" {
 		ref.Alias = alias
 		ref.Loc.End = p.prev.Loc.End

--- a/starrocks/parser/merge.go
+++ b/starrocks/parser/merge.go
@@ -98,7 +98,7 @@ func (p *Parser) parseMergeSource() (ast.Node, string, error) {
 		if err != nil {
 			return nil, "", err
 		}
-		alias := p.parseOptionalAlias()
+		alias := p.parseOptionalAlias(false)
 		return subq, alias, nil
 	}
 
@@ -111,7 +111,7 @@ func (p *Parser) parseMergeSource() (ast.Node, string, error) {
 		Name: name,
 		Loc:  name.Loc,
 	}
-	alias := p.parseOptionalAlias()
+	alias := p.parseOptionalAlias(false)
 	if alias != "" {
 		ref.Alias = alias
 		ref.Loc.End = p.prev.Loc.End

--- a/starrocks/parser/select.go
+++ b/starrocks/parser/select.go
@@ -510,9 +510,10 @@ func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
 				Expr: fc,
 				Loc:  ast.Loc{Start: startLoc.Start},
 			}
-			alias := p.parseOptionalAlias(true)
-			if alias != "" {
+			alias, aliased := p.parseOptionalAlias(true)
+			if aliased {
 				item.Alias = alias
+				item.Aliased = true
 			}
 			item.Loc.End = p.prev.Loc.End
 			return item, nil
@@ -527,9 +528,10 @@ func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
 			Expr: colRef,
 			Loc:  ast.Loc{Start: startLoc.Start},
 		}
-		alias := p.parseOptionalAlias(true)
-		if alias != "" {
+		alias, aliased := p.parseOptionalAlias(true)
+		if aliased {
 			item.Alias = alias
+			item.Aliased = true
 		}
 		item.Loc.End = p.prev.Loc.End
 		return item, nil
@@ -546,9 +548,10 @@ func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
 		Loc:  ast.Loc{Start: startLoc.Start},
 	}
 
-	alias := p.parseOptionalAlias(true)
-	if alias != "" {
+	alias, aliased := p.parseOptionalAlias(true)
+	if aliased {
 		item.Alias = alias
+		item.Aliased = true
 	}
 
 	item.Loc.End = p.prev.Loc.End
@@ -571,18 +574,22 @@ func (p *Parser) isSelectIdentToken() bool {
 //   - identifier (implicit, if not a clause keyword)
 //
 // stringOK selects between those two grammar rules.
-func (p *Parser) parseOptionalAlias(stringOK bool) string {
+//
+// The second return reports whether an alias was present at all: the empty
+// string alias AS ” is engine-valid and distinct from "no alias", so the
+// value alone cannot carry presence.
+func (p *Parser) parseOptionalAlias(stringOK bool) (string, bool) {
 	// Explicit: AS alias
 	if p.cur.Kind == kwAS {
 		p.advance() // consume AS
 		if stringOK && p.cur.Kind == tokString {
-			return p.advance().Str
+			return p.advance().Str, true
 		}
 		name, _, err := p.parseAliasIdentifier()
 		if err != nil {
-			return ""
+			return "", false
 		}
-		return name
+		return name, true
 	}
 
 	// Implicit alias: current token is an identifier or non-reserved keyword
@@ -590,12 +597,12 @@ func (p *Parser) parseOptionalAlias(stringOK bool) string {
 	if p.isAliasIdentToken() {
 		name, _, err := p.parseAliasIdentifier()
 		if err != nil {
-			return ""
+			return "", false
 		}
-		return name
+		return name, true
 	}
 
-	return ""
+	return "", false
 }
 
 // isAliasIdentToken reports whether the current token can be used as an
@@ -707,7 +714,7 @@ func (p *Parser) parsePrimarySource() (ast.Node, error) {
 			ref := &ast.TableRef{
 				Loc: ast.Loc{Start: startLoc.Start},
 			}
-			alias := p.parseOptionalAlias(false)
+			alias, _ := p.parseOptionalAlias(false)
 			if alias != "" {
 				ref.Alias = alias
 			}
@@ -829,7 +836,7 @@ func (p *Parser) parseTableOrFunction() (ast.Node, error) {
 		}
 	}
 
-	if alias := p.parseOptionalAlias(false); alias != "" {
+	if alias, _ := p.parseOptionalAlias(false); alias != "" {
 		ref.Alias = alias
 	}
 
@@ -853,7 +860,7 @@ func (p *Parser) parseTableFunction(name *ast.ObjectName) (ast.Node, error) {
 		Call: call,
 		Loc:  ast.Loc{Start: name.Loc.Start},
 	}
-	if alias := p.parseOptionalAlias(false); alias != "" {
+	if alias, _ := p.parseOptionalAlias(false); alias != "" {
 		tf.Alias = alias
 		if p.cur.Kind == int('(') {
 			cols, err := p.parseColumnAliasList()
@@ -891,7 +898,7 @@ func (p *Parser) parseInlineTable(start int) (ast.Node, error) {
 	}
 
 	// Optional alias, then an optional column-alias list (requires the alias).
-	alias := p.parseOptionalAlias(false)
+	alias, _ := p.parseOptionalAlias(false)
 	if alias != "" {
 		tbl.Alias = alias
 		if p.cur.Kind == int('(') {

--- a/starrocks/parser/select.go
+++ b/starrocks/parser/select.go
@@ -477,18 +477,19 @@ func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
 		return item, nil
 	}
 
-	// Try to detect table.* pattern:
-	// If we see an identifier followed by '.', it might be table.* or table.col.
-	// We need to check for qualified star: ident.* or ident.ident.*
+	// Qualified star: ident.* or ident.ident.*. This lookahead exists ONLY
+	// for the star form — any other qualified name must go through the
+	// general expression path below, because an expression can continue
+	// after it (t.a + 1, t.arr[1], db.f(1) OVER (...)); returning a bare
+	// ColumnRef here would hand that continuation to the trailing-token
+	// swallow. The multipart identifier is re-parsed after the rollback —
+	// a few tokens, same cost class as the paren-lambda speculation.
 	if p.isSelectIdentToken() && p.peekNext().Kind == int('.') {
-		// Save state to potentially backtrack.
-		// Parse the multipart identifier first, then check for .*
+		saved := p.save()
 		name, err := p.parseMultipartIdentifier()
 		if err != nil {
 			return nil, err
 		}
-
-		// Check for .* after the multipart identifier
 		if p.cur.Kind == int('.') && p.peekNext().Kind == int('*') {
 			p.advance() // consume '.'
 			p.advance() // consume '*'
@@ -498,43 +499,7 @@ func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
 				Loc:       ast.Loc{Start: startLoc.Start, End: p.prev.Loc.End},
 			}, nil
 		}
-
-		// Not a qualified star — the multipart identifier is a column ref or
-		// function call. Check if it's a function call.
-		if p.cur.Kind == int('(') {
-			fc, err := p.parseFuncCall(name)
-			if err != nil {
-				return nil, err
-			}
-			item := &ast.SelectItem{
-				Expr: fc,
-				Loc:  ast.Loc{Start: startLoc.Start},
-			}
-			alias, aliased := p.parseOptionalAlias(true)
-			if aliased {
-				item.Alias = alias
-				item.Aliased = true
-			}
-			item.Loc.End = p.prev.Loc.End
-			return item, nil
-		}
-
-		// Plain column reference — check for alias.
-		colRef := &ast.ColumnRef{
-			Name: name,
-			Loc:  name.Loc,
-		}
-		item := &ast.SelectItem{
-			Expr: colRef,
-			Loc:  ast.Loc{Start: startLoc.Start},
-		}
-		alias, aliased := p.parseOptionalAlias(true)
-		if aliased {
-			item.Alias = alias
-			item.Aliased = true
-		}
-		item.Loc.End = p.prev.Loc.End
-		return item, nil
+		p.restore(saved)
 	}
 
 	// General expression

--- a/starrocks/parser/select.go
+++ b/starrocks/parser/select.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"strings"
-
 	"github.com/bytebase/omni/starrocks/ast"
 )
 
@@ -68,12 +66,11 @@ func (p *Parser) parseSelectStmt() (*ast.SelectStmt, error) {
 
 	// GROUP BY clause
 	if p.cur.Kind == kwGROUP {
-		groupBy, withRollup, err := p.parseGroupByClause()
+		groupBy, err := p.parseGroupByClause()
 		if err != nil {
 			return nil, err
 		}
 		stmt.GroupBy = groupBy
-		stmt.GroupByWithRollup = withRollup
 	}
 
 	// HAVING clause
@@ -836,53 +833,8 @@ func (p *Parser) parseTableOrFunction() (ast.Node, error) {
 		ref.Alias = alias
 	}
 
-	// TABLESAMPLE(...) [REPEATABLE seed] follows the alias (grammar:
-	// tableAlias sample?).
-	if p.cur.Kind == kwTABLESAMPLE && p.peekNext().Kind == int('(') {
-		sample, err := p.parseTableSample()
-		if err != nil {
-			return nil, err
-		}
-		ref.Sample = sample
-	}
-
 	ref.Loc.End = p.prev.Loc.End
 	return ref, nil
-}
-
-// parseTableSample parses TABLESAMPLE(n ROWS | n PERCENT | ) [REPEATABLE seed].
-// On entry cur is TABLESAMPLE with '(' next.
-func (p *Parser) parseTableSample() (*ast.TableSample, error) {
-	p.advance() // consume TABLESAMPLE
-	p.advance() // consume '('
-
-	sample := &ast.TableSample{}
-	if p.cur.Kind != int(')') {
-		valTok, err := p.expect(tokInt)
-		if err != nil {
-			return nil, err
-		}
-		sample.Value = &ast.Literal{Kind: ast.LitInt, Value: valTok.Str, Loc: valTok.Loc}
-		switch p.cur.Kind {
-		case kwROWS, kwPERCENT:
-			sample.Unit = strings.ToUpper(p.advance().Str)
-		default:
-			return nil, p.syntaxErrorAtCur()
-		}
-	}
-	if _, err := p.expect(int(')')); err != nil {
-		return nil, err
-	}
-
-	if p.cur.Kind == kwREPEATABLE {
-		p.advance() // consume REPEATABLE
-		seedTok, err := p.expect(tokInt)
-		if err != nil {
-			return nil, err
-		}
-		sample.Seed = &ast.Literal{Kind: ast.LitInt, Value: seedTok.Str, Loc: seedTok.Loc}
-	}
-	return sample, nil
 }
 
 // parseTableFunction parses a table-function relation primary:
@@ -1292,10 +1244,10 @@ func (p *Parser) consumeDirectionAndJoin() ast.JoinType {
 
 // parseGroupByClause parses GROUP BY expr, expr, ...
 // Returns the list of GROUP BY expressions.
-func (p *Parser) parseGroupByClause() ([]ast.Node, bool, error) {
+func (p *Parser) parseGroupByClause() ([]ast.Node, error) {
 	p.advance() // consume GROUP
 	if _, err := p.expect(kwBY); err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
 	// CUBE is a reserved keyword, so `GROUP BY CUBE(a, b)` cannot reach the
@@ -1303,45 +1255,35 @@ func (p *Parser) parseGroupByClause() ([]ast.Node, bool, error) {
 	if p.cur.Kind == kwCUBE && p.peekNext().Kind == int('(') {
 		fc, err := p.parseGroupingElementCall()
 		if err != nil {
-			return nil, false, err
+			return nil, err
 		}
 		// CUBE(...) is the entire grouping specification — the engine rejects
 		// both `GROUP BY CUBE(a), b` and `GROUP BY CUBE(a), CUBE(b)`. Without
 		// this check, returning here would silently discard everything after
 		// the comma and hand downstream analysis an incomplete GROUP BY.
 		if p.cur.Kind == int(',') {
-			return nil, false, p.syntaxErrorAtCur()
+			return nil, p.syntaxErrorAtCur()
 		}
-		return []ast.Node{fc}, false, nil
+		return []ast.Node{fc}, nil
 	}
 
 	// GROUPING SETS (...) — like CUBE, the entire grouping specification.
 	// GROUPING alone stays an ordinary identifier (it is non-reserved), so a
-	// column named grouping still groups normally.
+	// column named grouping still groups normally. Unlike Doris, StarRocks
+	// has no `GROUP BY ... WITH ROLLUP` form (engine-verified), so none is
+	// parsed here.
 	if p.cur.Kind == kwGROUPING && p.peekNext().Kind == kwSETS {
 		gs, err := p.parseGroupingSets()
 		if err != nil {
-			return nil, false, err
+			return nil, err
 		}
 		if p.cur.Kind == int(',') {
-			return nil, false, p.syntaxErrorAtCur()
+			return nil, p.syntaxErrorAtCur()
 		}
-		return []ast.Node{gs}, false, nil
+		return []ast.Node{gs}, nil
 	}
 
-	list, err := p.parseExprList()
-	if err != nil {
-		return nil, false, err
-	}
-
-	// Optional WITH ROLLUP — the grammar allows it only on the plain
-	// expression-list form, not after CUBE / GROUPING SETS.
-	if p.cur.Kind == kwWITH && p.peekNext().Kind == kwROLLUP {
-		p.advance() // consume WITH
-		p.advance() // consume ROLLUP
-		return list, true, nil
-	}
-	return list, false, nil
+	return p.parseExprList()
 }
 
 // parseGroupingSets parses GROUPING SETS ((a, b), (a), ()). On entry cur is

--- a/starrocks/parser/select.go
+++ b/starrocks/parser/select.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"strings"
+
 	"github.com/bytebase/omni/starrocks/ast"
 )
 
@@ -66,11 +68,12 @@ func (p *Parser) parseSelectStmt() (*ast.SelectStmt, error) {
 
 	// GROUP BY clause
 	if p.cur.Kind == kwGROUP {
-		groupBy, err := p.parseGroupByClause()
+		groupBy, withRollup, err := p.parseGroupByClause()
 		if err != nil {
 			return nil, err
 		}
 		stmt.GroupBy = groupBy
+		stmt.GroupByWithRollup = withRollup
 	}
 
 	// HAVING clause
@@ -510,7 +513,7 @@ func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
 				Expr: fc,
 				Loc:  ast.Loc{Start: startLoc.Start},
 			}
-			alias := p.parseOptionalAlias()
+			alias := p.parseOptionalAlias(true)
 			if alias != "" {
 				item.Alias = alias
 			}
@@ -527,7 +530,7 @@ func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
 			Expr: colRef,
 			Loc:  ast.Loc{Start: startLoc.Start},
 		}
-		alias := p.parseOptionalAlias()
+		alias := p.parseOptionalAlias(true)
 		if alias != "" {
 			item.Alias = alias
 		}
@@ -546,7 +549,7 @@ func (p *Parser) parseSelectItem() (*ast.SelectItem, error) {
 		Loc:  ast.Loc{Start: startLoc.Start},
 	}
 
-	alias := p.parseOptionalAlias()
+	alias := p.parseOptionalAlias(true)
 	if alias != "" {
 		item.Alias = alias
 	}
@@ -566,11 +569,18 @@ func (p *Parser) isSelectIdentToken() bool {
 //
 // Alias forms:
 //   - AS identifier
+//   - AS 'string' (SELECT items only: identifierOrText allows AS "20%",
+//     while a table alias is a strictIdentifier and rejects strings)
 //   - identifier (implicit, if not a clause keyword)
-func (p *Parser) parseOptionalAlias() string {
+//
+// stringOK selects between those two grammar rules.
+func (p *Parser) parseOptionalAlias(stringOK bool) string {
 	// Explicit: AS alias
 	if p.cur.Kind == kwAS {
 		p.advance() // consume AS
+		if stringOK && p.cur.Kind == tokString {
+			return p.advance().Str
+		}
 		name, _, err := p.parseAliasIdentifier()
 		if err != nil {
 			return ""
@@ -700,7 +710,7 @@ func (p *Parser) parsePrimarySource() (ast.Node, error) {
 			ref := &ast.TableRef{
 				Loc: ast.Loc{Start: startLoc.Start},
 			}
-			alias := p.parseOptionalAlias()
+			alias := p.parseOptionalAlias(false)
 			if alias != "" {
 				ref.Alias = alias
 			}
@@ -800,11 +810,79 @@ func (p *Parser) parseTableOrFunction() (ast.Node, error) {
 		Name: name,
 		Loc:  ast.Loc{Start: name.Loc.Start},
 	}
-	if alias := p.parseOptionalAlias(); alias != "" {
+
+	// TABLET(id, ...) sits between the name and the alias (grammar:
+	// tabletList? tableAlias). Only TABLET followed by '(' is the clause.
+	if p.cur.Kind == kwTABLET && p.peekNext().Kind == int('(') {
+		p.advance() // consume TABLET
+		p.advance() // consume '('
+		for {
+			idTok, err := p.expect(tokInt)
+			if err != nil {
+				return nil, err
+			}
+			ref.TabletIDs = append(ref.TabletIDs, idTok.Ival)
+			if p.cur.Kind != int(',') {
+				break
+			}
+			p.advance() // consume ','
+		}
+		if _, err := p.expect(int(')')); err != nil {
+			return nil, err
+		}
+	}
+
+	if alias := p.parseOptionalAlias(false); alias != "" {
 		ref.Alias = alias
 	}
+
+	// TABLESAMPLE(...) [REPEATABLE seed] follows the alias (grammar:
+	// tableAlias sample?).
+	if p.cur.Kind == kwTABLESAMPLE && p.peekNext().Kind == int('(') {
+		sample, err := p.parseTableSample()
+		if err != nil {
+			return nil, err
+		}
+		ref.Sample = sample
+	}
+
 	ref.Loc.End = p.prev.Loc.End
 	return ref, nil
+}
+
+// parseTableSample parses TABLESAMPLE(n ROWS | n PERCENT | ) [REPEATABLE seed].
+// On entry cur is TABLESAMPLE with '(' next.
+func (p *Parser) parseTableSample() (*ast.TableSample, error) {
+	p.advance() // consume TABLESAMPLE
+	p.advance() // consume '('
+
+	sample := &ast.TableSample{}
+	if p.cur.Kind != int(')') {
+		valTok, err := p.expect(tokInt)
+		if err != nil {
+			return nil, err
+		}
+		sample.Value = &ast.Literal{Kind: ast.LitInt, Value: valTok.Str, Loc: valTok.Loc}
+		switch p.cur.Kind {
+		case kwROWS, kwPERCENT:
+			sample.Unit = strings.ToUpper(p.advance().Str)
+		default:
+			return nil, p.syntaxErrorAtCur()
+		}
+	}
+	if _, err := p.expect(int(')')); err != nil {
+		return nil, err
+	}
+
+	if p.cur.Kind == kwREPEATABLE {
+		p.advance() // consume REPEATABLE
+		seedTok, err := p.expect(tokInt)
+		if err != nil {
+			return nil, err
+		}
+		sample.Seed = &ast.Literal{Kind: ast.LitInt, Value: seedTok.Str, Loc: seedTok.Loc}
+	}
+	return sample, nil
 }
 
 // parseTableFunction parses a table-function relation primary:
@@ -823,7 +901,7 @@ func (p *Parser) parseTableFunction(name *ast.ObjectName) (ast.Node, error) {
 		Call: call,
 		Loc:  ast.Loc{Start: name.Loc.Start},
 	}
-	if alias := p.parseOptionalAlias(); alias != "" {
+	if alias := p.parseOptionalAlias(false); alias != "" {
 		tf.Alias = alias
 		if p.cur.Kind == int('(') {
 			cols, err := p.parseColumnAliasList()
@@ -861,7 +939,7 @@ func (p *Parser) parseInlineTable(start int) (ast.Node, error) {
 	}
 
 	// Optional alias, then an optional column-alias list (requires the alias).
-	alias := p.parseOptionalAlias()
+	alias := p.parseOptionalAlias(false)
 	if alias != "" {
 		tbl.Alias = alias
 		if p.cur.Kind == int('(') {
@@ -1214,10 +1292,10 @@ func (p *Parser) consumeDirectionAndJoin() ast.JoinType {
 
 // parseGroupByClause parses GROUP BY expr, expr, ...
 // Returns the list of GROUP BY expressions.
-func (p *Parser) parseGroupByClause() ([]ast.Node, error) {
+func (p *Parser) parseGroupByClause() ([]ast.Node, bool, error) {
 	p.advance() // consume GROUP
 	if _, err := p.expect(kwBY); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	// CUBE is a reserved keyword, so `GROUP BY CUBE(a, b)` cannot reach the
@@ -1225,19 +1303,85 @@ func (p *Parser) parseGroupByClause() ([]ast.Node, error) {
 	if p.cur.Kind == kwCUBE && p.peekNext().Kind == int('(') {
 		fc, err := p.parseGroupingElementCall()
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		// CUBE(...) is the entire grouping specification — the engine rejects
 		// both `GROUP BY CUBE(a), b` and `GROUP BY CUBE(a), CUBE(b)`. Without
 		// this check, returning here would silently discard everything after
 		// the comma and hand downstream analysis an incomplete GROUP BY.
 		if p.cur.Kind == int(',') {
-			return nil, p.syntaxErrorAtCur()
+			return nil, false, p.syntaxErrorAtCur()
 		}
-		return []ast.Node{fc}, nil
+		return []ast.Node{fc}, false, nil
 	}
 
-	return p.parseExprList()
+	// GROUPING SETS (...) — like CUBE, the entire grouping specification.
+	// GROUPING alone stays an ordinary identifier (it is non-reserved), so a
+	// column named grouping still groups normally.
+	if p.cur.Kind == kwGROUPING && p.peekNext().Kind == kwSETS {
+		gs, err := p.parseGroupingSets()
+		if err != nil {
+			return nil, false, err
+		}
+		if p.cur.Kind == int(',') {
+			return nil, false, p.syntaxErrorAtCur()
+		}
+		return []ast.Node{gs}, false, nil
+	}
+
+	list, err := p.parseExprList()
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Optional WITH ROLLUP — the grammar allows it only on the plain
+	// expression-list form, not after CUBE / GROUPING SETS.
+	if p.cur.Kind == kwWITH && p.peekNext().Kind == kwROLLUP {
+		p.advance() // consume WITH
+		p.advance() // consume ROLLUP
+		return list, true, nil
+	}
+	return list, false, nil
+}
+
+// parseGroupingSets parses GROUPING SETS ((a, b), (a), ()). On entry cur is
+// GROUPING with SETS next. Every set is itself parenthesized and may be empty.
+func (p *Parser) parseGroupingSets() (ast.Node, error) {
+	startTok := p.advance() // consume GROUPING
+	p.advance()             // consume SETS
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+
+	gs := &ast.GroupingSetsExpr{}
+	for {
+		if _, err := p.expect(int('(')); err != nil {
+			return nil, err
+		}
+		var set []ast.Node
+		if p.cur.Kind != int(')') {
+			exprs, err := p.parseExprList()
+			if err != nil {
+				return nil, err
+			}
+			set = exprs
+		}
+		if _, err := p.expect(int(')')); err != nil {
+			return nil, err
+		}
+		gs.Sets = append(gs.Sets, set)
+		if p.cur.Kind != int(',') {
+			break
+		}
+		p.advance() // consume ','
+	}
+
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	gs.Loc = ast.Loc{Start: startTok.Loc.Start, End: closeTok.Loc.End}
+	return gs, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -1255,7 +1399,17 @@ func (p *Parser) parseLimitClause() (ast.Node, ast.Node, error) {
 	}
 
 	var offsetExpr ast.Node
-	if p.cur.Kind == kwOFFSET {
+	switch p.cur.Kind {
+	case int(','):
+		// MySQL form LIMIT offset, row_count: the expression parsed first is
+		// the offset and the one after the comma is the count.
+		p.advance() // consume ','
+		offsetExpr = limitExpr
+		limitExpr, err = p.parseExpr()
+		if err != nil {
+			return nil, nil, err
+		}
+	case kwOFFSET:
 		p.advance() // consume OFFSET
 		offsetExpr, err = p.parseExpr()
 		if err != nil {

--- a/starrocks/parser/select_test.go
+++ b/starrocks/parser/select_test.go
@@ -601,6 +601,17 @@ func TestSelectStringAlias(t *testing.T) {
 	if len(stmt.From) != 1 {
 		t.Fatalf("From = %+v, want tb_book to survive the alias", stmt.From)
 	}
+
+	// The empty alias AS '' is engine-valid and distinct from no alias:
+	// presence is carried by Aliased, not by the string value.
+	stmt = mustParseSelect(t, "SELECT c AS '' FROM t")
+	if !stmt.Items[0].Aliased || stmt.Items[0].Alias != "" {
+		t.Errorf("AS '': Aliased=%v Alias=%q, want true and empty", stmt.Items[0].Aliased, stmt.Items[0].Alias)
+	}
+	stmt = mustParseSelect(t, "SELECT c FROM t")
+	if stmt.Items[0].Aliased {
+		t.Error("unaliased item reports Aliased=true")
+	}
 }
 
 func TestSelectGroupByGroupingSets(t *testing.T) {

--- a/starrocks/parser/select_test.go
+++ b/starrocks/parser/select_test.go
@@ -603,17 +603,6 @@ func TestSelectStringAlias(t *testing.T) {
 	}
 }
 
-func TestSelectGroupByWithRollup(t *testing.T) {
-	stmt := mustParseSelect(t, "SELECT a, SUM(b) FROM t GROUP BY a WITH ROLLUP")
-	if !stmt.GroupByWithRollup {
-		t.Error("GroupByWithRollup = false, want true")
-	}
-	stmt = mustParseSelect(t, "SELECT a FROM t GROUP BY a")
-	if stmt.GroupByWithRollup {
-		t.Error("GroupByWithRollup = true, want false")
-	}
-}
-
 func TestSelectGroupByGroupingSets(t *testing.T) {
 	stmt := mustParseSelect(t, "SELECT a, SUM(b) FROM t GROUP BY GROUPING SETS ((a, b), (a), ())")
 	gs, ok := stmt.GroupBy[0].(*ast.GroupingSetsExpr)
@@ -630,16 +619,15 @@ func TestSelectGroupByGroupingSets(t *testing.T) {
 	}
 }
 
-func TestSelectFromTabletAndTableSample(t *testing.T) {
-	stmt := mustParseSelect(t, "SELECT * FROM t1 TABLET(10001) TABLESAMPLE(1000 ROWS) REPEATABLE 2 LIMIT 1000")
+func TestSelectFromTablet(t *testing.T) {
+	// TABLET(...) is engine-valid; TABLESAMPLE is not a StarRocks clause
+	// (engine-verified), so unlike Doris none is parsed here.
+	stmt := mustParseSelect(t, "SELECT * FROM t1 TABLET(10001) LIMIT 1000")
 	ref := stmt.From[0].(*ast.TableRef)
 	if len(ref.TabletIDs) != 1 || ref.TabletIDs[0] != 10001 {
 		t.Errorf("TabletIDs = %v, want [10001]", ref.TabletIDs)
 	}
-	if ref.Sample == nil || ref.Sample.Unit != "ROWS" {
-		t.Fatalf("Sample = %+v, want 1000 ROWS", ref.Sample)
-	}
 	if stmt.Limit == nil {
-		t.Error("LIMIT after the sample clause was lost")
+		t.Error("LIMIT after the tablet clause was lost")
 	}
 }

--- a/starrocks/parser/select_test.go
+++ b/starrocks/parser/select_test.go
@@ -642,3 +642,38 @@ func TestSelectFromTablet(t *testing.T) {
 		t.Error("LIMIT after the tablet clause was lost")
 	}
 }
+
+func TestSelectQualifiedColumnContinuations(t *testing.T) {
+	// A select item starting with a qualified column must flow through the
+	// general expression parser: the old fast path returned a bare ColumnRef
+	// and handed any continuation to the trailing-token swallow.
+	stmt := mustParseSelect(t, "SELECT t.secret_col[1] FROM sensitive_table t")
+	if _, ok := stmt.Items[0].Expr.(*ast.ElementAtExpr); !ok {
+		t.Fatalf("Items[0].Expr = %T, want *ast.ElementAtExpr", stmt.Items[0].Expr)
+	}
+	if len(stmt.From) != 1 {
+		t.Fatal("FROM clause lost after qualified subscript")
+	}
+
+	stmt = mustParseSelect(t, "SELECT t.a + 1 FROM t")
+	if _, ok := stmt.Items[0].Expr.(*ast.BinaryExpr); !ok {
+		t.Fatalf("Items[0].Expr = %T, want *ast.BinaryExpr", stmt.Items[0].Expr)
+	}
+	if len(stmt.From) != 1 {
+		t.Fatal("FROM clause lost after qualified arithmetic")
+	}
+
+	// The plain and star forms keep their shapes.
+	stmt = mustParseSelect(t, "SELECT t.a AS x FROM t")
+	if _, ok := stmt.Items[0].Expr.(*ast.ColumnRef); !ok || stmt.Items[0].Alias != "x" {
+		t.Fatalf("Items[0] = %+v, want aliased ColumnRef", stmt.Items[0])
+	}
+	stmt = mustParseSelect(t, "SELECT t.* FROM t")
+	if !stmt.Items[0].Star || stmt.Items[0].TableName == nil {
+		t.Fatalf("Items[0] = %+v, want qualified star", stmt.Items[0])
+	}
+	stmt = mustParseSelect(t, "SELECT db.f(1) FROM t")
+	if _, ok := stmt.Items[0].Expr.(*ast.FuncCallExpr); !ok {
+		t.Fatalf("Items[0].Expr = %T, want *ast.FuncCallExpr", stmt.Items[0].Expr)
+	}
+}

--- a/starrocks/parser/select_test.go
+++ b/starrocks/parser/select_test.go
@@ -574,3 +574,72 @@ func TestSelectIntoOutfileWalkProperties(t *testing.T) {
 		t.Errorf("T_Property visited %d times, want 2", count[ast.T_Property])
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Constructs previously hidden by the trailing-token swallow (BYT-10084)
+// ---------------------------------------------------------------------------
+
+func TestSelectLimitOffsetComma(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT * FROM tbl LIMIT 5, 10")
+	lit, ok := stmt.Limit.(*ast.Literal)
+	if !ok || lit.Value != "10" {
+		t.Fatalf("Limit = %+v, want literal 10", stmt.Limit)
+	}
+	off, ok := stmt.Offset.(*ast.Literal)
+	if !ok || off.Value != "5" {
+		t.Fatalf("Offset = %+v, want literal 5", stmt.Offset)
+	}
+}
+
+func TestSelectStringAlias(t *testing.T) {
+	// AS "string": the alias used to be dropped together with everything
+	// after it, so the span lost the FROM table.
+	stmt := mustParseSelect(t, `SELECT *, (price * 0.8) AS "20%" FROM tb_book`)
+	if len(stmt.Items) != 2 || stmt.Items[1].Alias != "20%" {
+		t.Fatalf("Items[1].Alias = %+v, want 20%%", stmt.Items)
+	}
+	if len(stmt.From) != 1 {
+		t.Fatalf("From = %+v, want tb_book to survive the alias", stmt.From)
+	}
+}
+
+func TestSelectGroupByWithRollup(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a, SUM(b) FROM t GROUP BY a WITH ROLLUP")
+	if !stmt.GroupByWithRollup {
+		t.Error("GroupByWithRollup = false, want true")
+	}
+	stmt = mustParseSelect(t, "SELECT a FROM t GROUP BY a")
+	if stmt.GroupByWithRollup {
+		t.Error("GroupByWithRollup = true, want false")
+	}
+}
+
+func TestSelectGroupByGroupingSets(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT a, SUM(b) FROM t GROUP BY GROUPING SETS ((a, b), (a), ())")
+	gs, ok := stmt.GroupBy[0].(*ast.GroupingSetsExpr)
+	if !ok {
+		t.Fatalf("GroupBy[0] = %T, want *ast.GroupingSetsExpr", stmt.GroupBy[0])
+	}
+	if len(gs.Sets) != 3 || len(gs.Sets[0]) != 2 || len(gs.Sets[2]) != 0 {
+		t.Fatalf("Sets shape = %v, want [2 1 0]", gs.Sets)
+	}
+
+	_, errs := Parse("SELECT a FROM t GROUP BY GROUPING SETS ((a)), b")
+	if len(errs) == 0 {
+		t.Error("GROUPING SETS with a trailing item parsed, want error")
+	}
+}
+
+func TestSelectFromTabletAndTableSample(t *testing.T) {
+	stmt := mustParseSelect(t, "SELECT * FROM t1 TABLET(10001) TABLESAMPLE(1000 ROWS) REPEATABLE 2 LIMIT 1000")
+	ref := stmt.From[0].(*ast.TableRef)
+	if len(ref.TabletIDs) != 1 || ref.TabletIDs[0] != 10001 {
+		t.Errorf("TabletIDs = %v, want [10001]", ref.TabletIDs)
+	}
+	if ref.Sample == nil || ref.Sample.Unit != "ROWS" {
+		t.Fatalf("Sample = %+v, want 1000 ROWS", ref.Sample)
+	}
+	if stmt.Limit == nil {
+		t.Error("LIMIT after the sample clause was lost")
+	}
+}

--- a/starrocks/parser/show.go
+++ b/starrocks/parser/show.go
@@ -148,11 +148,21 @@ func (p *Parser) parseShowTables(stmt *ast.ShowStmt) (ast.Node, error) {
 	return stmt, nil
 }
 
-// parseShowDatabases parses: SHOW DATABASES [LIKE 'pat'] [WHERE ...]
+// parseShowDatabases parses: SHOW DATABASES [FROM catalog] [LIKE 'pat'] [WHERE ...]
 // On entry, cur == kwDATABASES or kwSCHEMAS.
 func (p *Parser) parseShowDatabases(stmt *ast.ShowStmt) (ast.Node, error) {
 	p.advance() // consume DATABASES/SCHEMAS
 	stmt.Type = "DATABASES"
+
+	// Optional FROM/IN <catalog>: SHOW DATABASES FROM hms_catalog.
+	if p.cur.Kind == kwFROM || p.cur.Kind == kwIN {
+		p.advance() // consume FROM/IN
+		catalog, _, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		stmt.From = catalog
+	}
 
 	p.parseShowLikeWhere(stmt)
 

--- a/starrocks/parser/show_test.go
+++ b/starrocks/parser/show_test.go
@@ -469,3 +469,16 @@ func TestShowLocValid(t *testing.T) {
 		t.Errorf("Loc.Start = %d, want 0", n.Loc.Start)
 	}
 }
+
+func TestShowDatabasesFromCatalog(t *testing.T) {
+	for _, sql := range []string{"SHOW DATABASES FROM hive_catalog", "SHOW DATABASES IN hive_catalog"} {
+		file, errs := Parse(sql)
+		if len(errs) != 0 {
+			t.Fatalf("Parse(%q) errors: %v", sql, errs)
+		}
+		n := file.Stmts[0].(*ast.ShowStmt)
+		if n.Type != "DATABASES" || n.From != "hive_catalog" {
+			t.Errorf("Parse(%q) = Type %q From %q, want DATABASES hive_catalog", sql, n.Type, n.From)
+		}
+	}
+}

--- a/starrocks/parser/split.go
+++ b/starrocks/parser/split.go
@@ -26,8 +26,8 @@ func (s Segment) Empty() bool {
 type splitState int
 
 const (
-	stateTop      splitState = iota
-	stateInBlock              // inside a BEGIN..END compound block
+	stateTop     splitState = iota
+	stateInBlock            // inside a BEGIN..END compound block
 )
 
 // Split extracts top-level SQL statements from input.
@@ -40,7 +40,7 @@ const (
 // should use NewLexer(input).Errors() directly.
 //
 // Split correctly handles:
-//   - Single-quoted strings with '' and \ escapes
+//   - Single-quoted strings with ” and \ escapes
 //   - Double-quoted strings with "" escapes
 //   - Backtick-quoted identifiers
 //   - X'...' hex literals and B'...' bit literals
@@ -60,23 +60,30 @@ func Split(input string) []Segment {
 	state := stateTop
 	depth := 0
 
-	// We need one-token lookahead after kwBEGIN to disambiguate TCL from
-	// compound block. Use a one-slot buffered lookahead.
-	var pending *Token
+	// We need lookahead after kwBEGIN to disambiguate TCL from a compound
+	// block: one token for most followers, two for BEGIN WITH LABEL (WITH
+	// alone could open a block whose first statement is a CTE). Use a small
+	// buffered queue.
+	var pending []Token
 	nextToken := func() Token {
-		if pending != nil {
-			t := *pending
-			pending = nil
+		if len(pending) > 0 {
+			t := pending[0]
+			pending = pending[1:]
 			return t
 		}
 		return l.NextToken()
 	}
 	peekToken := func() Token {
-		if pending == nil {
-			t := l.NextToken()
-			pending = &t
+		if len(pending) == 0 {
+			pending = append(pending, l.NextToken())
 		}
-		return *pending
+		return pending[0]
+	}
+	peekToken2 := func() Token {
+		for len(pending) < 2 {
+			pending = append(pending, l.NextToken())
+		}
+		return pending[1]
 	}
 
 	// emit creates a Segment covering input[stmtStart:end] — where end is
@@ -104,7 +111,12 @@ func Split(input string) []Segment {
 			switch tok.Kind {
 			case kwBEGIN:
 				next := peekToken()
-				if isDorisTCLBeginFollower(next) {
+				// BEGIN WITH LABEL x is the transaction form. WITH alone does
+				// not decide — a compound block's first statement can be a
+				// CTE — so the LABEL after it is what disambiguates.
+				isTCL := isDorisTCLBeginFollower(next) ||
+					(next.Kind == kwWITH && peekToken2().Kind == kwLABEL)
+				if isTCL {
 					// TCL: BEGIN;, BEGIN TRANSACTION, BEGIN WORK, BEGIN EOF.
 					// Stay in stateTop; the buffered peek will be returned
 					// by the next nextToken() call and handled normally.

--- a/starrocks/parser/split_test.go
+++ b/starrocks/parser/split_test.go
@@ -227,3 +227,16 @@ func TestSplit_Mixed(t *testing.T) {
 	}
 	runSplitCases(t, cases)
 }
+
+func TestSplit_BeginWithLabelIsTCL(t *testing.T) {
+	segs := Split("BEGIN WITH LABEL load_1; COMMIT")
+	if len(segs) != 2 {
+		t.Fatalf("Split returned %d segments, want 2: %+v", len(segs), segs)
+	}
+
+	// A compound block whose first statement is a CTE must stay one segment.
+	segs = Split("BEGIN WITH c AS (SELECT 1) SELECT * FROM c; END")
+	if len(segs) != 1 {
+		t.Fatalf("Split returned %d segments, want 1 (compound block): %+v", len(segs), segs)
+	}
+}

--- a/starrocks/parser/starrocks_syntax_conformance_test.go
+++ b/starrocks/parser/starrocks_syntax_conformance_test.go
@@ -90,6 +90,8 @@ func TestStarRocksSyntaxConformance(t *testing.T) {
 		{"string_alias_empty", "SELECT 1 AS ''", true},
 		{"element_at_literal", "SELECT [1, 2, 3][1]", true},
 		{"element_at_column", "SELECT c1[1] FROM t", true},
+		{"element_at_qualified", "SELECT t.c1[1] FROM t", true},
+		{"qualified_column_arith", "SELECT t.a + 1 FROM t", true},
 		// Unlike Doris, the slice form is engine-rejected here.
 		{"array_slice_rejected", "SELECT [1, 2, 3][1:2]", false},
 		{"grouping_sets", "SELECT a, SUM(b) FROM t GROUP BY GROUPING SETS ((a), ())", true},

--- a/starrocks/parser/starrocks_syntax_conformance_test.go
+++ b/starrocks/parser/starrocks_syntax_conformance_test.go
@@ -89,13 +89,16 @@ func TestStarRocksSyntaxConformance(t *testing.T) {
 		{"string_alias", `SELECT (1 + 1) AS "20%"`, true},
 		{"element_at_literal", "SELECT [1, 2, 3][1]", true},
 		{"element_at_column", "SELECT c1[1] FROM t", true},
-		{"array_slice", "SELECT [1, 2, 3][1:2]", true},
-		{"group_by_with_rollup", "SELECT a, SUM(b) FROM t GROUP BY a WITH ROLLUP", true},
+		// Unlike Doris, the slice form is engine-rejected here.
+		{"array_slice_rejected", "SELECT [1, 2, 3][1:2]", false},
 		{"grouping_sets", "SELECT a, SUM(b) FROM t GROUP BY GROUPING SETS ((a), ())", true},
 		{"grouping_sets_trailing_item", "SELECT a FROM t GROUP BY GROUPING SETS ((a)), b", false},
-		{"tablet_tablesample", "SELECT * FROM t TABLET(10001) TABLESAMPLE(1000 ROWS) REPEATABLE 2", true},
+		// TABLET is engine-valid; TABLESAMPLE and GROUP BY ... WITH ROLLUP are
+		// not StarRocks syntax (engine-verified) — their negative arms land
+		// with the strict trailing-token check (BYT-10085), because until
+		// then the parser still swallows them as trailing junk.
+		{"tablet", "SELECT * FROM t TABLET(10001)", true},
 		{"show_databases_from", "SHOW DATABASES FROM default_catalog", true},
-		{"build_index_partition", "BUILD INDEX index1 ON table1 PARTITION(p1, p2)", true},
 		{"create_table_primary_key", "CREATE TABLE conf_pk (id BIGINT NOT NULL, v VARCHAR(64)) PRIMARY KEY(id) DISTRIBUTED BY HASH(id)", true},
 	}
 

--- a/starrocks/parser/starrocks_syntax_conformance_test.go
+++ b/starrocks/parser/starrocks_syntax_conformance_test.go
@@ -87,6 +87,7 @@ func TestStarRocksSyntaxConformance(t *testing.T) {
 		// rest of the statement.
 		{"limit_offset_comma", "SELECT * FROM t LIMIT 5, 10", true},
 		{"string_alias", `SELECT (1 + 1) AS "20%"`, true},
+		{"string_alias_empty", "SELECT 1 AS ''", true},
 		{"element_at_literal", "SELECT [1, 2, 3][1]", true},
 		{"element_at_column", "SELECT c1[1] FROM t", true},
 		// Unlike Doris, the slice form is engine-rejected here.

--- a/starrocks/parser/starrocks_syntax_conformance_test.go
+++ b/starrocks/parser/starrocks_syntax_conformance_test.go
@@ -81,6 +81,22 @@ func TestStarRocksSyntaxConformance(t *testing.T) {
 		{"substring_from", "SELECT SUBSTRING('abcdef' FROM 2)", false},
 		{"trim_both_from", "SELECT TRIM(BOTH 'x' FROM 'xax')", false},
 		{"position_in", "SELECT POSITION('b' IN 'abc')", false},
+
+		// --- Constructs previously hidden by the trailing-token swallow
+		// (BYT-10084): each parsed as a valid prefix and silently dropped the
+		// rest of the statement.
+		{"limit_offset_comma", "SELECT * FROM t LIMIT 5, 10", true},
+		{"string_alias", `SELECT (1 + 1) AS "20%"`, true},
+		{"element_at_literal", "SELECT [1, 2, 3][1]", true},
+		{"element_at_column", "SELECT c1[1] FROM t", true},
+		{"array_slice", "SELECT [1, 2, 3][1:2]", true},
+		{"group_by_with_rollup", "SELECT a, SUM(b) FROM t GROUP BY a WITH ROLLUP", true},
+		{"grouping_sets", "SELECT a, SUM(b) FROM t GROUP BY GROUPING SETS ((a), ())", true},
+		{"grouping_sets_trailing_item", "SELECT a FROM t GROUP BY GROUPING SETS ((a)), b", false},
+		{"tablet_tablesample", "SELECT * FROM t TABLET(10001) TABLESAMPLE(1000 ROWS) REPEATABLE 2", true},
+		{"show_databases_from", "SHOW DATABASES FROM default_catalog", true},
+		{"build_index_partition", "BUILD INDEX index1 ON table1 PARTITION(p1, p2)", true},
+		{"create_table_primary_key", "CREATE TABLE conf_pk (id BIGINT NOT NULL, v VARCHAR(64)) PRIMARY KEY(id) DISTRIBUTED BY HASH(id)", true},
 	}
 
 	for _, tc := range cases {

--- a/starrocks/parser/testdata/legacy/data_query_select.sql
+++ b/starrocks/parser/testdata/legacy/data_query_select.sql
@@ -15,7 +15,7 @@ SELECT t1.name, t2.salary FROM employee AS t1 INNER JOIN info AS t2 ON t1.name =
 SELECT t1.name, t2.salary FROM employee t1 INNER JOIN info t2 ON t1.name = t2.name;
 SELECT left_tbl.* FROM left_tbl LEFT JOIN right_tbl ON left_tbl.id = right_tbl.id WHERE right_tbl.id IS NULL;
 SELECT * FROM t1 RIGHT JOIN t2 ON (t1.a = t2.a);
-SELECT * FROM t1 TABLET(10001) TABLESAMPLE(1000 ROWS) REPEATABLE 2 LIMIT 1000;
+SELECT * FROM t1 TABLET(10001) LIMIT 1000;
 SELECT college, region, seed FROM tournament ORDER BY region, seed;
 SELECT college, region AS r, seed AS s FROM tournament ORDER BY r, s;
 SELECT college, region, seed FROM tournament ORDER BY 2, 3;

--- a/starrocks/parser/testdata/legacy/ddl_index.sql
+++ b/starrocks/parser/testdata/legacy/ddl_index.sql
@@ -1,5 +1,4 @@
 CREATE INDEX index1 ON table1 (col1) USING INVERTED;
 CREATE INDEX index2 ON table1 (col1) USING NGRAM_BF PROPERTIES("gram_size" = "3", "bf_size" = "1024");
 DROP INDEX IF EXISTS index_name ON table1;
-BUILD INDEX index1 ON table1;
-BUILD INDEX index1 ON table1 PARTITION(p1, p2)
+


### PR DESCRIPTION
## Problem

`parseSingle` never verifies that a statement parse consumed its whole segment, so any valid statement prefix + unparseable tail is **silently accepted with a truncated AST**. The concrete fail-open case:

```sql
SELECT secret_col[1] FROM sensitive_table
```

parses with zero errors, the FROM clause vanishes from the AST, and `GetQuerySpan` reports `AccessTables=[]` — while the engine executes the full query. Masking and lineage see less than what runs.

The hole is congenital: inherited from the v1 snowflake parser-entry framework (#19), copied into doris (#52/#61), forked into starrocks (#287) two days before snowflake fixed itself (#303). mongo got the same discipline in #395. The strict flip is BYT-10085 (stacked PR); this PR closes every piece of engine-valid syntax the swallow was hiding first — flipping first would regress silently-working customer queries into hard editor errors.

## Method

Prototype measurement: patch the 5-line strict check in locally, run the full `-short` suites + legacy corpora → 17 failures, fully inventoried, each closed here. Two were defects inside already-merged tests: doris `GROUP BY GROUPING SETS ((a),())` was never actually parsed (`SETS ((a),())` swallowed — the #400 conformance case passed as a false positive), and the starrocks `DEFAULT (uuid())` test silently dropped `PRIMARY KEY(id) DISTRIBUTED BY ...`.

Everything is container-verified: Doris 3.1.4 and StarRocks 3.4.10.

## What this closes

| Area | Now parses |
|---|---|
| LIMIT | `LIMIT offset, count` (`LIMIT 5, 10`) |
| Aliases | `expr AS "20%"` / `AS 'x'` — SELECT items only; table aliases keep rejecting strings per the grammar's strictIdentifier |
| Grouping | `GROUP BY GROUPING SETS ((a,b),(a),())` for real; `GROUP BY a WITH ROLLUP` (doris) |
| Collections | `expr[i]`, `expr[b:e]`, `expr[b:]` — new `ElementAtExpr` / `ArraySliceExpr` nodes, postfix at primary tightness |
| FROM | table-valued functions `BACKENDS()`, `numbers("k"="v")` (doris; starrocks already had `TableFunctionRef`); `TABLET(...)` before the alias; `TABLESAMPLE(n ROWS\|PERCENT) [REPEATABLE s]` after it (doris) |
| Utility | `SHOW DATABASES FROM/IN <catalog>`; `BUILD INDEX ... PARTITION p \| PARTITION (list) \| PARTITIONS (list)` (doris) |
| starrocks | post-column-list `PRIMARY KEY(...)` key description |
| splitter | `BEGIN WITH LABEL x; COMMIT` is TCL, not a compound-block opener — two-token lookahead, since a block can also open with a CTE |

## The StarRocks container corrected four mirrored assumptions

The live 3.4.10 run flagged four forms as engine-rejected that the doris mirror had assumed valid: `TABLESAMPLE`, `GROUP BY ... WITH ROLLUP`, `arr[b:e]` slices, and **every** form of `BUILD INDEX`. Their starrocks support is removed (TABLET alone stays — engine-valid), and the starrocks legacy-corpus lines demanding them were doris leakage the StarRocks engine itself rejects — pruned to their engine-valid parts. The pre-existing base `BUILD INDEX` over-acceptance from the fork is left for a follow-up. Negative conformance arms for TABLESAMPLE / WITH ROLLUP land with BYT-10085, where the parser stops swallowing them as trailing junk.

## Testing

- Doris conformance: green, 17 new cases against the 3.1.4 container (positives above + `[1,2][1,2]`, `[1,2][:2]`, `GROUPING SETS ((a)), b` negatives)
- StarRocks conformance: green against 3.4.10, including the corrected divergences
- Unit tests per construct in both engines; analysis regression pinning `GetQuerySpan("SELECT secret_col[1] FROM sensitive_table")` → `AccessTables=[sensitive_table]`
- **Gate for BYT-10085**: with the strict trailing-token check patched in locally, both engines' full suites and legacy corpora run green — nothing else hides behind the swallow
- `go test -short ./doris/... ./starrocks/...` green; gofmt baseline unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)