### PR TITLE
proto: check for breaking changes against main in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
             exit 1
           fi
 
+      - name: Check proto for breaking changes against main
+        run: make proto-breaking
+
       - name: Build
         run: go build ./...
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-pg test-mysql test-mysql-quick test-mysql-full test-mysql-containers test-mssql test-oracle proto clean
+.PHONY: build test test-pg test-mysql test-mysql-quick test-mysql-full test-mysql-containers test-mssql test-oracle proto proto-breaking clean
 
 BUF := go run github.com/bufbuild/buf/cmd/buf@v1.72.0
 
@@ -31,6 +31,9 @@ test-oracle:
 
 proto:
 	cd proto && $(BUF) format -w && $(BUF) lint && $(BUF) generate
+
+proto-breaking:
+	cd proto && $(BUF) breaking --against 'https://github.com/bytebase/omni.git#branch=main,subdir=proto'
 
 clean:
 	go clean ./...


### PR DESCRIPTION
Follow-up to #412. `make proto-breaking` runs `buf breaking` with the WIRE_JSON rules from `proto/buf.yaml` against main, and CI now runs it on every PR. A renamed field or enum value in the metadata proto would silently drop that value from every snapshot bytebase has stored, so this check has to fail CI.

It couldn't land with #412 because `buf breaking` fails against a baseline with no proto files, and main had none until #412 merged.

## Testing

- `make proto-breaking` passes against main.
- Renaming `ColumnMetadata.is_invisible` to `is_hidden` fails it: `Field "22" on message "ColumnMetadata" changed name from "is_invisible" to "is_hidden"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
