### PR TITLE
mysql/catalog: load a Bytebase metadata snapshot

### DIFF
--- a/mysql/catalog/metadata_load.go
+++ b/mysql/catalog/metadata_load.go
@@ -27,12 +27,13 @@ type LoadMetadataReport struct {
 }
 
 // LoadMetadata installs a Bytebase schema snapshot of a MySQL database into
-// the database meta.Name, creating it if needed, and leaves that database
-// selected. Foreign key checks are off during the load, so a table may
-// reference one that installs after it. A view may likewise name a view that
-// installs after it. Generated invisible primary keys are off and
-// explicit_defaults_for_timestamp is on, so each table installs as the snapshot
-// records it. The caller's settings are restored afterward.
+// the database meta.Name, creating it if needed, gives the database the
+// snapshot's character set and collation, and leaves it selected. Foreign key
+// checks are off during the load, so a table may reference one that installs
+// after it. A view may likewise name a view that installs after it. Generated
+// invisible primary keys are off and explicit_defaults_for_timestamp is on, so
+// each table installs as the snapshot records it. The caller's settings are
+// restored afterward.
 //
 // An object that fails to install does not stop the load. A table is replaced
 // by a stand-in with the same column names, all TEXT; a view by one that
@@ -48,8 +49,11 @@ func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchem
 		return report, err
 	}
 	if name := meta.GetName(); name != "" {
+		stmt := metadataDatabaseStmt(meta)
 		if c.GetDatabase(name) == nil {
-			_ = c.DefineDatabase(metadataDatabaseStmt(meta))
+			_ = c.DefineDatabase(stmt)
+		} else if len(stmt.Options) > 0 {
+			_ = c.alterDatabase(&nodes.AlterDatabaseStmt{Name: name, Options: stmt.Options})
 		}
 		c.SetCurrentDatabase(name)
 	}

--- a/mysql/catalog/metadata_load.go
+++ b/mysql/catalog/metadata_load.go
@@ -30,7 +30,9 @@ type LoadMetadataReport struct {
 // the database meta.Name, creating it if needed, and leaves that database
 // selected. Foreign key checks are off during the load, so a table may
 // reference one that installs after it. A view may likewise name a view that
-// installs after it.
+// installs after it. Generated invisible primary keys are off and
+// explicit_defaults_for_timestamp is on, so each table installs as the snapshot
+// records it. The caller's settings are restored afterward.
 //
 // An object that fails to install does not stop the load. A table is replaced
 // by a stand-in with the same column names, all TEXT; a view by one that
@@ -54,6 +56,9 @@ func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchem
 	fkChecks := c.ForeignKeyChecks()
 	c.SetForeignKeyChecks(false)
 	defer c.SetForeignKeyChecks(fkChecks)
+	gipk, explicitDefaults := c.generateGIPK, c.session.ExplicitDefaultsForTimestamp
+	c.generateGIPK, c.session.ExplicitDefaultsForTimestamp = false, true
+	defer func() { c.generateGIPK, c.session.ExplicitDefaultsForTimestamp = gipk, explicitDefaults }()
 
 	var views []*metadataObject
 	for _, o := range collectMetadataObjects(meta) {
@@ -351,7 +356,7 @@ func metadataColumnDef(col *metadata.ColumnMetadata) (*nodes.ColumnDef, error) {
 	autoIncrement := strings.EqualFold(col.GetDefault(), autoIncrementDefault)
 	def.AutoIncrement = autoIncrement
 	// Sync reports DEFAULT NULL for every nullable column, including types that
-	// take no DEFAULT clause, which would fail the whole table.
+	// show no default.
 	if !autoIncrement && col.GetDefault() != "" && col.GetGeneration() == nil &&
 		(!strings.EqualFold(col.GetDefault(), "NULL") || typeTakesDefault(col.GetType())) {
 		if expr, err := parseExpr(col.GetDefault()); err == nil {
@@ -371,19 +376,14 @@ func metadataColumnDef(col *metadata.ColumnMetadata) (*nodes.ColumnDef, error) {
 	return def, nil
 }
 
-// typeTakesDefault reports whether a column type accepts a literal DEFAULT
-// clause, which the BLOB types, JSON, and GEOMETRY do not.
+// typeTakesDefault reports whether a column type shows a DEFAULT NULL clause,
+// which the BLOB, TEXT, JSON, and spatial types never do.
 func typeTakesDefault(typ string) bool {
 	head := strings.ToLower(strings.TrimSpace(typ))
 	if i := strings.IndexAny(head, " ("); i >= 0 {
 		head = head[:i]
 	}
-	switch head {
-	case "blob", "tinyblob", "mediumblob", "longblob", "json", "geometry":
-		return false
-	default:
-		return true
-	}
+	return !isLiteralDefaultForbiddenType(head)
 }
 
 // metadataIndexConstraint builds an index from its key parts. The index type
@@ -490,10 +490,16 @@ func metadataViewStmt(v *metadata.ViewMetadata) (*nodes.CreateViewStmt, error) {
 		return nil, err
 	}
 	stmt := &nodes.CreateViewStmt{OrReplace: true, Name: &nodes.TableRef{Name: v.GetName()}, Select: sel, SelectText: v.GetDefinition()}
+	// A stored definition drops the column list of CREATE VIEW v (a, b), so the
+	// snapshot's columns become one only where they differ from the body's.
+	var names []string
 	for _, col := range v.GetColumns() {
 		if col.GetName() != "" {
-			stmt.Columns = append(stmt.Columns, col.GetName())
+			names = append(names, col.GetName())
 		}
+	}
+	if len(names) > 0 && !slices.EqualFunc(names, extractViewColumns(sel), strings.EqualFold) {
+		stmt.Columns = names
 	}
 	return stmt, nil
 }

--- a/mysql/catalog/metadata_load.go
+++ b/mysql/catalog/metadata_load.go
@@ -26,16 +26,17 @@ type LoadMetadataReport struct {
 	Missing map[string]error
 }
 
-// LoadMetadata installs a Bytebase schema snapshot of a MySQL database into
-// the database meta.Name, creating it if needed, gives the database the
-// snapshot's character set and collation, and leaves it selected. Foreign key
-// checks are off during the load, so a table may reference one that installs
-// after it. A view may likewise name a view that installs after it. Generated
-// invisible primary keys are off and explicit_defaults_for_timestamp is on, so
-// each table installs as the snapshot records it. The caller's settings are
-// restored afterward. Each routine, trigger, and event the load installs takes
-// the session context the snapshot records for it, as ApplySessionContext
-// stamps it.
+// LoadMetadata installs a Bytebase schema snapshot of a MySQL database into the
+// database meta.Name, creating it if needed with the snapshot's character set
+// and collation, and leaves that database selected.
+//
+// The settings that would rewrite what it installs are off for the length of
+// the load, and the caller's are restored afterward: a table may reference one
+// that installs after it, and each table installs as the snapshot records it. A
+// view may likewise name a view that installs after it, since views whose
+// bodies did not analyze are reinstalled once everything is in. Each routine,
+// trigger, and event the load installs takes the session context the snapshot
+// records for it, as ApplySessionContext stamps it.
 //
 // An object that fails to install does not stop the load. A table is replaced
 // by a stand-in with the same column names, all TEXT; a view by one that
@@ -50,21 +51,9 @@ func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchem
 	if err := ctx.Err(); err != nil {
 		return report, err
 	}
-	if name := meta.GetName(); name != "" {
-		stmt := metadataDatabaseStmt(meta)
-		if c.GetDatabase(name) == nil {
-			_ = c.DefineDatabase(stmt)
-		} else if len(stmt.Options) > 0 {
-			_ = c.alterDatabase(&nodes.AlterDatabaseStmt{Name: name, Options: stmt.Options})
-		}
-		c.SetCurrentDatabase(name)
-	}
-	fkChecks := c.ForeignKeyChecks()
-	c.SetForeignKeyChecks(false)
-	defer c.SetForeignKeyChecks(fkChecks)
-	gipk, explicitDefaults := c.generateGIPK, c.session.ExplicitDefaultsForTimestamp
-	c.generateGIPK, c.session.ExplicitDefaultsForTimestamp = false, true
-	defer func() { c.generateGIPK, c.session.ExplicitDefaultsForTimestamp = gipk, explicitDefaults }()
+	c.selectMetadataDatabase(meta)
+	restore := c.loadSessionSettings()
+	defer restore()
 
 	var views, installed []*metadataObject
 	for _, o := range collectMetadataObjects(meta) {
@@ -96,6 +85,38 @@ func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchem
 		applyDatabaseSessionContext(db, sessionContexts(installed))
 	}
 	return report, nil
+}
+
+// selectMetadataDatabase creates the snapshot's database where the catalog
+// lacks it, gives it the snapshot's character set and collation, and selects
+// it.
+func (c *Catalog) selectMetadataDatabase(meta *metadata.DatabaseSchemaMetadata) {
+	name := meta.GetName()
+	if name == "" {
+		return
+	}
+	stmt := metadataDatabaseStmt(meta)
+	if c.GetDatabase(name) == nil {
+		_ = c.DefineDatabase(stmt)
+	} else if len(stmt.Options) > 0 {
+		_ = c.alterDatabase(&nodes.AlterDatabaseStmt{Name: name, Options: stmt.Options})
+	}
+	c.SetCurrentDatabase(name)
+}
+
+// loadSessionSettings turns off the session settings that rewrite what a table
+// installs as: foreign key checks reject a forward reference, generated
+// invisible primary keys add a column, and explicit_defaults_for_timestamp=OFF
+// rewrites a TIMESTAMP column. It returns a function restoring the caller's.
+func (c *Catalog) loadSessionSettings() func() {
+	fkChecks, gipk := c.ForeignKeyChecks(), c.generateGIPK
+	explicitDefaults := c.session.ExplicitDefaultsForTimestamp
+	c.SetForeignKeyChecks(false)
+	c.generateGIPK, c.session.ExplicitDefaultsForTimestamp = false, true
+	return func() {
+		c.SetForeignKeyChecks(fkChecks)
+		c.generateGIPK, c.session.ExplicitDefaultsForTimestamp = gipk, explicitDefaults
+	}
 }
 
 // sessionContexts collects the creation context the snapshot records for each
@@ -402,16 +423,8 @@ func metadataColumnDef(col *metadata.ColumnMetadata) (*nodes.ColumnDef, error) {
 	if col.GetIsInvisible() {
 		def.Constraints = append(def.Constraints, &nodes.ColumnConstraint{Type: nodes.ColConstrInvisible})
 	}
-	autoIncrement := strings.EqualFold(col.GetDefault(), autoIncrementDefault)
-	def.AutoIncrement = autoIncrement
-	// Sync reports DEFAULT NULL for every nullable column, including types that
-	// show no default.
-	if !autoIncrement && col.GetDefault() != "" && col.GetGeneration() == nil &&
-		(!strings.EqualFold(col.GetDefault(), "NULL") || typeTakesDefault(col.GetType())) {
-		if expr, err := parseExpr(col.GetDefault()); err == nil {
-			def.DefaultValue = expr
-		}
-	}
+	def.AutoIncrement = strings.EqualFold(col.GetDefault(), autoIncrementDefault)
+	def.DefaultValue = columnDefault(col)
 	if col.GetOnUpdate() != "" {
 		if expr, err := parseExpr(col.GetOnUpdate()); err == nil {
 			def.OnUpdate = expr
@@ -423,6 +436,27 @@ func metadataColumnDef(col *metadata.ColumnMetadata) (*nodes.ColumnDef, error) {
 		}
 	}
 	return def, nil
+}
+
+// columnDefault parses the default the snapshot records for a column, or
+// returns nil where the catalog takes none: AUTO_INCREMENT is a flag rather
+// than a default, a generated column has no default, and sync reports DEFAULT
+// NULL even for the types that show no default.
+func columnDefault(col *metadata.ColumnMetadata) nodes.ExprNode {
+	value := col.GetDefault()
+	switch {
+	case value == "" || col.GetGeneration() != nil:
+		return nil
+	case strings.EqualFold(value, autoIncrementDefault):
+		return nil
+	case strings.EqualFold(value, "NULL") && !typeTakesDefault(col.GetType()):
+		return nil
+	}
+	expr, err := parseExpr(value)
+	if err != nil {
+		return nil
+	}
+	return expr
 }
 
 // typeTakesDefault reports whether a column type shows a DEFAULT NULL clause,
@@ -438,8 +472,7 @@ func typeTakesDefault(typ string) bool {
 // metadataIndexConstraint builds an index from its key parts. The index type
 // holds either the kind, FULLTEXT or SPATIAL, or the access method. Sync reports
 // the access method a key without USING gets too, so the engine's default one
-// stays unwritten. A key part that is an expression, or that has a length or
-// descends, goes into IndexColumns; plain columns go into Columns.
+// stays unwritten.
 func metadataIndexConstraint(idx *metadata.IndexMetadata, engine string) *nodes.Constraint {
 	indexType := strings.ToUpper(strings.TrimSpace(idx.GetType()))
 	if indexType == defaultIndexType(engine) {
@@ -458,6 +491,20 @@ func metadataIndexConstraint(idx *metadata.IndexMetadata, engine string) *nodes.
 	default:
 		c.Type, c.IndexType = nodes.ConstrIndex, indexType
 	}
+	c.Columns, c.IndexColumns = indexKeyParts(idx)
+	// A primary key is always visible.
+	if !idx.GetVisible() && !idx.GetPrimary() {
+		c.IndexOptions = append(c.IndexOptions, &nodes.IndexOption{Name: "INVISIBLE"})
+	}
+	if idx.GetComment() != "" {
+		c.IndexOptions = append(c.IndexOptions, &nodes.IndexOption{Name: "COMMENT", Value: &nodes.StringLit{Value: idx.GetComment()}})
+	}
+	return c
+}
+
+// indexKeyParts splits an index's key parts: plain column names, or, where a
+// part is an expression or has a length or descends, an IndexColumn for each.
+func indexKeyParts(idx *metadata.IndexMetadata) ([]string, []*nodes.IndexColumn) {
 	length := func(i int) int {
 		if i < len(idx.GetKeyLength()) {
 			return int(idx.GetKeyLength()[i])
@@ -471,11 +518,15 @@ func metadataIndexConstraint(idx *metadata.IndexMetadata, engine string) *nodes.
 			plain = false
 		}
 	}
-	for i, expr := range idx.GetExpressions() {
-		if plain {
-			c.Columns = append(c.Columns, unquoteIdent(expr))
-			continue
+	if plain {
+		var columns []string
+		for _, expr := range idx.GetExpressions() {
+			columns = append(columns, unquoteIdent(expr))
 		}
+		return columns, nil
+	}
+	var keys []*nodes.IndexColumn
+	for i, expr := range idx.GetExpressions() {
 		key := &nodes.IndexColumn{Expr: &nodes.ColumnRef{Column: unquoteIdent(expr)}, Desc: descending(i)}
 		if l := length(i); l > 0 {
 			key.Length = l
@@ -486,16 +537,9 @@ func metadataIndexConstraint(idx *metadata.IndexMetadata, engine string) *nodes.
 				key.Expr = parsed
 			}
 		}
-		c.IndexColumns = append(c.IndexColumns, key)
+		keys = append(keys, key)
 	}
-	// A primary key is always visible.
-	if !idx.GetVisible() && !idx.GetPrimary() {
-		c.IndexOptions = append(c.IndexOptions, &nodes.IndexOption{Name: "INVISIBLE"})
-	}
-	if idx.GetComment() != "" {
-		c.IndexOptions = append(c.IndexOptions, &nodes.IndexOption{Name: "COMMENT", Value: &nodes.StringLit{Value: idx.GetComment()}})
-	}
-	return c
+	return nil, keys
 }
 
 // defaultIndexType is the access method a key without USING gets.

--- a/mysql/catalog/metadata_load.go
+++ b/mysql/catalog/metadata_load.go
@@ -33,8 +33,9 @@ type LoadMetadataReport struct {
 // after it. A view may likewise name a view that installs after it. Generated
 // invisible primary keys are off and explicit_defaults_for_timestamp is on, so
 // each table installs as the snapshot records it. The caller's settings are
-// restored afterward. Each routine, trigger, and event takes the session context
-// the snapshot records for it, as ApplySessionContext stamps it.
+// restored afterward. Each routine, trigger, and event in the database takes
+// the session context the snapshot records for it, as ApplySessionContext
+// stamps it.
 //
 // An object that fails to install does not stop the load. A table is replaced
 // by a stand-in with the same column names, all TEXT; a view by one that
@@ -89,7 +90,9 @@ func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchem
 	if err := c.reanalyzeViews(ctx, views); err != nil {
 		return report, err
 	}
-	c.ApplySessionContext(sessionContexts(meta))
+	if db := c.GetDatabase(c.CurrentDatabase()); db != nil {
+		applyDatabaseSessionContext(db, sessionContexts(meta))
+	}
 	return report, nil
 }
 

--- a/mysql/catalog/metadata_load.go
+++ b/mysql/catalog/metadata_load.go
@@ -33,7 +33,8 @@ type LoadMetadataReport struct {
 // after it. A view may likewise name a view that installs after it. Generated
 // invisible primary keys are off and explicit_defaults_for_timestamp is on, so
 // each table installs as the snapshot records it. The caller's settings are
-// restored afterward.
+// restored afterward. Each routine, trigger, and event takes the session context
+// the snapshot records for it, as ApplySessionContext stamps it.
 //
 // An object that fails to install does not stop the load. A table is replaced
 // by a stand-in with the same column names, all TEXT; a view by one that
@@ -85,7 +86,45 @@ func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchem
 			report.Missing[o.key()] = standInErr
 		}
 	}
-	return report, c.reanalyzeViews(ctx, views)
+	if err := c.reanalyzeViews(ctx, views); err != nil {
+		return report, err
+	}
+	c.ApplySessionContext(sessionContexts(meta))
+	return report, nil
+}
+
+// sessionContexts collects the creation context the snapshot records for each
+// routine, trigger, and event. An object with none recorded is left out, so it
+// keeps a bare recreate.
+func sessionContexts(meta *metadata.DatabaseSchemaMetadata) SessionContextMap {
+	m := SessionContextMap{
+		Functions:  make(map[string]SessionContext),
+		Procedures: make(map[string]SessionContext),
+		Triggers:   make(map[string]SessionContext),
+		Events:     make(map[string]SessionContext),
+	}
+	add := func(into map[string]SessionContext, name string, ctx SessionContext) {
+		if ctx != (SessionContext{}) {
+			into[toLower(name)] = ctx
+		}
+	}
+	for _, s := range meta.GetSchemas() {
+		for _, fn := range s.GetFunctions() {
+			add(m.Functions, fn.GetName(), SessionContext{SQLMode: fn.GetSqlMode(), CharacterSetClient: fn.GetCharacterSetClient(), CollationConnection: fn.GetCollationConnection()})
+		}
+		for _, p := range s.GetProcedures() {
+			add(m.Procedures, p.GetName(), SessionContext{SQLMode: p.GetSqlMode(), CharacterSetClient: p.GetCharacterSetClient(), CollationConnection: p.GetCollationConnection()})
+		}
+		for _, t := range s.GetTables() {
+			for _, tr := range t.GetTriggers() {
+				add(m.Triggers, tr.GetName(), SessionContext{SQLMode: tr.GetSqlMode(), CharacterSetClient: tr.GetCharacterSetClient(), CollationConnection: tr.GetCollationConnection()})
+			}
+		}
+		for _, e := range s.GetEvents() {
+			add(m.Events, e.GetName(), SessionContext{SQLMode: e.GetSqlMode(), CharacterSetClient: e.GetCharacterSetClient(), CollationConnection: e.GetCollationConnection(), TimeZone: e.GetTimeZone()})
+		}
+	}
+	return m
 }
 
 // reanalyzeViews reinstalls each view whose body did not analyze while a pass
@@ -351,8 +390,13 @@ func metadataColumnDef(col *metadata.ColumnMetadata) (*nodes.ColumnDef, error) {
 		typeName.HasSRID = true
 	}
 	def := &nodes.ColumnDef{Name: col.GetName(), TypeName: typeName, Comment: col.GetComment()}
-	if !col.GetNullable() {
+	switch {
+	case !col.GetNullable():
 		def.Constraints = append(def.Constraints, &nodes.ColumnConstraint{Type: nodes.ColConstrNotNull})
+	case strings.EqualFold(typeName.Name, "timestamp"):
+		// A nullable TIMESTAMP says NULL, as SHOW CREATE TABLE prints it, so
+		// explicit_defaults_for_timestamp=OFF cannot read it as NOT NULL.
+		def.Constraints = append(def.Constraints, &nodes.ColumnConstraint{Type: nodes.ColConstrNull})
 	}
 	if col.GetIsInvisible() {
 		def.Constraints = append(def.Constraints, &nodes.ColumnConstraint{Type: nodes.ColConstrInvisible})

--- a/mysql/catalog/metadata_load.go
+++ b/mysql/catalog/metadata_load.go
@@ -29,7 +29,8 @@ type LoadMetadataReport struct {
 // LoadMetadata installs a Bytebase schema snapshot of a MySQL database into
 // the database meta.Name, creating it if needed, and leaves that database
 // selected. Foreign key checks are off during the load, so a table may
-// reference one that installs after it.
+// reference one that installs after it. A view may likewise name a view that
+// installs after it.
 //
 // An object that fails to install does not stop the load. A table is replaced
 // by a stand-in with the same column names, all TEXT; a view by one that
@@ -46,8 +47,7 @@ func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchem
 	}
 	if name := meta.GetName(); name != "" {
 		if c.GetDatabase(name) == nil {
-			// A database without options always installs.
-			_ = c.DefineDatabase(&nodes.CreateDatabaseStmt{Name: name})
+			_ = c.DefineDatabase(metadataDatabaseStmt(meta))
 		}
 		c.SetCurrentDatabase(name)
 	}
@@ -55,12 +55,16 @@ func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchem
 	c.SetForeignKeyChecks(false)
 	defer c.SetForeignKeyChecks(fkChecks)
 
+	var views []*metadataObject
 	for _, o := range collectMetadataObjects(meta) {
 		if err := ctx.Err(); err != nil {
 			return report, err
 		}
 		err := c.installMetadataObject(o)
 		if err == nil {
+			if o.kind == metadataView {
+				views = append(views, o)
+			}
 			continue
 		}
 		switch standInErr := c.installStandIn(o); {
@@ -72,7 +76,37 @@ func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchem
 			report.Missing[o.key()] = standInErr
 		}
 	}
-	return report, nil
+	return report, c.reanalyzeViews(ctx, views)
+}
+
+// reanalyzeViews reinstalls each view whose body did not analyze while a pass
+// analyzes more of them: a body analyzes only once the views it names are
+// installed, and those may install after it.
+func (c *Catalog) reanalyzeViews(ctx context.Context, views []*metadataObject) error {
+	for progress := true; progress; {
+		progress = false
+		for _, o := range views {
+			if c.viewAnalyzed(o.name) {
+				continue
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if c.installMetadataObject(o) == nil && c.viewAnalyzed(o.name) {
+				progress = true
+			}
+		}
+	}
+	return nil
+}
+
+func (c *Catalog) viewAnalyzed(name string) bool {
+	db := c.GetDatabase(c.CurrentDatabase())
+	if db == nil {
+		return false
+	}
+	v := db.Views[toLower(name)]
+	return v != nil && v.AnalyzedQuery != nil
 }
 
 // --- Objects ---
@@ -182,7 +216,11 @@ func (c *Catalog) installMetadataObject(o *metadataObject) error {
 		}
 		return c.DefineTable(stmt)
 	case metadataView:
-		return c.DefineView(metadataViewStmt(o.view))
+		stmt, err := metadataViewStmt(o.view)
+		if err != nil {
+			return err
+		}
+		return c.DefineView(stmt)
 	case metadataFunction:
 		stmt, err := parseRoutine(o.function.GetDefinition(), false)
 		if err != nil {
@@ -219,6 +257,19 @@ func (c *Catalog) installMetadataObject(o *metadataObject) error {
 // AUTO_INCREMENT column.
 const autoIncrementDefault = "AUTO_INCREMENT"
 
+func metadataDatabaseStmt(meta *metadata.DatabaseSchemaMetadata) *nodes.CreateDatabaseStmt {
+	stmt := &nodes.CreateDatabaseStmt{Name: meta.GetName()}
+	for _, opt := range []*nodes.DatabaseOption{
+		{Name: "CHARACTER SET", Value: meta.GetCharacterSet()},
+		{Name: "COLLATE", Value: meta.GetCollation()},
+	} {
+		if opt.Value != "" {
+			stmt.Options = append(stmt.Options, opt)
+		}
+	}
+	return stmt
+}
+
 // metadataTableStmt fails on a column whose type does not parse, so the table
 // gets a stand-in rather than a partial definition. A default, ON UPDATE,
 // generation, or CHECK expression that does not parse is dropped instead.
@@ -253,12 +304,24 @@ func metadataTableStmt(t *metadata.TableMetadata) (*nodes.CreateTableStmt, error
 		{"CHARSET", t.GetCharset()},
 		{"COLLATE", t.GetCollation()},
 		{"COMMENT", t.GetComment()},
+		{"ROW_FORMAT", createOption(t.GetCreateOptions(), "row_format")},
 	} {
 		if opt.value != "" {
 			stmt.Options = append(stmt.Options, &nodes.TableOption{Name: opt.name, Value: opt.value})
 		}
 	}
 	return stmt, nil
+}
+
+// createOption returns the value of one CREATE_OPTIONS entry; sync keeps them
+// as space-separated name=value pairs.
+func createOption(options, name string) string {
+	for _, opt := range strings.Fields(options) {
+		if k, v, ok := strings.Cut(opt, "="); ok && strings.EqualFold(k, name) {
+			return v
+		}
+	}
+	return ""
 }
 
 func metadataColumnDef(col *metadata.ColumnMetadata) (*nodes.ColumnDef, error) {
@@ -372,6 +435,13 @@ func metadataIndexConstraint(idx *metadata.IndexMetadata) *nodes.Constraint {
 		}
 		c.IndexColumns = append(c.IndexColumns, key)
 	}
+	// A primary key is always visible.
+	if !idx.GetVisible() && !idx.GetPrimary() {
+		c.IndexOptions = append(c.IndexOptions, &nodes.IndexOption{Name: "INVISIBLE"})
+	}
+	if idx.GetComment() != "" {
+		c.IndexOptions = append(c.IndexOptions, &nodes.IndexOption{Name: "COMMENT", Value: &nodes.StringLit{Value: idx.GetComment()}})
+	}
 	return c
 }
 
@@ -411,20 +481,21 @@ func referenceAction(action string) nodes.ReferenceAction {
 	}
 }
 
-// metadataViewStmt keeps the view's text as it is and its parsed body when it
-// parses. DefineView installs a view whose body does not analyze, so a view
-// may name one that installs after it.
-func metadataViewStmt(v *metadata.ViewMetadata) *nodes.CreateViewStmt {
-	stmt := &nodes.CreateViewStmt{OrReplace: true, Name: &nodes.TableRef{Name: v.GetName()}, SelectText: v.GetDefinition()}
+// metadataViewStmt keeps the view's text as it is along with its parsed body.
+// DefineView installs a view whose body does not analyze, so a view may name
+// one that installs after it; reanalyzeViews retries it then.
+func metadataViewStmt(v *metadata.ViewMetadata) (*nodes.CreateViewStmt, error) {
+	sel, err := parseFirstStatement[*nodes.SelectStmt](v.GetDefinition())
+	if err != nil {
+		return nil, err
+	}
+	stmt := &nodes.CreateViewStmt{OrReplace: true, Name: &nodes.TableRef{Name: v.GetName()}, Select: sel, SelectText: v.GetDefinition()}
 	for _, col := range v.GetColumns() {
 		if col.GetName() != "" {
 			stmt.Columns = append(stmt.Columns, col.GetName())
 		}
 	}
-	if sel, err := parseFirstStatement[*nodes.SelectStmt](v.GetDefinition()); err == nil {
-		stmt.Select = sel
-	}
-	return stmt
+	return stmt, nil
 }
 
 // metadataTriggerStmt builds a trigger from its parts. Sync stores the body

--- a/mysql/catalog/metadata_load.go
+++ b/mysql/catalog/metadata_load.go
@@ -33,7 +33,7 @@ type LoadMetadataReport struct {
 // after it. A view may likewise name a view that installs after it. Generated
 // invisible primary keys are off and explicit_defaults_for_timestamp is on, so
 // each table installs as the snapshot records it. The caller's settings are
-// restored afterward. Each routine, trigger, and event in the database takes
+// restored afterward. Each routine, trigger, and event the load installs takes
 // the session context the snapshot records for it, as ApplySessionContext
 // stamps it.
 //
@@ -66,13 +66,14 @@ func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchem
 	c.generateGIPK, c.session.ExplicitDefaultsForTimestamp = false, true
 	defer func() { c.generateGIPK, c.session.ExplicitDefaultsForTimestamp = gipk, explicitDefaults }()
 
-	var views []*metadataObject
+	var views, installed []*metadataObject
 	for _, o := range collectMetadataObjects(meta) {
 		if err := ctx.Err(); err != nil {
 			return report, err
 		}
 		err := c.installMetadataObject(o)
 		if err == nil {
+			installed = append(installed, o)
 			if o.kind == metadataView {
 				views = append(views, o)
 			}
@@ -80,6 +81,7 @@ func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchem
 		}
 		switch standInErr := c.installStandIn(o); {
 		case standInErr == nil:
+			installed = append(installed, o)
 			report.Degraded[o.key()] = err
 		case errors.Is(standInErr, errNoStandIn):
 			report.Missing[o.key()] = err
@@ -91,15 +93,15 @@ func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchem
 		return report, err
 	}
 	if db := c.GetDatabase(c.CurrentDatabase()); db != nil {
-		applyDatabaseSessionContext(db, sessionContexts(meta))
+		applyDatabaseSessionContext(db, sessionContexts(installed))
 	}
 	return report, nil
 }
 
 // sessionContexts collects the creation context the snapshot records for each
-// routine, trigger, and event. An object with none recorded is left out, so it
-// keeps a bare recreate.
-func sessionContexts(meta *metadata.DatabaseSchemaMetadata) SessionContextMap {
+// routine, trigger, and event in objects. An object with none recorded is left
+// out, so it keeps a bare recreate.
+func sessionContexts(objects []*metadataObject) SessionContextMap {
 	m := SessionContextMap{
 		Functions:  make(map[string]SessionContext),
 		Procedures: make(map[string]SessionContext),
@@ -111,20 +113,16 @@ func sessionContexts(meta *metadata.DatabaseSchemaMetadata) SessionContextMap {
 			into[toLower(name)] = ctx
 		}
 	}
-	for _, s := range meta.GetSchemas() {
-		for _, fn := range s.GetFunctions() {
-			add(m.Functions, fn.GetName(), SessionContext{SQLMode: fn.GetSqlMode(), CharacterSetClient: fn.GetCharacterSetClient(), CollationConnection: fn.GetCollationConnection()})
-		}
-		for _, p := range s.GetProcedures() {
-			add(m.Procedures, p.GetName(), SessionContext{SQLMode: p.GetSqlMode(), CharacterSetClient: p.GetCharacterSetClient(), CollationConnection: p.GetCollationConnection()})
-		}
-		for _, t := range s.GetTables() {
-			for _, tr := range t.GetTriggers() {
-				add(m.Triggers, tr.GetName(), SessionContext{SQLMode: tr.GetSqlMode(), CharacterSetClient: tr.GetCharacterSetClient(), CollationConnection: tr.GetCollationConnection()})
-			}
-		}
-		for _, e := range s.GetEvents() {
-			add(m.Events, e.GetName(), SessionContext{SQLMode: e.GetSqlMode(), CharacterSetClient: e.GetCharacterSetClient(), CollationConnection: e.GetCollationConnection(), TimeZone: e.GetTimeZone()})
+	for _, o := range objects {
+		switch o.kind {
+		case metadataFunction:
+			add(m.Functions, o.name, SessionContext{SQLMode: o.function.GetSqlMode(), CharacterSetClient: o.function.GetCharacterSetClient(), CollationConnection: o.function.GetCollationConnection()})
+		case metadataProcedure:
+			add(m.Procedures, o.name, SessionContext{SQLMode: o.procedure.GetSqlMode(), CharacterSetClient: o.procedure.GetCharacterSetClient(), CollationConnection: o.procedure.GetCollationConnection()})
+		case metadataTrigger:
+			add(m.Triggers, o.name, SessionContext{SQLMode: o.trigger.GetSqlMode(), CharacterSetClient: o.trigger.GetCharacterSetClient(), CollationConnection: o.trigger.GetCollationConnection()})
+		case metadataEvent:
+			add(m.Events, o.name, SessionContext{SQLMode: o.event.GetSqlMode(), CharacterSetClient: o.event.GetCharacterSetClient(), CollationConnection: o.event.GetCollationConnection(), TimeZone: o.event.GetTimeZone()})
 		}
 	}
 	return m

--- a/mysql/catalog/metadata_load.go
+++ b/mysql/catalog/metadata_load.go
@@ -1,0 +1,609 @@
+package catalog
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/bytebase/omni/metadata"
+	nodes "github.com/bytebase/omni/mysql/ast"
+	mysqlparser "github.com/bytebase/omni/mysql/parser"
+)
+
+// LoadMetadataReport lists the snapshot objects LoadMetadata could not install
+// as the snapshot defines them. Keys are "table:<name>", "view:<name>",
+// "function:<name>", "procedure:<name>", "trigger:<table>.<name>", and
+// "event:<name>".
+type LoadMetadataReport struct {
+	// Degraded maps each object replaced by a stand-in to the error its
+	// definition failed with.
+	Degraded map[string]error
+	// Missing maps each object the catalog has nothing for to the error that
+	// left it out.
+	Missing map[string]error
+}
+
+// LoadMetadata installs a Bytebase schema snapshot of a MySQL database into
+// the database meta.Name, creating it if needed, and leaves that database
+// selected. Foreign key checks are off during the load, so a table may
+// reference one that installs after it.
+//
+// An object that fails to install does not stop the load. A table is replaced
+// by a stand-in with the same column names, all TEXT; a view by one that
+// selects NULL under each of its column names; a trigger by one with an empty
+// body; and an event by one with only its name. A function or procedure that
+// fails is left out. The error is non-nil only when ctx is done.
+func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchemaMetadata) (*LoadMetadataReport, error) {
+	report := &LoadMetadataReport{
+		Degraded: make(map[string]error),
+		Missing:  make(map[string]error),
+	}
+	if err := ctx.Err(); err != nil {
+		return report, err
+	}
+	if name := meta.GetName(); name != "" {
+		if c.GetDatabase(name) == nil {
+			// A database without options always installs.
+			_ = c.DefineDatabase(&nodes.CreateDatabaseStmt{Name: name})
+		}
+		c.SetCurrentDatabase(name)
+	}
+	fkChecks := c.ForeignKeyChecks()
+	c.SetForeignKeyChecks(false)
+	defer c.SetForeignKeyChecks(fkChecks)
+
+	for _, o := range collectMetadataObjects(meta) {
+		if err := ctx.Err(); err != nil {
+			return report, err
+		}
+		err := c.installMetadataObject(o)
+		if err == nil {
+			continue
+		}
+		switch standInErr := c.installStandIn(o); {
+		case standInErr == nil:
+			report.Degraded[o.key()] = err
+		case errors.Is(standInErr, errNoStandIn):
+			report.Missing[o.key()] = err
+		default:
+			report.Missing[o.key()] = standInErr
+		}
+	}
+	return report, nil
+}
+
+// --- Objects ---
+
+// metadataObjectKind lists the kinds in the order they install. Only a
+// trigger needs another object first, its table: foreign key checks are off,
+// a view may name an object not yet installed, and routine bodies are not
+// analyzed.
+type metadataObjectKind int
+
+const (
+	metadataTable metadataObjectKind = iota
+	metadataView
+	metadataFunction
+	metadataProcedure
+	metadataTrigger
+	metadataEvent
+)
+
+// metadataObject is one install step. The metadata pointer matching kind is
+// set.
+type metadataObject struct {
+	kind metadataObjectKind
+	name string
+	// parent is a trigger's table.
+	parent string
+
+	table     *metadata.TableMetadata
+	view      *metadata.ViewMetadata
+	function  *metadata.FunctionMetadata
+	procedure *metadata.ProcedureMetadata
+	trigger   *metadata.TriggerMetadata
+	event     *metadata.EventMetadata
+}
+
+// key names the object in the report.
+func (o *metadataObject) key() string {
+	switch o.kind {
+	case metadataTable:
+		return "table:" + o.name
+	case metadataView:
+		return "view:" + o.name
+	case metadataFunction:
+		return "function:" + o.name
+	case metadataProcedure:
+		return "procedure:" + o.name
+	case metadataTrigger:
+		return "trigger:" + o.parent + "." + o.name
+	default:
+		return "event:" + o.name
+	}
+}
+
+// --- Collecting ---
+
+// collectMetadataObjects lists the snapshot's objects in install order: by
+// kind, then name.
+func collectMetadataObjects(meta *metadata.DatabaseSchemaMetadata) []*metadataObject {
+	var out []*metadataObject
+	for _, s := range meta.GetSchemas() {
+		for _, t := range s.GetTables() {
+			if t.GetName() == "" {
+				continue
+			}
+			out = append(out, &metadataObject{kind: metadataTable, name: t.GetName(), table: t})
+			for _, trg := range t.GetTriggers() {
+				if trg.GetName() != "" {
+					out = append(out, &metadataObject{kind: metadataTrigger, name: trg.GetName(), parent: t.GetName(), trigger: trg})
+				}
+			}
+		}
+		for _, v := range s.GetViews() {
+			if v.GetName() != "" {
+				out = append(out, &metadataObject{kind: metadataView, name: v.GetName(), view: v})
+			}
+		}
+		for _, fn := range s.GetFunctions() {
+			if fn.GetName() != "" {
+				out = append(out, &metadataObject{kind: metadataFunction, name: fn.GetName(), function: fn})
+			}
+		}
+		for _, p := range s.GetProcedures() {
+			if p.GetName() != "" {
+				out = append(out, &metadataObject{kind: metadataProcedure, name: p.GetName(), procedure: p})
+			}
+		}
+		for _, e := range s.GetEvents() {
+			if e.GetName() != "" {
+				out = append(out, &metadataObject{kind: metadataEvent, name: e.GetName(), event: e})
+			}
+		}
+	}
+	slices.SortFunc(out, func(a, b *metadataObject) int {
+		return cmp.Or(cmp.Compare(a.kind, b.kind), cmp.Compare(a.name, b.name), cmp.Compare(a.parent, b.parent))
+	})
+	return out
+}
+
+// --- Installing ---
+
+func (c *Catalog) installMetadataObject(o *metadataObject) error {
+	switch o.kind {
+	case metadataTable:
+		stmt, err := metadataTableStmt(o.table)
+		if err != nil {
+			return err
+		}
+		return c.DefineTable(stmt)
+	case metadataView:
+		return c.DefineView(metadataViewStmt(o.view))
+	case metadataFunction:
+		stmt, err := parseRoutine(o.function.GetDefinition(), false)
+		if err != nil {
+			return err
+		}
+		return c.DefineFunction(stmt)
+	case metadataProcedure:
+		stmt, err := parseRoutine(o.procedure.GetDefinition(), true)
+		if err != nil {
+			return err
+		}
+		return c.DefineProcedure(stmt)
+	case metadataTrigger:
+		if o.trigger.GetTiming() == "" || o.trigger.GetEvent() == "" {
+			return errors.New("trigger has no timing or event")
+		}
+		return c.DefineTrigger(metadataTriggerStmt(o.trigger, o.parent))
+	default:
+		stmt, err := parseFirstStatement[*nodes.CreateEventStmt](o.event.GetDefinition())
+		if err != nil {
+			return err
+		}
+		return c.DefineEvent(stmt)
+	}
+}
+
+// --- Statements ---
+
+// The snapshot carries types, defaults, and definitions as the text MySQL
+// reports for them. These builders turn that text into the statement ASTs the
+// Define* functions take.
+
+// autoIncrementDefault is what MySQL sync stores as the default of an
+// AUTO_INCREMENT column.
+const autoIncrementDefault = "AUTO_INCREMENT"
+
+// metadataTableStmt fails on a column whose type does not parse, so the table
+// gets a stand-in rather than a partial definition. A default, ON UPDATE,
+// generation, or CHECK expression that does not parse is dropped instead.
+// Partitions are left out: they do not change what the columns resolve to.
+func metadataTableStmt(t *metadata.TableMetadata) (*nodes.CreateTableStmt, error) {
+	stmt := &nodes.CreateTableStmt{Table: &nodes.TableRef{Name: t.GetName()}}
+	for _, col := range t.GetColumns() {
+		if col.GetName() == "" {
+			continue
+		}
+		def, err := metadataColumnDef(col)
+		if err != nil {
+			return nil, fmt.Errorf("column %q: %w", col.GetName(), err)
+		}
+		stmt.Columns = append(stmt.Columns, def)
+	}
+	for _, idx := range t.GetIndexes() {
+		if len(idx.GetExpressions()) > 0 {
+			stmt.Constraints = append(stmt.Constraints, metadataIndexConstraint(idx))
+		}
+	}
+	for _, fk := range t.GetForeignKeys() {
+		stmt.Constraints = append(stmt.Constraints, metadataForeignKey(fk))
+	}
+	for _, check := range t.GetCheckConstraints() {
+		if expr, err := parseExpr(check.GetExpression()); err == nil {
+			stmt.Constraints = append(stmt.Constraints, &nodes.Constraint{Type: nodes.ConstrCheck, Name: check.GetName(), Expr: expr})
+		}
+	}
+	for _, opt := range []struct{ name, value string }{
+		{"ENGINE", t.GetEngine()},
+		{"CHARSET", t.GetCharset()},
+		{"COLLATE", t.GetCollation()},
+		{"COMMENT", t.GetComment()},
+	} {
+		if opt.value != "" {
+			stmt.Options = append(stmt.Options, &nodes.TableOption{Name: opt.name, Value: opt.value})
+		}
+	}
+	return stmt, nil
+}
+
+func metadataColumnDef(col *metadata.ColumnMetadata) (*nodes.ColumnDef, error) {
+	typeName, err := parseTypeName(col.GetType())
+	if err != nil {
+		return nil, err
+	}
+	// The type text may carry its own character set and collation.
+	if typeName.Charset == "" {
+		typeName.Charset = col.GetCharacterSet()
+	}
+	if typeName.Collate == "" {
+		typeName.Collate = col.GetCollation()
+	}
+	// SRID 0 is a valid SRID, so presence decides.
+	if col.Srid != nil {
+		typeName.SRID = int(col.GetSrid())
+		typeName.HasSRID = true
+	}
+	def := &nodes.ColumnDef{Name: col.GetName(), TypeName: typeName, Comment: col.GetComment()}
+	if !col.GetNullable() {
+		def.Constraints = append(def.Constraints, &nodes.ColumnConstraint{Type: nodes.ColConstrNotNull})
+	}
+	if col.GetIsInvisible() {
+		def.Constraints = append(def.Constraints, &nodes.ColumnConstraint{Type: nodes.ColConstrInvisible})
+	}
+	autoIncrement := strings.EqualFold(col.GetDefault(), autoIncrementDefault)
+	def.AutoIncrement = autoIncrement
+	// Sync reports DEFAULT NULL for every nullable column, including types that
+	// take no DEFAULT clause, which would fail the whole table.
+	if !autoIncrement && col.GetDefault() != "" && col.GetGeneration() == nil &&
+		(!strings.EqualFold(col.GetDefault(), "NULL") || typeTakesDefault(col.GetType())) {
+		if expr, err := parseExpr(col.GetDefault()); err == nil {
+			def.DefaultValue = expr
+		}
+	}
+	if col.GetOnUpdate() != "" {
+		if expr, err := parseExpr(col.GetOnUpdate()); err == nil {
+			def.OnUpdate = expr
+		}
+	}
+	if gen := col.GetGeneration(); gen.GetExpression() != "" {
+		if expr, err := parseExpr(gen.GetExpression()); err == nil {
+			def.Generated = &nodes.GeneratedColumn{Expr: expr, Stored: gen.GetType() == metadata.GenerationMetadata_TYPE_STORED}
+		}
+	}
+	return def, nil
+}
+
+// typeTakesDefault reports whether a column type accepts a literal DEFAULT
+// clause, which the BLOB types, JSON, and GEOMETRY do not.
+func typeTakesDefault(typ string) bool {
+	head := strings.ToLower(strings.TrimSpace(typ))
+	if i := strings.IndexAny(head, " ("); i >= 0 {
+		head = head[:i]
+	}
+	switch head {
+	case "blob", "tinyblob", "mediumblob", "longblob", "json", "geometry":
+		return false
+	default:
+		return true
+	}
+}
+
+// metadataIndexConstraint builds an index from its key parts. The index type
+// holds either the kind, FULLTEXT or SPATIAL, or the access method. A key part
+// that is an expression, or that has a length or descends, goes into
+// IndexColumns; plain columns go into Columns.
+func metadataIndexConstraint(idx *metadata.IndexMetadata) *nodes.Constraint {
+	indexType := strings.ToUpper(strings.TrimSpace(idx.GetType()))
+	c := &nodes.Constraint{Name: idx.GetName()}
+	switch {
+	case idx.GetPrimary():
+		c.Type, c.IndexType = nodes.ConstrPrimaryKey, indexType
+	case idx.GetUnique():
+		c.Type, c.IndexType = nodes.ConstrUnique, indexType
+	case indexType == "FULLTEXT":
+		c.Type = nodes.ConstrFulltextIndex
+	case indexType == "SPATIAL":
+		c.Type = nodes.ConstrSpatialIndex
+	default:
+		c.Type, c.IndexType = nodes.ConstrIndex, indexType
+	}
+	length := func(i int) int {
+		if i < len(idx.GetKeyLength()) {
+			return int(idx.GetKeyLength()[i])
+		}
+		return 0
+	}
+	descending := func(i int) bool { return i < len(idx.GetDescending()) && idx.GetDescending()[i] }
+	plain := true
+	for i, expr := range idx.GetExpressions() {
+		if isExpressionKey(expr) || length(i) > 0 || descending(i) {
+			plain = false
+		}
+	}
+	for i, expr := range idx.GetExpressions() {
+		if plain {
+			c.Columns = append(c.Columns, unquoteIdent(expr))
+			continue
+		}
+		key := &nodes.IndexColumn{Expr: &nodes.ColumnRef{Column: unquoteIdent(expr)}, Desc: descending(i)}
+		if l := length(i); l > 0 {
+			key.Length = l
+		}
+		if isExpressionKey(expr) {
+			// On a parse failure the key stays a column, so the index still installs.
+			if parsed, err := parseExpr(expr); err == nil {
+				key.Expr = parsed
+			}
+		}
+		c.IndexColumns = append(c.IndexColumns, key)
+	}
+	return c
+}
+
+// isExpressionKey reports whether a key part is a functional expression, as
+// in "(lower(name))" or "lower(`name`)", rather than a column.
+func isExpressionKey(s string) bool {
+	return strings.Contains(s, "(")
+}
+
+func metadataForeignKey(fk *metadata.ForeignKeyMetadata) *nodes.Constraint {
+	return &nodes.Constraint{
+		Type:       nodes.ConstrForeignKey,
+		Name:       fk.GetName(),
+		Columns:    fk.GetColumns(),
+		RefTable:   &nodes.TableRef{Schema: fk.GetReferencedSchema(), Name: fk.GetReferencedTable()},
+		RefColumns: fk.GetReferencedColumns(),
+		OnUpdate:   referenceAction(fk.GetOnUpdate()),
+		OnDelete:   referenceAction(fk.GetOnDelete()),
+		Match:      strings.ToUpper(fk.GetMatchType()),
+	}
+}
+
+func referenceAction(action string) nodes.ReferenceAction {
+	switch strings.ToUpper(strings.TrimSpace(action)) {
+	case "RESTRICT":
+		return nodes.RefActRestrict
+	case "CASCADE":
+		return nodes.RefActCascade
+	case "SET NULL":
+		return nodes.RefActSetNull
+	case "SET DEFAULT":
+		return nodes.RefActSetDefault
+	case "NO ACTION":
+		return nodes.RefActNoAction
+	default:
+		return nodes.RefActNone
+	}
+}
+
+// metadataViewStmt keeps the view's text as it is and its parsed body when it
+// parses. DefineView installs a view whose body does not analyze, so a view
+// may name one that installs after it.
+func metadataViewStmt(v *metadata.ViewMetadata) *nodes.CreateViewStmt {
+	stmt := &nodes.CreateViewStmt{OrReplace: true, Name: &nodes.TableRef{Name: v.GetName()}, SelectText: v.GetDefinition()}
+	for _, col := range v.GetColumns() {
+		if col.GetName() != "" {
+			stmt.Columns = append(stmt.Columns, col.GetName())
+		}
+	}
+	if sel, err := parseFirstStatement[*nodes.SelectStmt](v.GetDefinition()); err == nil {
+		stmt.Select = sel
+	}
+	return stmt
+}
+
+// metadataTriggerStmt builds a trigger from its parts. Sync stores the body
+// without the CREATE TRIGGER header, and a body that does not parse is kept as
+// text only.
+func metadataTriggerStmt(tm *metadata.TriggerMetadata, table string) *nodes.CreateTriggerStmt {
+	stmt := &nodes.CreateTriggerStmt{
+		Name:     tm.GetName(),
+		Timing:   tm.GetTiming(),
+		Event:    tm.GetEvent(),
+		Table:    &nodes.TableRef{Name: table},
+		BodyText: tm.GetBody(),
+	}
+	if strings.TrimSpace(tm.GetBody()) != "" {
+		probe := fmt.Sprintf("CREATE TRIGGER `probe` %s %s ON %s FOR EACH ROW %s", tm.GetTiming(), tm.GetEvent(), quoteIdent(table), tm.GetBody())
+		if parsed, err := parseFirstStatement[*nodes.CreateTriggerStmt](probe); err == nil {
+			stmt.Body = parsed.Body
+		}
+	}
+	return stmt
+}
+
+// --- Stand-ins ---
+
+var errNoStandIn = errors.New("no stand-in for this kind of object")
+
+// installStandIn installs o's stand-in, or returns errNoStandIn for a kind
+// without one.
+func (c *Catalog) installStandIn(o *metadataObject) error {
+	switch o.kind {
+	case metadataTable:
+		return c.DefineTable(standInTableStmt(o.table))
+	case metadataView:
+		return c.DefineView(standInViewStmt(o.view))
+	case metadataTrigger:
+		timing, event := o.trigger.GetTiming(), o.trigger.GetEvent()
+		if timing == "" {
+			timing = "BEFORE"
+		}
+		if event == "" {
+			event = "INSERT"
+		}
+		return c.DefineTrigger(&nodes.CreateTriggerStmt{
+			Name:     o.name,
+			Timing:   timing,
+			Event:    event,
+			Table:    &nodes.TableRef{Name: o.parent},
+			BodyText: "BEGIN END",
+		})
+	case metadataEvent:
+		return c.DefineEvent(&nodes.CreateEventStmt{Name: o.name})
+	default:
+		return errNoStandIn
+	}
+}
+
+// standInPlaceholder names the one column of a stand-in with no column names;
+// MySQL requires a table or view to have a column.
+const standInPlaceholder = "__stand_in"
+
+func standInTableStmt(t *metadata.TableMetadata) *nodes.CreateTableStmt {
+	stmt := &nodes.CreateTableStmt{Table: &nodes.TableRef{Name: t.GetName()}}
+	var names []string
+	for _, col := range t.GetColumns() {
+		names = appendUniqueName(names, col.GetName())
+	}
+	if len(names) == 0 {
+		names = []string{standInPlaceholder}
+	}
+	for _, name := range names {
+		stmt.Columns = append(stmt.Columns, &nodes.ColumnDef{Name: name, TypeName: &nodes.DataType{Name: "TEXT"}})
+	}
+	return stmt
+}
+
+// standInViewStmt selects NULL under the view's own column names, else under
+// the names of the columns it reads.
+func standInViewStmt(v *metadata.ViewMetadata) *nodes.CreateViewStmt {
+	var names []string
+	for _, col := range v.GetColumns() {
+		names = appendUniqueName(names, col.GetName())
+	}
+	if len(names) == 0 {
+		for _, dep := range v.GetDependencyColumns() {
+			names = appendUniqueName(names, dep.GetColumn())
+		}
+	}
+	if len(names) == 0 {
+		names = []string{standInPlaceholder}
+	}
+	targets := make([]nodes.ExprNode, 0, len(names))
+	for _, name := range names {
+		targets = append(targets, &nodes.ResTarget{Name: name, Val: &nodes.NullLit{}})
+	}
+	return &nodes.CreateViewStmt{
+		OrReplace: true,
+		Name:      &nodes.TableRef{Name: v.GetName()},
+		Select:    &nodes.SelectStmt{TargetList: targets},
+	}
+}
+
+func appendUniqueName(names []string, name string) []string {
+	if name == "" || slices.Contains(names, name) {
+		return names
+	}
+	return append(names, name)
+}
+
+// --- Parsing snapshot text ---
+
+// parseTypeName parses a column type as MySQL reports it, such as
+// "varchar(255)", "int unsigned", or "enum('a','b')".
+func parseTypeName(typ string) (*nodes.DataType, error) {
+	if strings.TrimSpace(typ) == "" {
+		return nil, errors.New("empty type")
+	}
+	stmt, err := parseFirstStatement[*nodes.CreateTableStmt]("CREATE TABLE `probe` (`c` " + typ + ")")
+	if err != nil {
+		return nil, fmt.Errorf("type %q: %w", typ, err)
+	}
+	if len(stmt.Columns) == 0 || stmt.Columns[0].TypeName == nil {
+		return nil, fmt.Errorf("type %q: no type parsed", typ)
+	}
+	return stmt.Columns[0].TypeName, nil
+}
+
+// parseExpr parses a default, ON UPDATE, generation, or CHECK expression.
+func parseExpr(expr string) (nodes.ExprNode, error) {
+	if strings.TrimSpace(expr) == "" {
+		return nil, errors.New("empty expression")
+	}
+	sel, err := parseFirstStatement[*nodes.SelectStmt]("SELECT (" + expr + ") AS `probe`")
+	if err != nil {
+		return nil, fmt.Errorf("expression %q: %w", expr, err)
+	}
+	if len(sel.TargetList) == 0 {
+		return nil, fmt.Errorf("expression %q: no target parsed", expr)
+	}
+	target, ok := sel.TargetList[0].(*nodes.ResTarget)
+	if !ok {
+		return nil, fmt.Errorf("expression %q: parsed as %T", expr, sel.TargetList[0])
+	}
+	return target.Val, nil
+}
+
+// parseRoutine parses a function's or procedure's SHOW CREATE text.
+func parseRoutine(definition string, procedure bool) (*nodes.CreateFunctionStmt, error) {
+	stmt, err := parseFirstStatement[*nodes.CreateFunctionStmt](definition)
+	if err != nil {
+		return nil, err
+	}
+	stmt.IsProcedure = procedure
+	return stmt, nil
+}
+
+// parseFirstStatement parses sql and returns its first statement of type T.
+func parseFirstStatement[T nodes.Node](sql string) (T, error) {
+	var zero T
+	if strings.TrimSpace(sql) == "" {
+		return zero, errors.New("empty definition")
+	}
+	list, err := mysqlparser.Parse(sql)
+	if err != nil {
+		return zero, err
+	}
+	if list != nil {
+		for _, item := range list.Items {
+			if stmt, ok := item.(T); ok {
+				return stmt, nil
+			}
+		}
+	}
+	return zero, fmt.Errorf("no %T statement", zero)
+}
+
+func unquoteIdent(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' {
+		return strings.ReplaceAll(s[1:len(s)-1], "``", "`")
+	}
+	return s
+}

--- a/mysql/catalog/metadata_load.go
+++ b/mysql/catalog/metadata_load.go
@@ -337,7 +337,7 @@ func metadataTableStmt(t *metadata.TableMetadata) (*nodes.CreateTableStmt, error
 	}
 	for _, idx := range t.GetIndexes() {
 		if len(idx.GetExpressions()) > 0 {
-			stmt.Constraints = append(stmt.Constraints, metadataIndexConstraint(idx))
+			stmt.Constraints = append(stmt.Constraints, metadataIndexConstraint(idx, t.GetEngine()))
 		}
 	}
 	for _, fk := range t.GetForeignKeys() {
@@ -436,11 +436,15 @@ func typeTakesDefault(typ string) bool {
 }
 
 // metadataIndexConstraint builds an index from its key parts. The index type
-// holds either the kind, FULLTEXT or SPATIAL, or the access method. A key part
-// that is an expression, or that has a length or descends, goes into
-// IndexColumns; plain columns go into Columns.
-func metadataIndexConstraint(idx *metadata.IndexMetadata) *nodes.Constraint {
+// holds either the kind, FULLTEXT or SPATIAL, or the access method. Sync reports
+// the access method a key without USING gets too, so the engine's default one
+// stays unwritten. A key part that is an expression, or that has a length or
+// descends, goes into IndexColumns; plain columns go into Columns.
+func metadataIndexConstraint(idx *metadata.IndexMetadata, engine string) *nodes.Constraint {
 	indexType := strings.ToUpper(strings.TrimSpace(idx.GetType()))
+	if indexType == defaultIndexType(engine) {
+		indexType = ""
+	}
 	c := &nodes.Constraint{Name: idx.GetName()}
 	switch {
 	case idx.GetPrimary():
@@ -492,6 +496,14 @@ func metadataIndexConstraint(idx *metadata.IndexMetadata) *nodes.Constraint {
 		c.IndexOptions = append(c.IndexOptions, &nodes.IndexOption{Name: "COMMENT", Value: &nodes.StringLit{Value: idx.GetComment()}})
 	}
 	return c
+}
+
+// defaultIndexType is the access method a key without USING gets.
+func defaultIndexType(engine string) string {
+	if strings.EqualFold(engine, "MEMORY") || strings.EqualFold(engine, "HEAP") {
+		return "HASH"
+	}
+	return "BTREE"
 }
 
 // isExpressionKey reports whether a key part is a functional expression, as
@@ -547,10 +559,32 @@ func metadataViewStmt(v *metadata.ViewMetadata) (*nodes.CreateViewStmt, error) {
 			names = append(names, col.GetName())
 		}
 	}
-	if len(names) > 0 && !slices.EqualFunc(names, extractViewColumns(sel), strings.EqualFold) {
+	// A * names its columns only once the catalog resolves it, so the body
+	// gives no names to compare.
+	if len(names) > 0 && !selectsStar(sel) && !slices.EqualFunc(names, extractViewColumns(sel), strings.EqualFold) {
 		stmt.Columns = names
 	}
 	return stmt, nil
+}
+
+// selectsStar reports whether a view body's output list has a *, as in SELECT *
+// or SELECT t.*.
+func selectsStar(sel *nodes.SelectStmt) bool {
+	for _, target := range nodes.LeftmostQueryLeaf(sel).TargetList {
+		expr := target
+		if rt, ok := target.(*nodes.ResTarget); ok {
+			expr = rt.Val
+		}
+		switch t := expr.(type) {
+		case *nodes.StarExpr:
+			return true
+		case *nodes.ColumnRef:
+			if t.Star {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // metadataTriggerStmt builds a trigger from its parts. Sync stores the body
@@ -692,6 +726,10 @@ func parseExpr(expr string) (nodes.ExprNode, error) {
 	target, ok := sel.TargetList[0].(*nodes.ResTarget)
 	if !ok {
 		return nil, fmt.Errorf("expression %q: parsed as %T", expr, sel.TargetList[0])
+	}
+	// The probe's parentheses are not part of the expression.
+	if p, ok := target.Val.(*nodes.ParenExpr); ok {
+		return p.Expr, nil
 	}
 	return target.Val, nil
 }

--- a/mysql/catalog/metadata_load_test.go
+++ b/mysql/catalog/metadata_load_test.go
@@ -473,6 +473,24 @@ func TestLoadMetadataInstallsRoutines(t *testing.T) {
 	}
 }
 
+func TestLoadMetadataStampsOnlyTheLoadedDatabase(t *testing.T) {
+	c := New()
+	if _, err := c.Exec("CREATE DATABASE other; USE other; CREATE FUNCTION add_one(x INT) RETURNS int DETERMINISTIC RETURN x + 1;", nil); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if _, err := c.LoadMetadata(context.Background(), snapshot(&metadata.SchemaMetadata{Functions: []*metadata.FunctionMetadata{
+		{Name: "add_one", Definition: "CREATE FUNCTION `add_one`(x INT) RETURNS int DETERMINISTIC RETURN x + 1", SqlMode: "PIPES_AS_CONCAT"},
+	}})); err != nil {
+		t.Fatalf("LoadMetadata: %v", err)
+	}
+	if fn := snapshotDatabase(t, c).Functions["add_one"]; fn == nil || fn.SQLMode != "PIPES_AS_CONCAT" {
+		t.Errorf("testdb add_one = %+v, want the snapshot's context", fn)
+	}
+	if fn := c.GetDatabase("other").Functions["add_one"]; fn == nil || fn.HasSessionContext {
+		t.Errorf("other add_one = %+v, want its own context untouched", fn)
+	}
+}
+
 func TestLoadMetadataStandsInForFailedObjects(t *testing.T) {
 	c, report := loadMySQLSnapshot(t, snapshot(&metadata.SchemaMetadata{
 		Tables: []*metadata.TableMetadata{

--- a/mysql/catalog/metadata_load_test.go
+++ b/mysql/catalog/metadata_load_test.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"context"
+	"maps"
 	"slices"
 	"strings"
 	"testing"
@@ -160,6 +161,9 @@ func TestLoadMetadataInstallsTable(t *testing.T) {
 			{Name: "email", Type: "varchar(255)", CharacterSet: "latin1"},
 			{Name: "created_at", Type: "timestamp", Default: "CURRENT_TIMESTAMP", OnUpdate: "CURRENT_TIMESTAMP"},
 			{Name: "bio", Type: "text", Nullable: true, Comment: "free form text"},
+			{Name: "status", Type: "varchar(16)", Default: "'active'"},
+			{Name: "score", Type: "int", Default: "0"},
+			{Name: "seed", Type: "double", Default: "(rand())"},
 		},
 		Indexes: []*metadata.IndexMetadata{
 			{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}},
@@ -169,7 +173,7 @@ func TestLoadMetadataInstallsTable(t *testing.T) {
 	requireReport(t, report, nil, nil)
 
 	tbl := requireTable(t, c, "users")
-	if len(tbl.Columns) != 4 || tbl.Engine != "InnoDB" || tbl.Charset != "utf8mb4" || tbl.Comment != "users table" {
+	if len(tbl.Columns) != 7 || tbl.Engine != "InnoDB" || tbl.Charset != "utf8mb4" || tbl.Comment != "users table" {
 		t.Errorf("table = %d columns, engine %q, charset %q, comment %q", len(tbl.Columns), tbl.Engine, tbl.Charset, tbl.Comment)
 	}
 	id := tbl.GetColumn("id")
@@ -188,6 +192,12 @@ func TestLoadMetadataInstallsTable(t *testing.T) {
 	}
 	if bio := tbl.GetColumn("bio"); bio.Comment != "free form text" {
 		t.Errorf("bio comment = %q", bio.Comment)
+	}
+	// A literal default stays a constant; a parenthesized one stays an expression.
+	for name, constant := range map[string]bool{"status": true, "score": true, "seed": false} {
+		if col := tbl.GetColumn(name); (col.DefaultKind == ColumnDefaultConstant) != constant {
+			t.Errorf("%s default kind = %v, want constant %v", name, col.DefaultKind, constant)
+		}
 	}
 	var hasPK, hasUnique bool
 	for _, con := range tbl.Constraints {
@@ -257,6 +267,28 @@ func TestLoadMetadataInstallsIndexKinds(t *testing.T) {
 	}
 	if idx := indexes["idx_hidden"]; idx == nil || idx.Comment != "rarely used" {
 		t.Errorf("idx_hidden = %+v, want its comment", idx)
+	}
+}
+
+func TestLoadMetadataLeavesDefaultIndexTypesUnwritten(t *testing.T) {
+	c, report := loadMySQLSnapshot(t, snapshotWithTables(
+		&metadata.TableMetadata{Name: "disk", Columns: []*metadata.ColumnMetadata{{Name: "a", Type: "int"}}, Indexes: []*metadata.IndexMetadata{
+			{Name: "k", Type: "BTREE", Expressions: []string{"a"}},
+		}},
+		&metadata.TableMetadata{Name: "mem", Engine: "MEMORY", Columns: []*metadata.ColumnMetadata{{Name: "a", Type: "int"}}, Indexes: []*metadata.IndexMetadata{
+			{Name: "k_hash", Type: "HASH", Expressions: []string{"a"}},
+			{Name: "k_btree", Type: "BTREE", Expressions: []string{"a"}},
+		}},
+	))
+	requireReport(t, report, nil, nil)
+	types := make(map[string]string)
+	for _, name := range []string{"disk", "mem"} {
+		for _, idx := range requireTable(t, c, name).Indexes {
+			types[name+"."+idx.Name] = idx.IndexType
+		}
+	}
+	if want := map[string]string{"disk.k": "", "mem.k_hash": "", "mem.k_btree": "BTREE"}; !maps.Equal(types, want) {
+		t.Errorf("index types = %v, want %v", types, want)
 	}
 }
 
@@ -372,14 +404,18 @@ func TestLoadMetadataKeepsViewColumnListsOnlyWhereNeeded(t *testing.T) {
 			// Created as CREATE VIEW renamed (user_id) AS SELECT id FROM users.
 			{Name: "renamed", Definition: "SELECT id FROM users", Columns: []*metadata.ColumnMetadata{{Name: "user_id"}}},
 			{Name: "same", Definition: "SELECT id FROM users", Columns: []*metadata.ColumnMetadata{{Name: "ID"}}},
+			{Name: "star", Definition: "SELECT * FROM users", Columns: []*metadata.ColumnMetadata{{Name: "id"}}},
+			{Name: "star_qualified", Definition: "SELECT u.* FROM users u", Columns: []*metadata.ColumnMetadata{{Name: "id"}}},
 		},
 	}))
 	requireReport(t, report, nil, nil)
 	if v := requireView(t, c, "renamed"); !v.ExplicitColumns || !slices.Equal(v.Columns, []string{"user_id"}) {
 		t.Errorf("renamed = explicit %v, columns %v; want the snapshot's user_id", v.ExplicitColumns, v.Columns)
 	}
-	if v := requireView(t, c, "same"); v.ExplicitColumns {
-		t.Errorf("same = explicit columns %v, want the body's", v.Columns)
+	for _, name := range []string{"same", "star", "star_qualified"} {
+		if v := requireView(t, c, name); v.ExplicitColumns {
+			t.Errorf("%s = explicit columns %v, want the body's", name, v.Columns)
+		}
 	}
 }
 

--- a/mysql/catalog/metadata_load_test.go
+++ b/mysql/catalog/metadata_load_test.go
@@ -126,15 +126,21 @@ func TestLoadMetadataCreatesAndSelectsDatabase(t *testing.T) {
 	if !c.ForeignKeyChecks() || !c.generateGIPK || c.session.ExplicitDefaultsForTimestamp {
 		t.Error("the caller's session settings must be back after the load")
 	}
-	// Loading into an existing database adds to it.
-	if _, err := c.LoadMetadata(context.Background(), snapshotWithTables(&metadata.TableMetadata{
+	// Loading into an existing database adds to it and takes the snapshot's
+	// defaults.
+	meta = snapshotWithTables(&metadata.TableMetadata{
 		Name:    "u",
 		Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}},
-	})); err != nil {
+	})
+	meta.CharacterSet, meta.Collation = "utf8mb4", "utf8mb4_bin"
+	if _, err := c.LoadMetadata(context.Background(), meta); err != nil {
 		t.Fatalf("second LoadMetadata: %v", err)
 	}
 	requireTable(t, c, "t")
 	requireTable(t, c, "u")
+	if db := snapshotDatabase(t, c); db.Charset != "utf8mb4" || db.Collation != "utf8mb4_bin" {
+		t.Errorf("database charset %q, collation %q; want the second snapshot's utf8mb4, utf8mb4_bin", db.Charset, db.Collation)
+	}
 }
 
 func TestLoadMetadataInstallsTable(t *testing.T) {

--- a/mysql/catalog/metadata_load_test.go
+++ b/mysql/catalog/metadata_load_test.go
@@ -100,15 +100,20 @@ func snapshotWithTables(tables ...*metadata.TableMetadata) *metadata.DatabaseSch
 func TestLoadMetadataCreatesAndSelectsDatabase(t *testing.T) {
 	c := New()
 	c.SetForeignKeyChecks(true)
-	report, err := c.LoadMetadata(context.Background(), snapshotWithTables(&metadata.TableMetadata{
+	meta := snapshotWithTables(&metadata.TableMetadata{
 		Name:    "t",
 		Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}},
-	}))
+	})
+	meta.CharacterSet, meta.Collation = "latin1", "latin1_bin"
+	report, err := c.LoadMetadata(context.Background(), meta)
 	if err != nil {
 		t.Fatalf("LoadMetadata: %v", err)
 	}
 	requireReport(t, report, nil, nil)
 	requireTable(t, c, "t")
+	if db := snapshotDatabase(t, c); db.Charset != "latin1" || db.Collation != "latin1_bin" {
+		t.Errorf("database charset %q, collation %q; want the snapshot's latin1, latin1_bin", db.Charset, db.Collation)
+	}
 	if c.CurrentDatabase() != snapshotDB {
 		t.Errorf("current database = %q, want %q", c.CurrentDatabase(), snapshotDB)
 	}
@@ -128,11 +133,12 @@ func TestLoadMetadataCreatesAndSelectsDatabase(t *testing.T) {
 
 func TestLoadMetadataInstallsTable(t *testing.T) {
 	c, report := loadMySQLSnapshot(t, snapshotWithTables(&metadata.TableMetadata{
-		Name:      "users",
-		Engine:    "InnoDB",
-		Charset:   "utf8mb4",
-		Collation: "utf8mb4_0900_ai_ci",
-		Comment:   "users table",
+		Name:          "users",
+		Engine:        "InnoDB",
+		Charset:       "utf8mb4",
+		Collation:     "utf8mb4_0900_ai_ci",
+		Comment:       "users table",
+		CreateOptions: "row_format=COMPRESSED stats_persistent=0",
 		Columns: []*metadata.ColumnMetadata{
 			{Name: "id", Type: "bigint unsigned", Default: autoIncrementDefault},
 			{Name: "email", Type: "varchar(255)", CharacterSet: "latin1"},
@@ -153,6 +159,9 @@ func TestLoadMetadataInstallsTable(t *testing.T) {
 	id := tbl.GetColumn("id")
 	if !id.AutoIncrement || id.Nullable || !strings.EqualFold(id.DataType, "bigint") {
 		t.Errorf("id = auto increment %v, nullable %v, type %q", id.AutoIncrement, id.Nullable, id.DataType)
+	}
+	if tbl.RowFormat != "COMPRESSED" {
+		t.Errorf("row format = %q, want the declared COMPRESSED", tbl.RowFormat)
 	}
 	if email := tbl.GetColumn("email"); email.Charset != "latin1" {
 		t.Errorf("email charset = %q, want the column's latin1", email.Charset)
@@ -194,6 +203,8 @@ func TestLoadMetadataInstallsIndexKinds(t *testing.T) {
 			{Name: "idx_lower_name", Type: "BTREE", Expressions: []string{"lower(`name`)"}},
 			{Name: "idx_mixed", Type: "BTREE", Expressions: []string{"tag", "(lower(`name`))"}},
 			{Name: "idx_prefix", Type: "BTREE", Expressions: []string{"name"}, KeyLength: []int64{10}, Descending: []bool{true}},
+			{Name: "idx_shown", Type: "BTREE", Expressions: []string{"tag"}, Visible: true},
+			{Name: "idx_hidden", Type: "BTREE", Expressions: []string{"tag"}, Comment: "rarely used"},
 		},
 	}))
 	requireReport(t, report, nil, nil)
@@ -221,6 +232,15 @@ func TestLoadMetadataInstallsIndexKinds(t *testing.T) {
 	}
 	if idx := indexes["idx_prefix"]; idx != nil && (len(idx.Columns) != 1 || idx.Columns[0].Length != 10 || !idx.Columns[0].Descending) {
 		t.Errorf("idx_prefix key parts = %+v, want name(10) DESC", idx.Columns)
+	}
+	// The primary key is visible though the snapshot does not say so.
+	for name, visible := range map[string]bool{"PRIMARY": true, "idx_shown": true, "idx_hidden": false} {
+		if idx := indexes[name]; idx == nil || idx.Visible != visible {
+			t.Errorf("%s = %+v, want visible %v", name, idx, visible)
+		}
+	}
+	if idx := indexes["idx_hidden"]; idx == nil || idx.Comment != "rarely used" {
+		t.Errorf("idx_hidden = %+v, want its comment", idx)
 	}
 }
 
@@ -283,6 +303,9 @@ func TestLoadMetadataInstallsColumnValues(t *testing.T) {
 			{Name: "blob_body", Type: "blob", Nullable: true, Default: "NULL"},
 			{Name: "location", Type: "geometry", Nullable: true, Default: "NULL"},
 			{Name: "name", Type: "varchar(255)", Nullable: true, Default: "NULL"},
+			// TEXT and the spatial subtypes take DEFAULT NULL, though no other literal.
+			{Name: "notes", Type: "text", Nullable: true, Default: "NULL"},
+			{Name: "spot", Type: "point", Nullable: true, Default: "NULL"},
 		},
 	}))
 	requireReport(t, report, nil, nil)
@@ -302,14 +325,16 @@ func TestLoadMetadataInstallsColumnValues(t *testing.T) {
 }
 
 func TestLoadMetadataInstallsViewsInAnyOrder(t *testing.T) {
-	// a_view reads z_view, which installs after it.
+	// Each view reads the next, which installs after it, and m_view's columns
+	// come only from analyzing its body.
 	c, report := loadMySQLSnapshot(t, snapshot(&metadata.SchemaMetadata{
 		Tables: []*metadata.TableMetadata{{
 			Name:    "users",
 			Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}, {Name: "name", Type: "varchar(255)", Nullable: true}},
 		}},
 		Views: []*metadata.ViewMetadata{
-			{Name: "a_view", Definition: "SELECT id FROM z_view"},
+			{Name: "a_view", Definition: "SELECT id FROM m_view"},
+			{Name: "m_view", Definition: "SELECT * FROM z_view"},
 			{Name: "z_view", Definition: "SELECT id, name FROM users"},
 		},
 	}))
@@ -318,7 +343,11 @@ func TestLoadMetadataInstallsViewsInAnyOrder(t *testing.T) {
 	if v := requireView(t, c, "z_view"); !strings.Contains(strings.ToUpper(v.Definition), "SELECT") || !slices.Equal(v.Columns, []string{"id", "name"}) {
 		t.Errorf("z_view = definition %q, columns %v; want its body and id, name", v.Definition, v.Columns)
 	}
-	requireView(t, c, "a_view")
+	for _, name := range []string{"a_view", "m_view"} {
+		if v := requireView(t, c, name); v.AnalyzedQuery == nil {
+			t.Errorf("%s was not analyzed once the view it reads installed", name)
+		}
+	}
 }
 
 func TestLoadMetadataInstallsTriggers(t *testing.T) {
@@ -415,12 +444,15 @@ func TestLoadMetadataStandsInForFailedObjects(t *testing.T) {
 				},
 			},
 		},
+		Views: []*metadata.ViewMetadata{
+			{Name: "bad_view", Definition: "SELEC nonsense", Columns: []*metadata.ColumnMetadata{{Name: "x"}}},
+		},
 		Events: []*metadata.EventMetadata{
 			{Name: "e_empty"},
 			{Name: "e_broken", Definition: "this is definitely not a CREATE EVENT statement $$"},
 		},
 	}))
-	requireReport(t, report, []string{"table:broken", "trigger:broken.trg_needs_defaults", "event:e_empty", "event:e_broken"}, nil)
+	requireReport(t, report, []string{"table:broken", "trigger:broken.trg_needs_defaults", "view:bad_view", "event:e_empty", "event:e_broken"}, nil)
 
 	tbl := requireTable(t, c, "broken")
 	if len(tbl.Columns) != 2 {
@@ -434,6 +466,9 @@ func TestLoadMetadataStandsInForFailedObjects(t *testing.T) {
 	requireTrigger(t, c, "ins_stub")
 	if trg := requireTrigger(t, c, "trg_needs_defaults"); trg.Timing == "" || trg.Event == "" || !strings.EqualFold(trg.Table, "broken") {
 		t.Errorf("trigger stand-in = %s %s ON %s", trg.Timing, trg.Event, trg.Table)
+	}
+	if cols := requireView(t, c, "bad_view").Columns; !slices.Equal(cols, []string{"x"}) {
+		t.Errorf("bad_view stand-in columns = %v, want x", cols)
 	}
 	requireEvent(t, c, "e_empty")
 	requireEvent(t, c, "e_broken")
@@ -477,6 +512,10 @@ func TestLoadMetadataStopsWhenContextIsDone(t *testing.T) {
 	}{
 		{name: "before planning", checks: 0, meta: snapshot(&metadata.SchemaMetadata{})},
 		{name: "before an install", checks: 1, meta: snapshotWithTables(&metadata.TableMetadata{Name: "t"})},
+		{name: "before a view reinstall", checks: 3, meta: snapshot(&metadata.SchemaMetadata{Views: []*metadata.ViewMetadata{
+			{Name: "a", Definition: "SELECT id FROM z"},
+			{Name: "z", Definition: "SELECT 1 AS id"},
+		}})},
 	} {
 		if _, err := New().LoadMetadata(&doneAfter{Context: context.Background(), checks: tt.checks}, tt.meta); err != context.Canceled {
 			t.Errorf("%s: err = %v, want context.Canceled", tt.name, err)

--- a/mysql/catalog/metadata_load_test.go
+++ b/mysql/catalog/metadata_load_test.go
@@ -100,9 +100,12 @@ func snapshotWithTables(tables ...*metadata.TableMetadata) *metadata.DatabaseSch
 func TestLoadMetadataCreatesAndSelectsDatabase(t *testing.T) {
 	c := New()
 	c.SetForeignKeyChecks(true)
+	if _, err := c.Exec("SET sql_generate_invisible_primary_key = ON; SET explicit_defaults_for_timestamp = OFF;", nil); err != nil {
+		t.Fatalf("SET: %v", err)
+	}
 	meta := snapshotWithTables(&metadata.TableMetadata{
 		Name:    "t",
-		Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}},
+		Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}, {Name: "ts", Type: "timestamp", Nullable: true}},
 	})
 	meta.CharacterSet, meta.Collation = "latin1", "latin1_bin"
 	report, err := c.LoadMetadata(context.Background(), meta)
@@ -110,15 +113,18 @@ func TestLoadMetadataCreatesAndSelectsDatabase(t *testing.T) {
 		t.Fatalf("LoadMetadata: %v", err)
 	}
 	requireReport(t, report, nil, nil)
-	requireTable(t, c, "t")
+	// Neither a generated primary key nor the legacy TIMESTAMP rules apply.
+	if tbl := requireTable(t, c, "t"); tbl.GetColumn("my_row_id") != nil || !tbl.GetColumn("ts").Nullable {
+		t.Errorf("t = %+v, want id and a nullable ts only", tbl.Columns)
+	}
 	if db := snapshotDatabase(t, c); db.Charset != "latin1" || db.Collation != "latin1_bin" {
 		t.Errorf("database charset %q, collation %q; want the snapshot's latin1, latin1_bin", db.Charset, db.Collation)
 	}
 	if c.CurrentDatabase() != snapshotDB {
 		t.Errorf("current database = %q, want %q", c.CurrentDatabase(), snapshotDB)
 	}
-	if !c.ForeignKeyChecks() {
-		t.Error("foreign key checks must be back on after the load")
+	if !c.ForeignKeyChecks() || !c.generateGIPK || c.session.ExplicitDefaultsForTimestamp {
+		t.Error("the caller's session settings must be back after the load")
 	}
 	// Loading into an existing database adds to it.
 	if _, err := c.LoadMetadata(context.Background(), snapshotWithTables(&metadata.TableMetadata{
@@ -298,14 +304,13 @@ func TestLoadMetadataInstallsColumnValues(t *testing.T) {
 				Type: metadata.GenerationMetadata_TYPE_STORED, Expression: "a + b",
 			}},
 			// Sync reports DEFAULT NULL for every nullable column, including
-			// types that take no DEFAULT clause.
+			// types that show no default.
 			{Name: "payload_json", Type: "json", Nullable: true, Default: "NULL"},
 			{Name: "blob_body", Type: "blob", Nullable: true, Default: "NULL"},
 			{Name: "location", Type: "geometry", Nullable: true, Default: "NULL"},
-			{Name: "name", Type: "varchar(255)", Nullable: true, Default: "NULL"},
-			// TEXT and the spatial subtypes take DEFAULT NULL, though no other literal.
 			{Name: "notes", Type: "text", Nullable: true, Default: "NULL"},
 			{Name: "spot", Type: "point", Nullable: true, Default: "NULL"},
+			{Name: "name", Type: "varchar(255)", Nullable: true, Default: "NULL"},
 		},
 	}))
 	requireReport(t, report, nil, nil)
@@ -314,7 +319,7 @@ func TestLoadMetadataInstallsColumnValues(t *testing.T) {
 	if gen := tbl.GetColumn("c").Generated; gen == nil || !gen.Stored || !strings.Contains(gen.Expr, "a") {
 		t.Errorf("generated column = %+v, want stored a + b", gen)
 	}
-	for _, name := range []string{"payload_json", "blob_body", "location"} {
+	for _, name := range []string{"payload_json", "blob_body", "location", "notes", "spot"} {
 		if col := tbl.GetColumn(name); col.Default != nil {
 			t.Errorf("%s: default = %q, want none", name, *col.Default)
 		}
@@ -347,6 +352,24 @@ func TestLoadMetadataInstallsViewsInAnyOrder(t *testing.T) {
 		if v := requireView(t, c, name); v.AnalyzedQuery == nil {
 			t.Errorf("%s was not analyzed once the view it reads installed", name)
 		}
+	}
+}
+
+func TestLoadMetadataKeepsViewColumnListsOnlyWhereNeeded(t *testing.T) {
+	c, report := loadMySQLSnapshot(t, snapshot(&metadata.SchemaMetadata{
+		Tables: []*metadata.TableMetadata{{Name: "users", Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}}}},
+		Views: []*metadata.ViewMetadata{
+			// Created as CREATE VIEW renamed (user_id) AS SELECT id FROM users.
+			{Name: "renamed", Definition: "SELECT id FROM users", Columns: []*metadata.ColumnMetadata{{Name: "user_id"}}},
+			{Name: "same", Definition: "SELECT id FROM users", Columns: []*metadata.ColumnMetadata{{Name: "ID"}}},
+		},
+	}))
+	requireReport(t, report, nil, nil)
+	if v := requireView(t, c, "renamed"); !v.ExplicitColumns || !slices.Equal(v.Columns, []string{"user_id"}) {
+		t.Errorf("renamed = explicit %v, columns %v; want the snapshot's user_id", v.ExplicitColumns, v.Columns)
+	}
+	if v := requireView(t, c, "same"); v.ExplicitColumns {
+		t.Errorf("same = explicit columns %v, want the body's", v.Columns)
 	}
 }
 

--- a/mysql/catalog/metadata_load_test.go
+++ b/mysql/catalog/metadata_load_test.go
@@ -473,21 +473,28 @@ func TestLoadMetadataInstallsRoutines(t *testing.T) {
 	}
 }
 
-func TestLoadMetadataStampsOnlyTheLoadedDatabase(t *testing.T) {
+func TestLoadMetadataStampsOnlyObjectsItInstalls(t *testing.T) {
 	c := New()
-	if _, err := c.Exec("CREATE DATABASE other; USE other; CREATE FUNCTION add_one(x INT) RETURNS int DETERMINISTIC RETURN x + 1;", nil); err != nil {
+	// Same-named functions in another database, and already in the destination.
+	if _, err := c.Exec("CREATE DATABASE other; USE other; CREATE FUNCTION add_one(x INT) RETURNS int DETERMINISTIC RETURN x + 1; CREATE DATABASE testdb; USE testdb; CREATE FUNCTION dup(x INT) RETURNS int DETERMINISTIC RETURN x;", nil); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
-	if _, err := c.LoadMetadata(context.Background(), snapshot(&metadata.SchemaMetadata{Functions: []*metadata.FunctionMetadata{
+	report, err := c.LoadMetadata(context.Background(), snapshot(&metadata.SchemaMetadata{Functions: []*metadata.FunctionMetadata{
 		{Name: "add_one", Definition: "CREATE FUNCTION `add_one`(x INT) RETURNS int DETERMINISTIC RETURN x + 1", SqlMode: "PIPES_AS_CONCAT"},
-	}})); err != nil {
+		{Name: "dup", Definition: "CREATE FUNCTION `dup`(x INT) RETURNS int DETERMINISTIC RETURN x", SqlMode: "PIPES_AS_CONCAT"},
+	}}))
+	if err != nil {
 		t.Fatalf("LoadMetadata: %v", err)
 	}
-	if fn := snapshotDatabase(t, c).Functions["add_one"]; fn == nil || fn.SQLMode != "PIPES_AS_CONCAT" {
+	requireReport(t, report, nil, []string{"function:dup"})
+	db := snapshotDatabase(t, c)
+	if fn := db.Functions["add_one"]; fn == nil || fn.SQLMode != "PIPES_AS_CONCAT" {
 		t.Errorf("testdb add_one = %+v, want the snapshot's context", fn)
 	}
-	if fn := c.GetDatabase("other").Functions["add_one"]; fn == nil || fn.HasSessionContext {
-		t.Errorf("other add_one = %+v, want its own context untouched", fn)
+	for name, fn := range map[string]*Routine{"other add_one": c.GetDatabase("other").Functions["add_one"], "testdb dup": db.Functions["dup"]} {
+		if fn == nil || fn.HasSessionContext {
+			t.Errorf("%s = %+v, want its own context untouched", name, fn)
+		}
 	}
 }
 

--- a/mysql/catalog/metadata_load_test.go
+++ b/mysql/catalog/metadata_load_test.go
@@ -105,7 +105,7 @@ func TestLoadMetadataCreatesAndSelectsDatabase(t *testing.T) {
 	}
 	meta := snapshotWithTables(&metadata.TableMetadata{
 		Name:    "t",
-		Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}, {Name: "ts", Type: "timestamp", Nullable: true}},
+		Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}, {Name: "at", Type: "timestamp"}, {Name: "ts", Type: "timestamp", Nullable: true}},
 	})
 	meta.CharacterSet, meta.Collation = "latin1", "latin1_bin"
 	report, err := c.LoadMetadata(context.Background(), meta)
@@ -114,8 +114,12 @@ func TestLoadMetadataCreatesAndSelectsDatabase(t *testing.T) {
 	}
 	requireReport(t, report, nil, nil)
 	// Neither a generated primary key nor the legacy TIMESTAMP rules apply.
-	if tbl := requireTable(t, c, "t"); tbl.GetColumn("my_row_id") != nil || !tbl.GetColumn("ts").Nullable {
-		t.Errorf("t = %+v, want id and a nullable ts only", tbl.Columns)
+	tbl := requireTable(t, c, "t")
+	if tbl.GetColumn("my_row_id") != nil || !tbl.GetColumn("ts").Nullable || !tbl.GetColumn("ts").NullExplicit {
+		t.Errorf("t = %+v, want no generated key and an explicitly nullable ts", tbl.Columns)
+	}
+	if at := tbl.GetColumn("at"); at.Default != nil || at.OnUpdate != "" {
+		t.Errorf("at = %+v, want no implicit default", at)
 	}
 	if db := snapshotDatabase(t, c); db.Charset != "latin1" || db.Collation != "latin1_bin" {
 		t.Errorf("database charset %q, collation %q; want the snapshot's latin1, latin1_bin", db.Charset, db.Collation)
@@ -388,7 +392,7 @@ func TestLoadMetadataInstallsTriggers(t *testing.T) {
 		}
 	}
 	c, report := loadMySQLSnapshot(t, snapshotWithTables(account(
-		&metadata.TriggerMetadata{Name: "ins_sum", Timing: "BEFORE", Event: "INSERT", Body: "SET @sum = @sum + NEW.amount"},
+		&metadata.TriggerMetadata{Name: "ins_sum", Timing: "BEFORE", Event: "INSERT", Body: "SET @sum = @sum + NEW.amount", SqlMode: "ANSI_QUOTES"},
 		&metadata.TriggerMetadata{Name: "upd_check", Timing: "BEFORE", Event: "UPDATE", Body: `BEGIN
 			IF NEW.amount < 0 THEN
 				SET NEW.amount = 0;
@@ -417,12 +421,15 @@ func TestLoadMetadataInstallsTriggers(t *testing.T) {
 			t.Errorf("%s = %s %s ON %s, body %q", tt.name, trg.Timing, trg.Event, trg.Table, trg.Body)
 		}
 	}
+	if trg := requireTrigger(t, c, "ins_sum"); !trg.HasSessionContext || trg.SQLMode != "ANSI_QUOTES" {
+		t.Errorf("ins_sum sql_mode = %q (context %v), want the snapshot's ANSI_QUOTES", trg.SQLMode, trg.HasSessionContext)
+	}
 }
 
 func TestLoadMetadataInstallsEvents(t *testing.T) {
 	c, report := loadMySQLSnapshot(t, snapshot(&metadata.SchemaMetadata{Events: []*metadata.EventMetadata{
 		{Name: "myevent", Definition: "CREATE EVENT `myevent` ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 HOUR DO UPDATE mytable SET mycol = mycol + 1"},
-		{Name: "e_hourly", Definition: "CREATE EVENT `e_hourly` ON SCHEDULE EVERY 1 HOUR COMMENT 'Clears out sessions table each hour.' DO DELETE FROM site_activity.sessions"},
+		{Name: "e_hourly", Definition: "CREATE EVENT `e_hourly` ON SCHEDULE EVERY 1 HOUR COMMENT 'Clears out sessions table each hour.' DO DELETE FROM site_activity.sessions", TimeZone: "+08:00"},
 		{Name: "e_daily", Definition: "CREATE EVENT `e_daily` ON SCHEDULE EVERY 1 DAY STARTS CURRENT_TIMESTAMP + INTERVAL 5 HOUR COMMENT 'Saves total then clears each day' " +
 			"DO BEGIN INSERT INTO totals (time, total) SELECT NOW(), COUNT(*) FROM sessions; DELETE FROM sessions; END"},
 	}}))
@@ -436,12 +443,15 @@ func TestLoadMetadataInstallsEvents(t *testing.T) {
 	if ev := requireEvent(t, c, "e_hourly"); !strings.Contains(ev.Comment, "sessions") {
 		t.Errorf("e_hourly comment = %q", ev.Comment)
 	}
+	if ev := requireEvent(t, c, "e_hourly"); !ev.HasSessionContext || ev.TimeZone != "+08:00" {
+		t.Errorf("e_hourly time zone = %q (context %v), want the snapshot's +08:00", ev.TimeZone, ev.HasSessionContext)
+	}
 }
 
 func TestLoadMetadataInstallsRoutines(t *testing.T) {
 	c, report := loadMySQLSnapshot(t, snapshot(&metadata.SchemaMetadata{
 		Functions: []*metadata.FunctionMetadata{
-			{Name: "add_one", Definition: "CREATE FUNCTION `add_one`(x INT) RETURNS int DETERMINISTIC RETURN x + 1"},
+			{Name: "add_one", Definition: "CREATE FUNCTION `add_one`(x INT) RETURNS int DETERMINISTIC RETURN x + 1", SqlMode: "PIPES_AS_CONCAT", CharacterSetClient: "utf8mb4", CollationConnection: "utf8mb4_0900_ai_ci"},
 			{Name: "broken_fn", Definition: "not a function"},
 		},
 		Procedures: []*metadata.ProcedureMetadata{
@@ -453,6 +463,13 @@ func TestLoadMetadataInstallsRoutines(t *testing.T) {
 	db := snapshotDatabase(t, c)
 	if db.Functions[strings.ToLower("add_one")] == nil || db.Procedures[strings.ToLower("touch")] == nil {
 		t.Errorf("functions %v, procedures %v; want add_one and touch", db.Functions, db.Procedures)
+	}
+	// A routine takes the context the snapshot records; one with none stays bare.
+	if fn := db.Functions["add_one"]; fn == nil || !fn.HasSessionContext || fn.SQLMode != "PIPES_AS_CONCAT" || fn.CollationConnection != "utf8mb4_0900_ai_ci" {
+		t.Errorf("add_one = %+v, want the snapshot's session context", fn)
+	}
+	if p := db.Procedures["touch"]; p == nil || p.HasSessionContext {
+		t.Errorf("touch = %+v, want no session context", p)
 	}
 }
 

--- a/mysql/catalog/metadata_load_test.go
+++ b/mysql/catalog/metadata_load_test.go
@@ -1,0 +1,543 @@
+package catalog
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/metadata"
+)
+
+const snapshotDB = "testdb"
+
+func loadMySQLSnapshot(t *testing.T, meta *metadata.DatabaseSchemaMetadata) (*Catalog, *LoadMetadataReport) {
+	t.Helper()
+	c := New()
+	report, err := c.LoadMetadata(context.Background(), meta)
+	if err != nil {
+		t.Fatalf("LoadMetadata: %v", err)
+	}
+	return c, report
+}
+
+// requireReport fails unless exactly the given objects were replaced by
+// stand-ins and exactly the given objects are missing.
+func requireReport(t *testing.T, report *LoadMetadataReport, degraded, missing []string) {
+	t.Helper()
+	keys := func(m map[string]error) []string {
+		var out []string
+		for k := range m {
+			out = append(out, k)
+		}
+		slices.Sort(out)
+		return out
+	}
+	slices.Sort(degraded)
+	slices.Sort(missing)
+	if got := keys(report.Degraded); !slices.Equal(got, degraded) {
+		t.Errorf("degraded = %v, want %v (errors %v)", got, degraded, report.Degraded)
+	}
+	if got := keys(report.Missing); !slices.Equal(got, missing) {
+		t.Errorf("missing = %v, want %v (errors %v)", got, missing, report.Missing)
+	}
+}
+
+func snapshotDatabase(t *testing.T, c *Catalog) *Database {
+	t.Helper()
+	db := c.GetDatabase(snapshotDB)
+	if db == nil {
+		t.Fatalf("database %q not in catalog", snapshotDB)
+	}
+	return db
+}
+
+func requireTable(t *testing.T, c *Catalog, name string) *Table {
+	t.Helper()
+	tbl := snapshotDatabase(t, c).Tables[strings.ToLower(name)]
+	if tbl == nil {
+		t.Fatalf("table %q not in catalog", name)
+	}
+	return tbl
+}
+
+func requireView(t *testing.T, c *Catalog, name string) *View {
+	t.Helper()
+	v := snapshotDatabase(t, c).Views[strings.ToLower(name)]
+	if v == nil {
+		t.Fatalf("view %q not in catalog", name)
+	}
+	return v
+}
+
+func requireTrigger(t *testing.T, c *Catalog, name string) *Trigger {
+	t.Helper()
+	trg := snapshotDatabase(t, c).Triggers[strings.ToLower(name)]
+	if trg == nil {
+		t.Fatalf("trigger %q not in catalog", name)
+	}
+	return trg
+}
+
+func requireEvent(t *testing.T, c *Catalog, name string) *Event {
+	t.Helper()
+	ev := snapshotDatabase(t, c).Events[strings.ToLower(name)]
+	if ev == nil {
+		t.Fatalf("event %q not in catalog", name)
+	}
+	return ev
+}
+
+// snapshot wraps objects in the single unnamed schema MySQL sync produces.
+func snapshot(s *metadata.SchemaMetadata) *metadata.DatabaseSchemaMetadata {
+	return &metadata.DatabaseSchemaMetadata{Name: snapshotDB, Schemas: []*metadata.SchemaMetadata{s}}
+}
+
+func snapshotWithTables(tables ...*metadata.TableMetadata) *metadata.DatabaseSchemaMetadata {
+	return snapshot(&metadata.SchemaMetadata{Tables: tables})
+}
+
+func TestLoadMetadataCreatesAndSelectsDatabase(t *testing.T) {
+	c := New()
+	c.SetForeignKeyChecks(true)
+	report, err := c.LoadMetadata(context.Background(), snapshotWithTables(&metadata.TableMetadata{
+		Name:    "t",
+		Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}},
+	}))
+	if err != nil {
+		t.Fatalf("LoadMetadata: %v", err)
+	}
+	requireReport(t, report, nil, nil)
+	requireTable(t, c, "t")
+	if c.CurrentDatabase() != snapshotDB {
+		t.Errorf("current database = %q, want %q", c.CurrentDatabase(), snapshotDB)
+	}
+	if !c.ForeignKeyChecks() {
+		t.Error("foreign key checks must be back on after the load")
+	}
+	// Loading into an existing database adds to it.
+	if _, err := c.LoadMetadata(context.Background(), snapshotWithTables(&metadata.TableMetadata{
+		Name:    "u",
+		Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}},
+	})); err != nil {
+		t.Fatalf("second LoadMetadata: %v", err)
+	}
+	requireTable(t, c, "t")
+	requireTable(t, c, "u")
+}
+
+func TestLoadMetadataInstallsTable(t *testing.T) {
+	c, report := loadMySQLSnapshot(t, snapshotWithTables(&metadata.TableMetadata{
+		Name:      "users",
+		Engine:    "InnoDB",
+		Charset:   "utf8mb4",
+		Collation: "utf8mb4_0900_ai_ci",
+		Comment:   "users table",
+		Columns: []*metadata.ColumnMetadata{
+			{Name: "id", Type: "bigint unsigned", Default: autoIncrementDefault},
+			{Name: "email", Type: "varchar(255)", CharacterSet: "latin1"},
+			{Name: "created_at", Type: "timestamp", Default: "CURRENT_TIMESTAMP", OnUpdate: "CURRENT_TIMESTAMP"},
+			{Name: "bio", Type: "text", Nullable: true, Comment: "free form text"},
+		},
+		Indexes: []*metadata.IndexMetadata{
+			{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}},
+			{Name: "uniq_email", Type: "BTREE", Unique: true, Expressions: []string{"email"}},
+		},
+	}))
+	requireReport(t, report, nil, nil)
+
+	tbl := requireTable(t, c, "users")
+	if len(tbl.Columns) != 4 || tbl.Engine != "InnoDB" || tbl.Charset != "utf8mb4" || tbl.Comment != "users table" {
+		t.Errorf("table = %d columns, engine %q, charset %q, comment %q", len(tbl.Columns), tbl.Engine, tbl.Charset, tbl.Comment)
+	}
+	id := tbl.GetColumn("id")
+	if !id.AutoIncrement || id.Nullable || !strings.EqualFold(id.DataType, "bigint") {
+		t.Errorf("id = auto increment %v, nullable %v, type %q", id.AutoIncrement, id.Nullable, id.DataType)
+	}
+	if email := tbl.GetColumn("email"); email.Charset != "latin1" {
+		t.Errorf("email charset = %q, want the column's latin1", email.Charset)
+	}
+	// The catalog may print CURRENT_TIMESTAMP as now(), so only presence counts.
+	if created := tbl.GetColumn("created_at"); created.Default == nil || *created.Default == "" || created.OnUpdate == "" {
+		t.Errorf("created_at lost its default or ON UPDATE: %+v", created)
+	}
+	if bio := tbl.GetColumn("bio"); bio.Comment != "free form text" {
+		t.Errorf("bio comment = %q", bio.Comment)
+	}
+	var hasPK, hasUnique bool
+	for _, con := range tbl.Constraints {
+		hasPK = hasPK || con.Type == ConPrimaryKey
+		hasUnique = hasUnique || (con.Type == ConUniqueKey && con.Name == "uniq_email")
+	}
+	if !hasPK || !hasUnique {
+		t.Errorf("primary key %v, uniq_email %v; want both", hasPK, hasUnique)
+	}
+}
+
+func TestLoadMetadataInstallsIndexKinds(t *testing.T) {
+	c, report := loadMySQLSnapshot(t, snapshotWithTables(&metadata.TableMetadata{
+		Name: "t",
+		Columns: []*metadata.ColumnMetadata{
+			{Name: "id", Type: "int", Default: autoIncrementDefault},
+			{Name: "body", Type: "text", Nullable: true},
+			{Name: "location", Type: "geometry"},
+			{Name: "tag", Type: "varchar(64)", Nullable: true},
+			{Name: "name", Type: "varchar(255)", Nullable: true},
+		},
+		Indexes: []*metadata.IndexMetadata{
+			{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}},
+			{Name: "ft_body", Type: "FULLTEXT", Expressions: []string{"body"}},
+			{Name: "sp_location", Type: "SPATIAL", Expressions: []string{"location"}},
+			// Functional key parts, with and without outer parentheses, alone
+			// and next to a plain column.
+			{Name: "idx_abs", Type: "BTREE", Expressions: []string{"(abs(id))"}},
+			{Name: "idx_lower_name", Type: "BTREE", Expressions: []string{"lower(`name`)"}},
+			{Name: "idx_mixed", Type: "BTREE", Expressions: []string{"tag", "(lower(`name`))"}},
+			{Name: "idx_prefix", Type: "BTREE", Expressions: []string{"name"}, KeyLength: []int64{10}, Descending: []bool{true}},
+		},
+	}))
+	requireReport(t, report, nil, nil)
+
+	indexes := make(map[string]*Index)
+	for _, idx := range requireTable(t, c, "t").Indexes {
+		indexes[idx.Name] = idx
+	}
+	for _, name := range []string{"ft_body", "sp_location", "idx_abs", "idx_lower_name", "idx_mixed", "idx_prefix"} {
+		if indexes[name] == nil {
+			t.Errorf("index %s not installed", name)
+		}
+	}
+	if idx := indexes["ft_body"]; idx != nil && !idx.Fulltext {
+		t.Error("ft_body is not FULLTEXT")
+	}
+	if idx := indexes["sp_location"]; idx != nil && !idx.Spatial {
+		t.Error("sp_location is not SPATIAL")
+	}
+	if idx := indexes["idx_mixed"]; idx != nil && len(idx.Columns) != 2 {
+		t.Errorf("idx_mixed has %d key parts, want 2", len(idx.Columns))
+	}
+	if idx := indexes["idx_abs"]; idx != nil && (len(idx.Columns) != 1 || !strings.Contains(strings.ToLower(idx.Columns[0].Expr), "abs(")) {
+		t.Errorf("idx_abs key parts = %+v, want the abs() expression", idx.Columns)
+	}
+	if idx := indexes["idx_prefix"]; idx != nil && (len(idx.Columns) != 1 || idx.Columns[0].Length != 10 || !idx.Columns[0].Descending) {
+		t.Errorf("idx_prefix key parts = %+v, want name(10) DESC", idx.Columns)
+	}
+}
+
+func TestLoadMetadataInstallsForeignKeysInAnyOrder(t *testing.T) {
+	// The child sorts first and references the parent.
+	c, report := loadMySQLSnapshot(t, snapshotWithTables(
+		&metadata.TableMetadata{
+			Name: "a_child",
+			Columns: []*metadata.ColumnMetadata{
+				{Name: "id", Type: "bigint unsigned", Default: autoIncrementDefault},
+				{Name: "parent_id", Type: "bigint unsigned"},
+			},
+			Indexes: []*metadata.IndexMetadata{
+				{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}},
+				{Name: "idx_parent_id", Type: "BTREE", Expressions: []string{"parent_id"}},
+			},
+			ForeignKeys: []*metadata.ForeignKeyMetadata{{
+				Name:              "fk_child_parent",
+				Columns:           []string{"parent_id"},
+				ReferencedTable:   "z_parent",
+				ReferencedColumns: []string{"id"},
+				OnDelete:          "CASCADE",
+				OnUpdate:          "RESTRICT",
+			}},
+		},
+		&metadata.TableMetadata{
+			Name:    "z_parent",
+			Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "bigint unsigned", Default: autoIncrementDefault}},
+			Indexes: []*metadata.IndexMetadata{{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}}},
+		},
+	))
+	requireReport(t, report, nil, nil)
+
+	var fk *Constraint
+	for _, con := range requireTable(t, c, "a_child").Constraints {
+		if con.Type == ConForeignKey && con.Name == "fk_child_parent" {
+			fk = con
+		}
+	}
+	if fk == nil {
+		t.Fatal("fk_child_parent not installed")
+	}
+	if !strings.EqualFold(fk.OnDelete, "CASCADE") || !strings.EqualFold(fk.OnUpdate, "RESTRICT") {
+		t.Errorf("fk actions = ON DELETE %q ON UPDATE %q", fk.OnDelete, fk.OnUpdate)
+	}
+}
+
+func TestLoadMetadataInstallsColumnValues(t *testing.T) {
+	c, report := loadMySQLSnapshot(t, snapshotWithTables(&metadata.TableMetadata{
+		Name: "t",
+		Columns: []*metadata.ColumnMetadata{
+			{Name: "a", Type: "int", Nullable: true},
+			{Name: "b", Type: "int", Nullable: true},
+			{Name: "c", Type: "int", Nullable: true, Generation: &metadata.GenerationMetadata{
+				Type: metadata.GenerationMetadata_TYPE_STORED, Expression: "a + b",
+			}},
+			// Sync reports DEFAULT NULL for every nullable column, including
+			// types that take no DEFAULT clause.
+			{Name: "payload_json", Type: "json", Nullable: true, Default: "NULL"},
+			{Name: "blob_body", Type: "blob", Nullable: true, Default: "NULL"},
+			{Name: "location", Type: "geometry", Nullable: true, Default: "NULL"},
+			{Name: "name", Type: "varchar(255)", Nullable: true, Default: "NULL"},
+		},
+	}))
+	requireReport(t, report, nil, nil)
+
+	tbl := requireTable(t, c, "t")
+	if gen := tbl.GetColumn("c").Generated; gen == nil || !gen.Stored || !strings.Contains(gen.Expr, "a") {
+		t.Errorf("generated column = %+v, want stored a + b", gen)
+	}
+	for _, name := range []string{"payload_json", "blob_body", "location"} {
+		if col := tbl.GetColumn(name); col.Default != nil {
+			t.Errorf("%s: default = %q, want none", name, *col.Default)
+		}
+	}
+	if col := tbl.GetColumn("name"); col.Default == nil {
+		t.Error("name lost its DEFAULT NULL")
+	}
+}
+
+func TestLoadMetadataInstallsViewsInAnyOrder(t *testing.T) {
+	// a_view reads z_view, which installs after it.
+	c, report := loadMySQLSnapshot(t, snapshot(&metadata.SchemaMetadata{
+		Tables: []*metadata.TableMetadata{{
+			Name:    "users",
+			Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}, {Name: "name", Type: "varchar(255)", Nullable: true}},
+		}},
+		Views: []*metadata.ViewMetadata{
+			{Name: "a_view", Definition: "SELECT id FROM z_view"},
+			{Name: "z_view", Definition: "SELECT id, name FROM users"},
+		},
+	}))
+	requireReport(t, report, nil, nil)
+	// The columns come from analyzing the parsed body.
+	if v := requireView(t, c, "z_view"); !strings.Contains(strings.ToUpper(v.Definition), "SELECT") || !slices.Equal(v.Columns, []string{"id", "name"}) {
+		t.Errorf("z_view = definition %q, columns %v; want its body and id, name", v.Definition, v.Columns)
+	}
+	requireView(t, c, "a_view")
+}
+
+func TestLoadMetadataInstallsTriggers(t *testing.T) {
+	account := func(triggers ...*metadata.TriggerMetadata) *metadata.TableMetadata {
+		return &metadata.TableMetadata{
+			Name:     "account",
+			Columns:  []*metadata.ColumnMetadata{{Name: "acct_num", Type: "int", Nullable: true}, {Name: "amount", Type: "decimal(10,2)", Nullable: true}},
+			Triggers: triggers,
+		}
+	}
+	c, report := loadMySQLSnapshot(t, snapshotWithTables(account(
+		&metadata.TriggerMetadata{Name: "ins_sum", Timing: "BEFORE", Event: "INSERT", Body: "SET @sum = @sum + NEW.amount"},
+		&metadata.TriggerMetadata{Name: "upd_check", Timing: "BEFORE", Event: "UPDATE", Body: `BEGIN
+			IF NEW.amount < 0 THEN
+				SET NEW.amount = 0;
+			ELSEIF NEW.amount > 100 THEN
+				SET NEW.amount = 100;
+			END IF;
+		END`},
+		&metadata.TriggerMetadata{Name: "validate_amount", Timing: "AFTER", Event: "UPDATE", Body: `BEGIN
+			IF NEW.amount < 0 THEN
+				SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Negative amount not allowed';
+			END IF;
+		END`},
+		// A body that does not parse is kept as text.
+		&metadata.TriggerMetadata{Name: "bad_body", Timing: "BEFORE", Event: "INSERT", Body: "this is not sql $$$"},
+	)))
+	requireReport(t, report, nil, nil)
+
+	for _, tt := range []struct{ name, timing, event, body string }{
+		{"ins_sum", "BEFORE", "INSERT", "@SUM"},
+		{"upd_check", "BEFORE", "UPDATE", "IF NEW.AMOUNT"},
+		{"validate_amount", "AFTER", "UPDATE", "SIGNAL"},
+		{"bad_body", "BEFORE", "INSERT", "NOT SQL"},
+	} {
+		trg := requireTrigger(t, c, tt.name)
+		if !strings.EqualFold(trg.Timing, tt.timing) || !strings.EqualFold(trg.Event, tt.event) || !strings.EqualFold(trg.Table, "account") || !strings.Contains(strings.ToUpper(trg.Body), tt.body) {
+			t.Errorf("%s = %s %s ON %s, body %q", tt.name, trg.Timing, trg.Event, trg.Table, trg.Body)
+		}
+	}
+}
+
+func TestLoadMetadataInstallsEvents(t *testing.T) {
+	c, report := loadMySQLSnapshot(t, snapshot(&metadata.SchemaMetadata{Events: []*metadata.EventMetadata{
+		{Name: "myevent", Definition: "CREATE EVENT `myevent` ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 HOUR DO UPDATE mytable SET mycol = mycol + 1"},
+		{Name: "e_hourly", Definition: "CREATE EVENT `e_hourly` ON SCHEDULE EVERY 1 HOUR COMMENT 'Clears out sessions table each hour.' DO DELETE FROM site_activity.sessions"},
+		{Name: "e_daily", Definition: "CREATE EVENT `e_daily` ON SCHEDULE EVERY 1 DAY STARTS CURRENT_TIMESTAMP + INTERVAL 5 HOUR COMMENT 'Saves total then clears each day' " +
+			"DO BEGIN INSERT INTO totals (time, total) SELECT NOW(), COUNT(*) FROM sessions; DELETE FROM sessions; END"},
+	}}))
+	requireReport(t, report, nil, nil)
+
+	for name, schedule := range map[string]string{"myevent": "INTERVAL", "e_hourly": "EVERY", "e_daily": "STARTS"} {
+		if ev := requireEvent(t, c, name); !strings.Contains(strings.ToUpper(ev.Schedule), schedule) {
+			t.Errorf("%s schedule = %q, want %s in it", name, ev.Schedule, schedule)
+		}
+	}
+	if ev := requireEvent(t, c, "e_hourly"); !strings.Contains(ev.Comment, "sessions") {
+		t.Errorf("e_hourly comment = %q", ev.Comment)
+	}
+}
+
+func TestLoadMetadataInstallsRoutines(t *testing.T) {
+	c, report := loadMySQLSnapshot(t, snapshot(&metadata.SchemaMetadata{
+		Functions: []*metadata.FunctionMetadata{
+			{Name: "add_one", Definition: "CREATE FUNCTION `add_one`(x INT) RETURNS int DETERMINISTIC RETURN x + 1"},
+			{Name: "broken_fn", Definition: "not a function"},
+		},
+		Procedures: []*metadata.ProcedureMetadata{
+			{Name: "touch", Definition: "CREATE PROCEDURE `touch`() BEGIN SELECT 1; END"},
+		},
+	}))
+	// A function or procedure that fails has no stand-in.
+	requireReport(t, report, nil, []string{"function:broken_fn"})
+	db := snapshotDatabase(t, c)
+	if db.Functions[strings.ToLower("add_one")] == nil || db.Procedures[strings.ToLower("touch")] == nil {
+		t.Errorf("functions %v, procedures %v; want add_one and touch", db.Functions, db.Procedures)
+	}
+}
+
+func TestLoadMetadataStandsInForFailedObjects(t *testing.T) {
+	c, report := loadMySQLSnapshot(t, snapshot(&metadata.SchemaMetadata{
+		Tables: []*metadata.TableMetadata{
+			{
+				Name: "broken",
+				Columns: []*metadata.ColumnMetadata{
+					{Name: "id", Type: "int"},
+					{Name: "bad", Type: "varchar((("},
+				},
+				Triggers: []*metadata.TriggerMetadata{
+					// Attaches to the stand-in.
+					{Name: "ins_stub", Timing: "BEFORE", Event: "INSERT", Body: "SET @x = NEW.id"},
+					// No timing or event: the stand-in takes defaults.
+					{Name: "trg_needs_defaults"},
+				},
+			},
+		},
+		Events: []*metadata.EventMetadata{
+			{Name: "e_empty"},
+			{Name: "e_broken", Definition: "this is definitely not a CREATE EVENT statement $$"},
+		},
+	}))
+	requireReport(t, report, []string{"table:broken", "trigger:broken.trg_needs_defaults", "event:e_empty", "event:e_broken"}, nil)
+
+	tbl := requireTable(t, c, "broken")
+	if len(tbl.Columns) != 2 {
+		t.Fatalf("stand-in has %d columns, want 2", len(tbl.Columns))
+	}
+	for _, col := range tbl.Columns {
+		if !strings.EqualFold(col.DataType, "text") {
+			t.Errorf("stand-in column %s is %s, want text", col.Name, col.DataType)
+		}
+	}
+	requireTrigger(t, c, "ins_stub")
+	if trg := requireTrigger(t, c, "trg_needs_defaults"); trg.Timing == "" || trg.Event == "" || !strings.EqualFold(trg.Table, "broken") {
+		t.Errorf("trigger stand-in = %s %s ON %s", trg.Timing, trg.Event, trg.Table)
+	}
+	requireEvent(t, c, "e_empty")
+	requireEvent(t, c, "e_broken")
+}
+
+func TestStandInStatements(t *testing.T) {
+	c := New()
+	c.LoadMetadata(context.Background(), snapshot(&metadata.SchemaMetadata{})) //nolint:errcheck // creates the database
+	for _, stmt := range []struct {
+		name string
+		err  error
+	}{
+		{"pt", c.DefineTable(standInTableStmt(&metadata.TableMetadata{Name: "pt", Columns: []*metadata.ColumnMetadata{{Name: "a"}, {Name: "b"}, {Name: "a"}}}))},
+		{"empty", c.DefineTable(standInTableStmt(&metadata.TableMetadata{Name: "empty"}))},
+		{"pv", c.DefineView(standInViewStmt(&metadata.ViewMetadata{Name: "pv", Columns: []*metadata.ColumnMetadata{{Name: "x"}, {Name: "y"}}}))},
+		{"dv", c.DefineView(standInViewStmt(&metadata.ViewMetadata{Name: "dv", DependencyColumns: []*metadata.DependencyColumn{{Column: "id"}}}))},
+	} {
+		if stmt.err != nil {
+			t.Fatalf("%s: %v", stmt.name, stmt.err)
+		}
+	}
+	if cols := requireTable(t, c, "pt").Columns; len(cols) != 2 || !strings.EqualFold(cols[0].DataType, "text") {
+		t.Errorf("pt stand-in columns = %+v, want a and b as text", cols)
+	}
+	if cols := requireTable(t, c, "empty").Columns; len(cols) != 1 || cols[0].Name != standInPlaceholder {
+		t.Errorf("empty stand-in columns = %+v, want the placeholder", cols)
+	}
+	if cols := requireView(t, c, "pv").Columns; len(cols) != 2 {
+		t.Errorf("pv stand-in has %d columns, want 2", len(cols))
+	}
+	if cols := requireView(t, c, "dv").Columns; len(cols) != 1 || cols[0] != "id" {
+		t.Errorf("dv stand-in columns = %v, want the column it reads", cols)
+	}
+}
+
+func TestLoadMetadataStopsWhenContextIsDone(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		checks int
+		meta   *metadata.DatabaseSchemaMetadata
+	}{
+		{name: "before planning", checks: 0, meta: snapshot(&metadata.SchemaMetadata{})},
+		{name: "before an install", checks: 1, meta: snapshotWithTables(&metadata.TableMetadata{Name: "t"})},
+	} {
+		if _, err := New().LoadMetadata(&doneAfter{Context: context.Background(), checks: tt.checks}, tt.meta); err != context.Canceled {
+			t.Errorf("%s: err = %v, want context.Canceled", tt.name, err)
+		}
+	}
+}
+
+// doneAfter is a context that is done once Err has been called checks times.
+type doneAfter struct {
+	context.Context
+	checks int
+}
+
+func (c *doneAfter) Err() error {
+	if c.checks == 0 {
+		return context.Canceled
+	}
+	c.checks--
+	return nil
+}
+
+func TestParseTypeName(t *testing.T) {
+	for typ, want := range map[string]string{
+		"int":                          "INT",
+		"int unsigned":                 "INT",
+		"bigint(20) unsigned zerofill": "BIGINT",
+		"varchar(255)":                 "VARCHAR",
+		"char(1)":                      "CHAR",
+		"text":                         "TEXT",
+		"decimal(10,2)":                "DECIMAL",
+		"datetime(6)":                  "DATETIME",
+		"timestamp":                    "TIMESTAMP",
+		"tinyint(1)":                   "TINYINT",
+		"blob":                         "BLOB",
+		"json":                         "JSON",
+		"enum('a','b','c')":            "ENUM",
+		"set('x','y')":                 "SET",
+		"geometry":                     "GEOMETRY",
+		"bit(1)":                       "BIT",
+	} {
+		dt, err := parseTypeName(typ)
+		if err != nil || !strings.EqualFold(dt.Name, want) {
+			t.Errorf("parseTypeName(%q) = %v, %v; want %s", typ, dt, err, want)
+		}
+	}
+	for _, typ := range []string{"", "not a real type (((", "int UNSIGNED ZEROFILL NOT_A_THING"} {
+		if _, err := parseTypeName(typ); err == nil {
+			t.Errorf("parseTypeName(%q) succeeded, want an error", typ)
+		}
+	}
+}
+
+func TestParseExpr(t *testing.T) {
+	for _, expr := range []string{`'hello'`, `CURRENT_TIMESTAMP`, `NULL`, `0`, `a + b`, `CONCAT('x', 'y')`, `DATE_FORMAT(NOW(), '%Y-%m-%d')`} {
+		if _, err := parseExpr(expr); err != nil {
+			t.Errorf("parseExpr(%q): %v", expr, err)
+		}
+	}
+	for _, expr := range []string{"", "(((", "this is not sql at all ###"} {
+		if _, err := parseExpr(expr); err == nil {
+			t.Errorf("parseExpr(%q) succeeded, want an error", expr)
+		}
+	}
+}

--- a/mysql/catalog/session_context.go
+++ b/mysql/catalog/session_context.go
@@ -92,30 +92,36 @@ func (c *Catalog) ApplySessionContext(m SessionContextMap) {
 		return
 	}
 	for _, db := range c.Databases() {
-		applyRoutineContext(db.Functions, m.Functions)
-		applyRoutineContext(db.Procedures, m.Procedures)
-		for key, tr := range db.Triggers {
-			if tr == nil {
-				continue
-			}
-			if ctx, ok := lookupContext(m.Triggers, key, tr.Name); ok {
-				tr.SQLMode = ctx.SQLMode
-				tr.CharacterSetClient = ctx.CharacterSetClient
-				tr.CollationConnection = ctx.CollationConnection
-				tr.HasSessionContext = true
-			}
+		applyDatabaseSessionContext(db, m)
+	}
+}
+
+// applyDatabaseSessionContext stamps the routines, triggers, and events of one
+// database with their entries in m.
+func applyDatabaseSessionContext(db *Database, m SessionContextMap) {
+	applyRoutineContext(db.Functions, m.Functions)
+	applyRoutineContext(db.Procedures, m.Procedures)
+	for key, tr := range db.Triggers {
+		if tr == nil {
+			continue
 		}
-		for key, e := range db.Events {
-			if e == nil {
-				continue
-			}
-			if ctx, ok := lookupContext(m.Events, key, e.Name); ok {
-				e.SQLMode = ctx.SQLMode
-				e.CharacterSetClient = ctx.CharacterSetClient
-				e.CollationConnection = ctx.CollationConnection
-				e.TimeZone = ctx.TimeZone
-				e.HasSessionContext = true
-			}
+		if ctx, ok := lookupContext(m.Triggers, key, tr.Name); ok {
+			tr.SQLMode = ctx.SQLMode
+			tr.CharacterSetClient = ctx.CharacterSetClient
+			tr.CollationConnection = ctx.CollationConnection
+			tr.HasSessionContext = true
+		}
+	}
+	for key, e := range db.Events {
+		if e == nil {
+			continue
+		}
+		if ctx, ok := lookupContext(m.Events, key, e.Name); ok {
+			e.SQLMode = ctx.SQLMode
+			e.CharacterSetClient = ctx.CharacterSetClient
+			e.CollationConnection = ctx.CollationConnection
+			e.TimeZone = ctx.TimeZone
+			e.HasSessionContext = true
 		}
 	}
 }


### PR DESCRIPTION
Adds `(*Catalog).LoadMetadata`, which installs a `metadata.DatabaseSchemaMetadata` into the MySQL catalog. This is the MySQL counterpart of #414. Bytebase's SQL review walk-through for MySQL, MariaDB, and OceanBase currently loads its catalog with its own loader, and switches to this one.

## Behavior

- Installs into the database `meta.Name`, creating it if needed, gives it the snapshot's character set and collation, and leaves it selected.
- For the length of the load:
  - foreign key checks are off, so a table may reference one that installs after it;
  - generated invisible primary keys are off, and `explicit_defaults_for_timestamp` is on, so each table installs as the snapshot records it.

  The caller's settings are restored afterward.
- Objects install by kind, then name: tables, views, functions, procedures, triggers, events. Only a trigger needs another object installed first, namely its table. A view may name a view that installs after it. Once everything is in, each view whose body did not analyze is reinstalled, and the passes repeat while a pass analyzes more of them.
- A stored definition drops the column list of `CREATE VIEW v (a, b)`. So once the body resolves, the snapshot names the columns it left unnamed, and becomes a column list where the body names as many by other names.
- A nullable TIMESTAMP installs with an explicit NULL, as SHOW CREATE TABLE prints it, so it stays nullable when `explicit_defaults_for_timestamp` is OFF.
- After the load, each routine, trigger, and event the load installs takes the session context the snapshot records for it: `sql_mode`, the character set and collation, and for an event its time zone. This is what `ApplySessionContext` stamps, so a migration recreates the object under the same settings. An object whose snapshot records no context stays bare.
- An object that fails to install does not stop the load:
  - a table is replaced by a stand-in with the same column names, all `TEXT`;
  - a view, including one whose definition does not parse, by one that selects `NULL` under its column names;
  - a trigger by one with an empty body;
  - an event by one with only its name.

  A function or procedure that fails is left out.
- `LoadMetadataReport` lists the objects replaced by a stand-in (`Degraded`) and the ones left out (`Missing`), each with its error.

## Changes from the Bytebase loader

- The Bytebase loader carried Tarjan and Kahn ordering but had no edges to order by. A sort by kind and name replaces it, together with the view reanalysis above.
- It dropped failures silently; the report now records them.
- This loader also installs:
  - the database's character set and collation;
  - the declared row format from `CreateOptions`;
  - index visibility and comments. A primary key stays visible.
  - an explicit NULL on nullable TIMESTAMP columns;
  - each routine's, trigger's, and event's session context.
- It leaves `DEFAULT NULL` off every type MySQL shows no default for: BLOB, TEXT, JSON, and the spatial types. The Bytebase loader covered only BLOB, JSON, and GEOMETRY.
- It sets a view's column list only where the resolved body names the columns differently; the Bytebase loader always set it.
- It leaves an index's access method unwritten where it is the engine's default, as for a key declared without `USING`, and loads a literal default as a constant rather than an expression.
- Otherwise the behavior matches:
  - the `AUTO_INCREMENT` default sentinel;
  - functional, prefix, and descending key parts, and FULLTEXT and SPATIAL indexes;
  - SRID and INVISIBLE columns;
  - parsed view bodies, and trigger bodies stored without their header.

## Testing

- `go test -short ./mysql/...`
- 17 tests. They port the Bytebase loader's coverage, and add:
  - the report;
  - the database setup and the session settings;
  - view column lists;
  - session context, stamped only on objects the load installs;
  - cancellation.
- Mutation-checked: removing any of these makes a test fail:
  - database setup:
    - giving the database its character set and collation, whether it is new or already exists;
    - the three session settings, and restoring them;
    - the context checks;
  - failed objects:
    - each stand-in;
    - the view parse check;
    - the trigger timing and event check;
  - views:
    - parsed view bodies;
    - reanalyzing views until a pass makes no progress;
    - naming the columns the body left unnamed, and setting a column list only where the resolved names differ;
  - columns:
    - leaving `DEFAULT NULL` off the types MySQL shows no default for, and `AUTO_INCREMENT`;
    - the column character set, `ON UPDATE`, and generated columns;
    - the explicit NULL on nullable TIMESTAMP columns;
    - loading a literal default as a constant;
  - indexes:
    - functional, prefix, and descending key parts;
    - FULLTEXT and SPATIAL;
    - index visibility and comments;
    - leaving the engine's default access method unwritten;
  - session context: stamping each routine, trigger, and event with the snapshot's, only on objects the load installs, and leaving an object without one bare;
  - table options, including the row format;
  - foreign keys and routines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
