### PR TITLE
doris/starrocks: remove unreachable dead code in parseStmt SHOW case

### DIFF
--- a/doris/parser/parser.go
+++ b/doris/parser/parser.go
@@ -501,14 +501,6 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	// Show / Info
 	case kwSHOW:
 		return p.parseShow()
-		showTok := p.advance() // consume SHOW
-		if p.cur.Kind == kwJOB {
-			return p.parseShowJob(showTok.Loc)
-		}
-		// Return unsupported, but we already consumed SHOW so we need to emit the error at cur.
-		return p.unsupported("SHOW")
-		p.advance() // consume SHOW; dispatch inside parseShow
-		return p.parseShow()
 	case kwDESCRIBE:
 		return p.parseDescribe()
 	case kwDESC:

--- a/starrocks/parser/parser.go
+++ b/starrocks/parser/parser.go
@@ -510,14 +510,6 @@ func (p *Parser) parseStmt() (ast.Node, error) {
 	// Show / Info
 	case kwSHOW:
 		return p.parseShow()
-		showTok := p.advance() // consume SHOW
-		if p.cur.Kind == kwJOB {
-			return p.parseShowJob(showTok.Loc)
-		}
-		// Return unsupported, but we already consumed SHOW so we need to emit the error at cur.
-		return p.unsupported("SHOW")
-		p.advance() // consume SHOW; dispatch inside parseShow
-		return p.parseShow()
 	case kwDESCRIBE:
 		return p.parseDescribe()
 	case kwDESC:


### PR DESCRIPTION
## Summary

`parseStmt`'s `case kwSHOW` in both doris and starrocks returned `p.parseShow()` immediately, but still carried 8 unreachable leftover lines each from #151 (job scheduling): the old inline `SHOW JOB` dispatch, an `unsupported("SHOW")` fallback, and a second advance-then-`parseShow` sequence. staticcheck flagged these as unreachable code.

This deletes the dead lines (16 deletions total, no other changes). No behavior change: `SHOW JOB` is already dispatched on the live path inside `parseShow` (show.go:50 in both engines), covered by the existing `SHOW JOB` / `SHOW JOB TASK` tests.

## Verification

- `go vet ./doris/... ./starrocks/...` — clean
- `go test -short ./doris/parser/ ./starrocks/parser/` — both pass
- `staticcheck` (v0.8.1 via `go run honnef.co/go/tools/cmd/staticcheck@latest`) — zero `unreachable` warnings remain; zero diagnostics of any kind on either parser.go

🤖 Generated with [Claude Code](https://claude.com/claude-code)