### PR TITLE
doris: support LATERAL VIEW; starrocks: pin its engine-rejection

### DIFF
--- a/doris/analysis/query_span.go
+++ b/doris/analysis/query_span.go
@@ -443,6 +443,13 @@ func (w *spanWalker) visitTableRef(ref *ast.TableRef) {
 	if ref == nil {
 		return
 	}
+	// LATERAL VIEW generators carry real expressions (and possibly
+	// subqueries); walk them regardless of the underlying source kind.
+	for _, lv := range ref.LateralViews {
+		if lv.Func != nil {
+			w.walkExpr(lv.Func)
+		}
+	}
 	// A table-valued function is not a physical table access. Mirror the
 	// StarRocks TableFunctionRef handling: walk the call's arguments for
 	// lineage and record no table — authorization would otherwise be asked

--- a/doris/analysis/query_span_test.go
+++ b/doris/analysis/query_span_test.go
@@ -819,3 +819,22 @@ func TestGetQuerySpan_GroupedClausesOutsideCTEScope(t *testing.T) {
 		}
 	}
 }
+
+func TestGetQuerySpan_LateralViewGeneratorSubquery(t *testing.T) {
+	// The generator's arguments are real expressions: a subquery inside one
+	// contributes its table read, and the lateral alias itself is not a
+	// physical table.
+	span, err := GetQuerySpan("SELECT * FROM t LATERAL VIEW EXPLODE((SELECT arr FROM t3 LIMIT 1)) tmp AS c")
+	if err != nil {
+		t.Fatalf("GetQuerySpan returned error: %v", err)
+	}
+	sigs := toSigs(span.AccessTables)
+	for _, want := range []string{"t", "t3"} {
+		if !containsSig(sigs, tableSig{Table: want}) {
+			t.Errorf("AccessTables missing %s (got %+v)", want, sigs)
+		}
+	}
+	if containsSig(sigs, tableSig{Table: "tmp"}) {
+		t.Errorf("lateral alias misreported as a table (got %+v)", sigs)
+	}
+}

--- a/doris/ast/selectnodes.go
+++ b/doris/ast/selectnodes.go
@@ -130,7 +130,20 @@ type TableRef struct {
 	// Sample holds TABLESAMPLE(...) [REPEATABLE seed], which follows the alias.
 	Sample *TableSample
 
+	// LateralViews holds the Hive-style LATERAL VIEW suffixes that follow
+	// the alias: LATERAL VIEW generator(args) tableAlias AS col [, col...],
+	// chainable. The engine requires both the table alias and the AS column
+	// list and has no OUTER variant (container-verified).
+	LateralViews []*LateralView
+
 	Loc Loc
+}
+
+// LateralView is one LATERAL VIEW suffix of a table reference.
+type LateralView struct {
+	Func       *FuncCallExpr // the generator call, e.g. EXPLODE([1, 2])
+	TableAlias string        // required by the engine
+	Columns    []string      // AS col [, col ...] — at least one
 }
 
 // TableSample is the TABLESAMPLE(...) [REPEATABLE seed] suffix of a table

--- a/doris/ast/walk_children.go
+++ b/doris/ast/walk_children.go
@@ -237,6 +237,11 @@ func walkChildren(v Visitor, node Node) {
 				Walk(v, n.Sample.Seed)
 			}
 		}
+		for _, lv := range n.LateralViews {
+			if lv.Func != nil {
+				Walk(v, lv.Func)
+			}
+		}
 	case *JoinClause:
 		Walk(v, n.Left)
 		Walk(v, n.Right)

--- a/doris/parser/doris_container_test.go
+++ b/doris/parser/doris_container_test.go
@@ -340,6 +340,17 @@ func TestDorisSyntaxConformance(t *testing.T) {
 		{"paren_scoped_cte_union", "(WITH c AS (SELECT 1) SELECT 1) UNION SELECT * FROM c", true},
 		{"exists_grouped_subquery", "SELECT EXISTS (SELECT 1 FROM t ORDER BY 1 ORDER BY 2)", true},
 
+		// LATERAL VIEW — previously hidden by the trailing-token swallow.
+		{"lateral_view", "SELECT * FROM person LATERAL VIEW EXPLODE(ARRAY(30, 60)) tableName AS c_age", true},
+		{"lateral_view_multi_col", "SELECT * FROM t LATERAL VIEW EXPLODE_SPLIT(s, ',') tmp AS c1, c2", true},
+		{"lateral_view_chained", "SELECT * FROM t LATERAL VIEW EXPLODE([1]) a AS x LATERAL VIEW EXPLODE([2]) b AS y", true},
+		{"lateral_view_after_alias", "SELECT * FROM t tt LATERAL VIEW EXPLODE([1]) tmp AS c", true},
+		{"lateral_view_then_clauses", "SELECT * FROM t LATERAL VIEW EXPLODE([1]) tmp AS c WHERE c > 0 ORDER BY c LIMIT 1", true},
+		{"lateral_view_outer_rejected", "SELECT * FROM t LATERAL VIEW OUTER EXPLODE([1]) tmp AS c", false},
+		{"lateral_view_no_alias_rejected", "SELECT * FROM t LATERAL VIEW EXPLODE([1]) tmp", false},
+		{"lateral_view_no_table_alias_rejected", "SELECT * FROM t LATERAL VIEW EXPLODE([1]) AS c", false},
+		{"lateral_view_junk_rejected", "SELECT * FROM t LATERAL VIEW EXPLODE([1]) tmp AS c zzz", false},
+
 		// --- Constructs previously hidden by the trailing-token swallow
 		// (BYT-10084): each parsed as a valid prefix and silently dropped the
 		// rest of the statement.

--- a/doris/parser/select.go
+++ b/doris/parser/select.go
@@ -813,8 +813,76 @@ func (p *Parser) parseTableRef() (*ast.TableRef, error) {
 		ref.Sample = sample
 	}
 
+	// LATERAL VIEW generator(args) tableAlias AS col[, col...] — chainable.
+	// Engine-verified: the table alias and AS list are required, and the
+	// OUTER variant is rejected.
+	for p.cur.Kind == kwLATERAL {
+		lv, err := p.parseLateralView()
+		if err != nil {
+			return nil, err
+		}
+		ref.LateralViews = append(ref.LateralViews, lv)
+	}
+
 	ref.Loc.End = p.prev.Loc.End
 	return ref, nil
+}
+
+// parseLateralView parses one LATERAL VIEW suffix. On entry cur is LATERAL.
+func (p *Parser) parseLateralView() (*ast.LateralView, error) {
+	p.advance() // consume LATERAL
+	if _, err := p.expect(kwVIEW); err != nil {
+		return nil, err
+	}
+
+	name, nameLoc, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	fc := &ast.FuncCallExpr{
+		Name: &ast.ObjectName{Parts: []string{name}, Loc: nameLoc},
+		Loc:  ast.Loc{Start: nameLoc.Start},
+	}
+	if _, err := p.expect(int('(')); err != nil {
+		return nil, err
+	}
+	if p.cur.Kind != int(')') {
+		args, err := p.parseExprList()
+		if err != nil {
+			return nil, err
+		}
+		fc.Args = args
+	}
+	closeTok, err := p.expect(int(')'))
+	if err != nil {
+		return nil, err
+	}
+	fc.Loc.End = closeTok.Loc.End
+
+	lv := &ast.LateralView{Func: fc}
+	alias, _, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	lv.TableAlias = alias
+
+	if _, err := p.expect(kwAS); err != nil {
+		return nil, err
+	}
+	col, _, err := p.parseIdentifier()
+	if err != nil {
+		return nil, err
+	}
+	lv.Columns = append(lv.Columns, col)
+	for p.cur.Kind == int(',') {
+		p.advance() // consume ','
+		col, _, err := p.parseIdentifier()
+		if err != nil {
+			return nil, err
+		}
+		lv.Columns = append(lv.Columns, col)
+	}
+	return lv, nil
 }
 
 // parseTableSample parses TABLESAMPLE(n ROWS | n PERCENT | ) [REPEATABLE seed].

--- a/doris/parser/select_test.go
+++ b/doris/parser/select_test.go
@@ -967,3 +967,59 @@ func TestParenQueryLocCoversParens(t *testing.T) {
 		}
 	}
 }
+
+func TestLateralView(t *testing.T) {
+	// LATERAL VIEW generator(args) tableAlias AS col[, col...] — the engine
+	// requires the table alias and AS list and has no OUTER variant
+	// (container-verified).
+	file, errs := Parse("SELECT * FROM t LATERAL VIEW EXPLODE_SPLIT(s, ',') tmp AS c1, c2")
+	if len(errs) != 0 {
+		t.Fatalf("errors: %v", errs)
+	}
+	sel := file.Stmts[0].(*ast.SelectStmt)
+	ref := sel.From[0].(*ast.TableRef)
+	if len(ref.LateralViews) != 1 {
+		t.Fatalf("LateralViews = %d, want 1", len(ref.LateralViews))
+	}
+	lv := ref.LateralViews[0]
+	if lv.Func == nil || lv.Func.Name.Parts[0] != "EXPLODE_SPLIT" {
+		t.Fatalf("Func = %+v, want EXPLODE_SPLIT call", lv.Func)
+	}
+	if lv.TableAlias != "tmp" || len(lv.Columns) != 2 {
+		t.Fatalf("alias/columns = %q/%v, want tmp/[c1 c2]", lv.TableAlias, lv.Columns)
+	}
+
+	// Chained lateral views.
+	file, errs = Parse("SELECT * FROM t LATERAL VIEW EXPLODE([1]) a AS x LATERAL VIEW EXPLODE([2]) b AS y")
+	if len(errs) != 0 {
+		t.Fatalf("chained errors: %v", errs)
+	}
+	ref = file.Stmts[0].(*ast.SelectStmt).From[0].(*ast.TableRef)
+	if len(ref.LateralViews) != 2 {
+		t.Fatalf("LateralViews = %d, want 2", len(ref.LateralViews))
+	}
+
+	// Generator args are reachable from Walk (lineage depends on it).
+	count := 0
+	ast.Inspect(file.Stmts[0], func(n ast.Node) bool {
+		if n != nil && n.Tag() == ast.T_FuncCallExpr {
+			count++
+		}
+		return true
+	})
+	if count != 2 {
+		t.Errorf("FuncCallExpr visited %d times, want 2", count)
+	}
+
+	// Engine-rejected forms stay rejected.
+	for _, sql := range []string{
+		"SELECT * FROM t LATERAL VIEW OUTER EXPLODE([1]) tmp AS c",
+		"SELECT * FROM t LATERAL VIEW EXPLODE([1]) tmp",
+		"SELECT * FROM t LATERAL VIEW EXPLODE([1]) AS c",
+		"SELECT * FROM t LATERAL VIEW EXPLODE([1]) tmp AS c zzz",
+	} {
+		if _, errs := Parse(sql); len(errs) == 0 {
+			t.Errorf("%s parsed, want error", sql)
+		}
+	}
+}

--- a/starrocks/parser/starrocks_syntax_conformance_test.go
+++ b/starrocks/parser/starrocks_syntax_conformance_test.go
@@ -99,6 +99,10 @@ func TestStarRocksSyntaxConformance(t *testing.T) {
 		// after the set operation's LIMIT is engine-rejected.
 		{"union_limit_then_order_rejected", "SELECT 1 UNION SELECT 2 LIMIT 5 ORDER BY 1", false},
 		{"select_limit_then_order_rejected", "SELECT 1 LIMIT 5 ORDER BY 1", false},
+		// Unlike Doris, StarRocks has no Hive-style LATERAL VIEW at all —
+		// its lateral form is `, [LATERAL] unnest(...)` (engine-verified).
+		{"lateral_view_rejected", "SELECT * FROM person LATERAL VIEW EXPLODE(ARRAY(30, 60)) tableName AS c_age", false},
+		{"lateral_view_chained_rejected", "SELECT * FROM t LATERAL VIEW EXPLODE([1]) a AS x LATERAL VIEW EXPLODE([2]) b AS y", false},
 		{"build_index_rejected", "BUILD INDEX index1 ON table1", false},
 
 		// Forms the parser deliberately still rejects.


### PR DESCRIPTION
## What

Bumping bytebase to the strict parser (#402/#403) surfaced `LATERAL VIEW` as a previously-swallowed construct: the old parser truncated `SELECT * FROM person LATERAL VIEW EXPLODE(ARRAY(30, 60)) tableName AS c_age` at `LATERAL` and "accepted" the prefix — the clause never reached the AST or lineage.

Container-verified against Doris 3.1.4 and StarRocks 3.4.10:

- **doris**: parse `LATERAL VIEW generator(args) tableAlias AS col[, col...]` as a chainable `TableRef` suffix (new `ast.LateralView`, wired into Walk; the span walker analyzes the generator's expressions, so a subquery inside one contributes its table read and the lateral alias is not reported as a physical table). Engine-verified boundaries: the table alias and `AS` list are required, the `OUTER` variant is rejected, and trailing junk after the clause stays rejected.
- **starrocks**: the engine has **no** Hive-style LATERAL VIEW at all (its lateral form is `, [LATERAL] unnest(...)`, already supported), so the parser is unchanged and the rejection is pinned in the conformance matrix. The bytebase-side StarRocks smoke test asserting the old swallow-based "accept" will be flipped in the bytebase bump PR.

## Verification

- Engine verdict battery (10 shapes × both engines) drove every accept/reject decision.
- `-short` suites green; both container conformance matrices replayed green (doris +9 cases, starrocks +2).
- Span test pins generator-subquery lineage (`EXPLODE((SELECT arr FROM t3 ...))` → `t3` in AccessTables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)