### PR TITLE
catalog: load Bytebase metadata snapshots for TiDB, Trino, MongoDB, and PartiQL

### DIFF
--- a/mongo/catalog/metadata_load.go
+++ b/mongo/catalog/metadata_load.go
@@ -1,0 +1,15 @@
+package catalog
+
+import "github.com/bytebase/omni/metadata"
+
+// LoadMetadata adds the collections of a Bytebase schema snapshot to c. Sync
+// reports each collection as a table.
+func (c *Catalog) LoadMetadata(meta *metadata.DatabaseSchemaMetadata) {
+	for _, s := range meta.GetSchemas() {
+		for _, t := range s.GetTables() {
+			if t.GetName() != "" {
+				c.AddCollection(t.GetName())
+			}
+		}
+	}
+}

--- a/mongo/catalog/metadata_load_test.go
+++ b/mongo/catalog/metadata_load_test.go
@@ -1,0 +1,21 @@
+package catalog
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/bytebase/omni/metadata"
+)
+
+func TestLoadMetadata(t *testing.T) {
+	c := New()
+	c.LoadMetadata(&metadata.DatabaseSchemaMetadata{
+		Name: "app",
+		Schemas: []*metadata.SchemaMetadata{{
+			Tables: []*metadata.TableMetadata{{Name: "users"}, {Name: "orders"}, {Name: ""}},
+		}},
+	})
+	if got, want := c.Collections(), []string{"orders", "users"}; !slices.Equal(got, want) {
+		t.Errorf("collections = %v, want %v", got, want)
+	}
+}

--- a/partiql/catalog/metadata_load.go
+++ b/partiql/catalog/metadata_load.go
@@ -6,7 +6,9 @@ import "github.com/bytebase/omni/metadata"
 func (c *Catalog) LoadMetadata(meta *metadata.DatabaseSchemaMetadata) {
 	for _, s := range meta.GetSchemas() {
 		for _, t := range s.GetTables() {
-			c.AddTable(t.GetName())
+			if t.GetName() != "" {
+				c.AddTable(t.GetName())
+			}
 		}
 	}
 }

--- a/partiql/catalog/metadata_load.go
+++ b/partiql/catalog/metadata_load.go
@@ -1,0 +1,12 @@
+package catalog
+
+import "github.com/bytebase/omni/metadata"
+
+// LoadMetadata adds the tables of a Bytebase schema snapshot to c.
+func (c *Catalog) LoadMetadata(meta *metadata.DatabaseSchemaMetadata) {
+	for _, s := range meta.GetSchemas() {
+		for _, t := range s.GetTables() {
+			c.AddTable(t.GetName())
+		}
+	}
+}

--- a/partiql/catalog/metadata_load_test.go
+++ b/partiql/catalog/metadata_load_test.go
@@ -11,7 +11,7 @@ func TestLoadMetadata(t *testing.T) {
 	c.LoadMetadata(&metadata.DatabaseSchemaMetadata{
 		Name: "dynamo",
 		Schemas: []*metadata.SchemaMetadata{{
-			Tables: []*metadata.TableMetadata{{Name: "Orders"}, {Name: "users"}},
+			Tables: []*metadata.TableMetadata{{Name: "Orders"}, {Name: "users"}, {Name: ""}},
 		}},
 	})
 	for _, name := range []string{"Orders", "users"} {

--- a/partiql/catalog/metadata_load_test.go
+++ b/partiql/catalog/metadata_load_test.go
@@ -1,0 +1,25 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/metadata"
+)
+
+func TestLoadMetadata(t *testing.T) {
+	c := New()
+	c.LoadMetadata(&metadata.DatabaseSchemaMetadata{
+		Name: "dynamo",
+		Schemas: []*metadata.SchemaMetadata{{
+			Tables: []*metadata.TableMetadata{{Name: "Orders"}, {Name: "users"}},
+		}},
+	})
+	for _, name := range []string{"Orders", "users"} {
+		if !c.HasTable(name) {
+			t.Errorf("table %s not loaded; tables %v", name, c.Tables())
+		}
+	}
+	if got := len(c.Tables()); got != 2 {
+		t.Errorf("loaded %d tables, want 2: %v", got, c.Tables())
+	}
+}

--- a/tidb/catalog/metadata_load.go
+++ b/tidb/catalog/metadata_load.go
@@ -267,7 +267,7 @@ func metadataColumnDef(col *metadata.ColumnMetadata) (*nodes.ColumnDef, error) {
 	autoIncrement := strings.EqualFold(col.GetDefault(), autoIncrementDefault)
 	def.AutoIncrement = autoIncrement
 	// Sync reports DEFAULT NULL for every nullable column, including types that
-	// take no DEFAULT clause, which would fail the whole table.
+	// show no default.
 	if !autoIncrement && col.GetDefault() != "" && col.GetGeneration() == nil &&
 		(!strings.EqualFold(col.GetDefault(), "NULL") || typeTakesDefault(col.GetType())) {
 		if expr, err := parseExpr(col.GetDefault()); err == nil {
@@ -287,15 +287,15 @@ func metadataColumnDef(col *metadata.ColumnMetadata) (*nodes.ColumnDef, error) {
 	return def, nil
 }
 
-// typeTakesDefault reports whether a column type accepts a literal DEFAULT
-// clause, which the BLOB types and JSON do not.
+// typeTakesDefault reports whether a column type shows a DEFAULT NULL clause,
+// which the BLOB, TEXT, and JSON types never do.
 func typeTakesDefault(typ string) bool {
 	head := strings.ToLower(strings.TrimSpace(typ))
 	if i := strings.IndexAny(head, " ("); i >= 0 {
 		head = head[:i]
 	}
 	switch head {
-	case "blob", "tinyblob", "mediumblob", "longblob", "json":
+	case "blob", "tinyblob", "mediumblob", "longblob", "text", "tinytext", "mediumtext", "longtext", "json":
 		return false
 	default:
 		return true
@@ -404,10 +404,16 @@ func metadataViewStmt(v *metadata.ViewMetadata) (*nodes.CreateViewStmt, error) {
 		return nil, err
 	}
 	stmt := &nodes.CreateViewStmt{OrReplace: true, Name: &nodes.TableRef{Name: v.GetName()}, Select: sel, SelectText: v.GetDefinition()}
+	// A stored definition drops the column list of CREATE VIEW v (a, b), so the
+	// snapshot's columns become one only where they differ from the body's.
+	var names []string
 	for _, col := range v.GetColumns() {
 		if col.GetName() != "" {
-			stmt.Columns = append(stmt.Columns, col.GetName())
+			names = append(names, col.GetName())
 		}
+	}
+	if len(names) > 0 && !slices.EqualFunc(names, extractViewColumns(sel), strings.EqualFold) {
+		stmt.Columns = names
 	}
 	return stmt, nil
 }

--- a/tidb/catalog/metadata_load.go
+++ b/tidb/catalog/metadata_load.go
@@ -434,7 +434,12 @@ func metadataViewStmt(v *metadata.ViewMetadata) (*nodes.CreateViewStmt, error) {
 			names = append(names, col.GetName())
 		}
 	}
-	if len(names) > 0 && !slices.EqualFunc(names, extractViewColumns(sel), strings.EqualFold) {
+	// A * or an unaliased expression is named only once the catalog resolves the
+	// body, and extractViewColumns leaves such a target out, so the body names
+	// nothing to compare unless it names every one of them.
+	derived := extractViewColumns(sel)
+	if len(names) > 0 && len(derived) == len(nodes.LeftmostQueryLeaf(sel).TargetList) &&
+		!slices.EqualFunc(names, derived, strings.EqualFold) {
 		stmt.Columns = names
 	}
 	return stmt, nil

--- a/tidb/catalog/metadata_load.go
+++ b/tidb/catalog/metadata_load.go
@@ -43,8 +43,15 @@ func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchem
 		return report, err
 	}
 	if name := meta.GetName(); name != "" {
+		// A database already in the catalog keeps its own character set and
+		// collation otherwise, and a table that overrides neither would resolve
+		// its columns differently than the same snapshot loaded into an empty
+		// catalog.
+		stmt := metadataDatabaseStmt(meta)
 		if c.GetDatabase(name) == nil {
-			_ = c.DefineDatabase(metadataDatabaseStmt(meta))
+			_ = c.DefineDatabase(stmt)
+		} else if len(stmt.Options) > 0 {
+			_ = c.alterDatabase(&nodes.AlterDatabaseStmt{Name: name, Options: stmt.Options})
 		}
 		c.SetCurrentDatabase(name)
 	}

--- a/tidb/catalog/metadata_load.go
+++ b/tidb/catalog/metadata_load.go
@@ -436,25 +436,14 @@ func referenceAction(action string) nodes.ReferenceAction {
 
 // metadataViewStmt keeps the view's text as it is along with its parsed body.
 // DefineView installs a view whose body does not analyze, so a view may name
-// one that installs after it; reanalyzeViews retries it then.
+// one that installs after it; reanalyzeViews retries it then. nameViewColumns
+// names the columns once the body resolves.
 func metadataViewStmt(v *metadata.ViewMetadata) (*nodes.CreateViewStmt, error) {
 	sel, err := parseFirstStatement[*nodes.SelectStmt](v.GetDefinition())
 	if err != nil {
 		return nil, err
 	}
-	stmt := &nodes.CreateViewStmt{OrReplace: true, Name: &nodes.TableRef{Name: v.GetName()}, Select: sel, SelectText: v.GetDefinition()}
-	// A stored definition drops the column list of CREATE VIEW v (a, b), so the
-	// snapshot's columns become one only where they differ from the body's.
-	names := metadataViewColumnNames(v)
-	// A * or an unaliased expression is named only once the catalog resolves the
-	// body, and extractViewColumns leaves such a target out, so the body names
-	// nothing to compare unless it names every one of them.
-	derived := extractViewColumns(sel)
-	if len(names) > 0 && len(derived) == len(nodes.LeftmostQueryLeaf(sel).TargetList) &&
-		!slices.EqualFunc(names, derived, strings.EqualFold) {
-		stmt.Columns = names
-	}
-	return stmt, nil
+	return &nodes.CreateViewStmt{OrReplace: true, Name: &nodes.TableRef{Name: v.GetName()}, Select: sel, SelectText: v.GetDefinition()}, nil
 }
 
 // metadataViewColumnNames lists the column names the snapshot records for a
@@ -469,10 +458,21 @@ func metadataViewColumnNames(v *metadata.ViewMetadata) []string {
 	return names
 }
 
-// nameViewColumns names the columns a view's body left unnamed.
+// nameViewColumns names a view's columns from the snapshot: the ones its
+// resolved body left unnamed, and, where the body names as many by other names,
+// the snapshot's as a column list. A stored definition drops the column list of
+// CREATE VIEW v (a, b), and only a view created with one has names its body
+// does not give.
 func nameViewColumns(v *View, names []string) {
-	if v != nil && len(v.Columns) < len(names) {
+	if v == nil || len(names) == 0 {
+		return
+	}
+	if len(v.Columns) < len(names) {
 		v.Columns = names
+		return
+	}
+	if len(v.Columns) == len(names) && !slices.EqualFunc(v.Columns, names, strings.EqualFold) {
+		v.Columns, v.ExplicitColumns = names, true
 	}
 }
 

--- a/tidb/catalog/metadata_load.go
+++ b/tidb/catalog/metadata_load.go
@@ -27,7 +27,8 @@ type LoadMetadataReport struct {
 // LoadMetadata installs a Bytebase schema snapshot of a TiDB database into the
 // database meta.Name, creating it if needed, and leaves that database
 // selected. Foreign key checks are off during the load, so a table may
-// reference one that installs after it.
+// reference one that installs after it. A view may likewise name a view that
+// installs after it.
 //
 // An object that fails to install does not stop the load: a table is replaced
 // by a stand-in with the same column names, all TEXT, and a view by one that
@@ -43,8 +44,7 @@ func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchem
 	}
 	if name := meta.GetName(); name != "" {
 		if c.GetDatabase(name) == nil {
-			// A database without options always installs.
-			_ = c.DefineDatabase(&nodes.CreateDatabaseStmt{Name: name})
+			_ = c.DefineDatabase(metadataDatabaseStmt(meta))
 		}
 		c.SetCurrentDatabase(name)
 	}
@@ -52,12 +52,16 @@ func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchem
 	c.SetForeignKeyChecks(false)
 	defer c.SetForeignKeyChecks(fkChecks)
 
+	var views []*metadataObject
 	for _, o := range collectMetadataObjects(meta) {
 		if err := ctx.Err(); err != nil {
 			return report, err
 		}
 		err := c.installMetadataObject(o)
 		if err == nil {
+			if o.kind == metadataView {
+				views = append(views, o)
+			}
 			continue
 		}
 		if standInErr := c.installStandIn(o); standInErr != nil {
@@ -66,7 +70,37 @@ func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchem
 		}
 		report.Degraded[o.key()] = err
 	}
-	return report, nil
+	return report, c.reanalyzeViews(ctx, views)
+}
+
+// reanalyzeViews reinstalls each view whose body did not analyze while a pass
+// analyzes more of them: a body analyzes only once the views it names are
+// installed, and those may install after it.
+func (c *Catalog) reanalyzeViews(ctx context.Context, views []*metadataObject) error {
+	for progress := true; progress; {
+		progress = false
+		for _, o := range views {
+			if c.viewAnalyzed(o.name) {
+				continue
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if c.installMetadataObject(o) == nil && c.viewAnalyzed(o.name) {
+				progress = true
+			}
+		}
+	}
+	return nil
+}
+
+func (c *Catalog) viewAnalyzed(name string) bool {
+	db := c.GetDatabase(c.CurrentDatabase())
+	if db == nil {
+		return false
+	}
+	v := db.Views[toLower(name)]
+	return v != nil && v.AnalyzedQuery != nil
 }
 
 // --- Objects ---
@@ -126,7 +160,11 @@ func collectMetadataObjects(meta *metadata.DatabaseSchemaMetadata) []*metadataOb
 
 func (c *Catalog) installMetadataObject(o *metadataObject) error {
 	if o.kind == metadataView {
-		return c.DefineView(metadataViewStmt(o.view))
+		stmt, err := metadataViewStmt(o.view)
+		if err != nil {
+			return err
+		}
+		return c.DefineView(stmt)
 	}
 	stmt, err := metadataTableStmt(o.table)
 	if err != nil {
@@ -145,6 +183,19 @@ func (c *Catalog) installMetadataObject(o *metadataObject) error {
 // AUTO_INCREMENT column.
 const autoIncrementDefault = "AUTO_INCREMENT"
 
+func metadataDatabaseStmt(meta *metadata.DatabaseSchemaMetadata) *nodes.CreateDatabaseStmt {
+	stmt := &nodes.CreateDatabaseStmt{Name: meta.GetName()}
+	for _, opt := range []*nodes.DatabaseOption{
+		{Name: "CHARACTER SET", Value: meta.GetCharacterSet()},
+		{Name: "COLLATE", Value: meta.GetCollation()},
+	} {
+		if opt.Value != "" {
+			stmt.Options = append(stmt.Options, opt)
+		}
+	}
+	return stmt
+}
+
 // metadataTableStmt fails on a column whose type does not parse, so the table
 // gets a stand-in rather than a partial definition. A default, ON UPDATE,
 // generation, or CHECK expression that does not parse is dropped instead.
@@ -162,9 +213,16 @@ func metadataTableStmt(t *metadata.TableMetadata) (*nodes.CreateTableStmt, error
 		stmt.Columns = append(stmt.Columns, def)
 	}
 	for _, idx := range t.GetIndexes() {
-		if len(idx.GetExpressions()) > 0 {
-			stmt.Constraints = append(stmt.Constraints, metadataIndexConstraint(idx))
+		if len(idx.GetExpressions()) == 0 {
+			continue
 		}
+		con := metadataIndexConstraint(idx)
+		// Sync reports TIDB_PK_TYPE, CLUSTERED or NONCLUSTERED.
+		if idx.GetPrimary() && t.GetPrimaryKeyType() != "" {
+			clustered := strings.EqualFold(t.GetPrimaryKeyType(), "CLUSTERED")
+			con.Clustered = &clustered
+		}
+		stmt.Constraints = append(stmt.Constraints, con)
 	}
 	for _, fk := range t.GetForeignKeys() {
 		stmt.Constraints = append(stmt.Constraints, metadataForeignKey(fk))
@@ -291,6 +349,13 @@ func metadataIndexConstraint(idx *metadata.IndexMetadata) *nodes.Constraint {
 		}
 		c.IndexColumns = append(c.IndexColumns, key)
 	}
+	// A primary key is always visible.
+	if !idx.GetVisible() && !idx.GetPrimary() {
+		c.IndexOptions = append(c.IndexOptions, &nodes.IndexOption{Name: "INVISIBLE"})
+	}
+	if idx.GetComment() != "" {
+		c.IndexOptions = append(c.IndexOptions, &nodes.IndexOption{Name: "COMMENT", Value: &nodes.StringLit{Value: idx.GetComment()}})
+	}
 	return c
 }
 
@@ -330,20 +395,21 @@ func referenceAction(action string) nodes.ReferenceAction {
 	}
 }
 
-// metadataViewStmt keeps the view's text as it is and its parsed body when it
-// parses. DefineView installs a view whose body does not analyze, so a view
-// may name one that installs after it.
-func metadataViewStmt(v *metadata.ViewMetadata) *nodes.CreateViewStmt {
-	stmt := &nodes.CreateViewStmt{OrReplace: true, Name: &nodes.TableRef{Name: v.GetName()}, SelectText: v.GetDefinition()}
+// metadataViewStmt keeps the view's text as it is along with its parsed body.
+// DefineView installs a view whose body does not analyze, so a view may name
+// one that installs after it; reanalyzeViews retries it then.
+func metadataViewStmt(v *metadata.ViewMetadata) (*nodes.CreateViewStmt, error) {
+	sel, err := parseFirstStatement[*nodes.SelectStmt](v.GetDefinition())
+	if err != nil {
+		return nil, err
+	}
+	stmt := &nodes.CreateViewStmt{OrReplace: true, Name: &nodes.TableRef{Name: v.GetName()}, Select: sel, SelectText: v.GetDefinition()}
 	for _, col := range v.GetColumns() {
 		if col.GetName() != "" {
 			stmt.Columns = append(stmt.Columns, col.GetName())
 		}
 	}
-	if sel, err := parseFirstStatement[*nodes.SelectStmt](v.GetDefinition()); err == nil {
-		stmt.Select = sel
-	}
-	return stmt
+	return stmt, nil
 }
 
 // --- Stand-ins ---

--- a/tidb/catalog/metadata_load.go
+++ b/tidb/catalog/metadata_load.go
@@ -95,12 +95,17 @@ func (c *Catalog) reanalyzeViews(ctx context.Context, views []*metadataObject) e
 }
 
 func (c *Catalog) viewAnalyzed(name string) bool {
+	v := c.installedView(name)
+	return v != nil && v.AnalyzedQuery != nil
+}
+
+// installedView returns the view of that name in the database being loaded.
+func (c *Catalog) installedView(name string) *View {
 	db := c.GetDatabase(c.CurrentDatabase())
 	if db == nil {
-		return false
+		return nil
 	}
-	v := db.Views[toLower(name)]
-	return v != nil && v.AnalyzedQuery != nil
+	return db.Views[toLower(name)]
 }
 
 // --- Objects ---
@@ -164,7 +169,14 @@ func (c *Catalog) installMetadataObject(o *metadataObject) error {
 		if err != nil {
 			return err
 		}
-		return c.DefineView(stmt)
+		if err := c.DefineView(stmt); err != nil {
+			return err
+		}
+		// A * or an unaliased expression leaves the body naming fewer columns
+		// than the snapshot records, so the snapshot names the rest. They are
+		// not a column list the view was created with, so they stay inferred.
+		nameViewColumns(c.installedView(o.name), metadataViewColumnNames(o.view))
+		return nil
 	}
 	stmt, err := metadataTableStmt(o.table)
 	if err != nil {
@@ -316,9 +328,14 @@ func typeTakesDefault(typ string) bool {
 }
 
 // metadataIndexConstraint builds an index from its key parts. The index type
-// holds either the kind, FULLTEXT, or the access method.
+// holds either the kind, FULLTEXT, or the access method. Sync reports the
+// access method a key without USING gets too, and TiDB's is BTREE, so that one
+// stays unwritten.
 func metadataIndexConstraint(idx *metadata.IndexMetadata) *nodes.Constraint {
 	indexType := strings.ToUpper(strings.TrimSpace(idx.GetType()))
+	if indexType == "BTREE" {
+		indexType = ""
+	}
 	c := &nodes.Constraint{Name: idx.GetName()}
 	switch {
 	case idx.GetPrimary():
@@ -428,12 +445,7 @@ func metadataViewStmt(v *metadata.ViewMetadata) (*nodes.CreateViewStmt, error) {
 	stmt := &nodes.CreateViewStmt{OrReplace: true, Name: &nodes.TableRef{Name: v.GetName()}, Select: sel, SelectText: v.GetDefinition()}
 	// A stored definition drops the column list of CREATE VIEW v (a, b), so the
 	// snapshot's columns become one only where they differ from the body's.
-	var names []string
-	for _, col := range v.GetColumns() {
-		if col.GetName() != "" {
-			names = append(names, col.GetName())
-		}
-	}
+	names := metadataViewColumnNames(v)
 	// A * or an unaliased expression is named only once the catalog resolves the
 	// body, and extractViewColumns leaves such a target out, so the body names
 	// nothing to compare unless it names every one of them.
@@ -443,6 +455,25 @@ func metadataViewStmt(v *metadata.ViewMetadata) (*nodes.CreateViewStmt, error) {
 		stmt.Columns = names
 	}
 	return stmt, nil
+}
+
+// metadataViewColumnNames lists the column names the snapshot records for a
+// view.
+func metadataViewColumnNames(v *metadata.ViewMetadata) []string {
+	var names []string
+	for _, col := range v.GetColumns() {
+		if col.GetName() != "" {
+			names = append(names, col.GetName())
+		}
+	}
+	return names
+}
+
+// nameViewColumns names the columns a view's body left unnamed.
+func nameViewColumns(v *View, names []string) {
+	if v != nil && len(v.Columns) < len(names) {
+		v.Columns = names
+	}
 }
 
 // --- Stand-ins ---
@@ -540,6 +571,10 @@ func parseExpr(expr string) (nodes.ExprNode, error) {
 	target, ok := sel.TargetList[0].(*nodes.ResTarget)
 	if !ok {
 		return nil, fmt.Errorf("expression %q: parsed as %T", expr, sel.TargetList[0])
+	}
+	// The probe's parentheses are not part of the expression.
+	if p, ok := target.Val.(*nodes.ParenExpr); ok {
+		return p.Expr, nil
 	}
 	return target.Val, nil
 }

--- a/tidb/catalog/metadata_load.go
+++ b/tidb/catalog/metadata_load.go
@@ -464,14 +464,18 @@ func metadataViewColumnNames(v *metadata.ViewMetadata) []string {
 // CREATE VIEW v (a, b), and only a view created with one has names its body
 // does not give.
 func nameViewColumns(v *View, names []string) {
-	if v == nil || len(names) == 0 {
+	if v == nil || len(names) == 0 || len(v.Columns) > len(names) {
 		return
 	}
-	if len(v.Columns) < len(names) {
+	// Only a body that named every column of its own can disagree with the
+	// snapshot over a name. One that left a column unnamed did not resolve: a
+	// star over a missing relation expands to fewer columns, or to a single
+	// unnamed one, and names them all from the snapshot instead.
+	bodyNamedAll := len(v.Columns) == len(names) && !slices.Contains(v.Columns, "")
+	switch {
+	case !bodyNamedAll:
 		v.Columns = names
-		return
-	}
-	if len(v.Columns) == len(names) && !slices.EqualFunc(v.Columns, names, strings.EqualFold) {
+	case !slices.EqualFunc(v.Columns, names, strings.EqualFold):
 		v.Columns, v.ExplicitColumns = names, true
 	}
 }

--- a/tidb/catalog/metadata_load.go
+++ b/tidb/catalog/metadata_load.go
@@ -264,16 +264,8 @@ func metadataColumnDef(col *metadata.ColumnMetadata) (*nodes.ColumnDef, error) {
 	if col.GetIsInvisible() {
 		def.Constraints = append(def.Constraints, &nodes.ColumnConstraint{Type: nodes.ColConstrInvisible})
 	}
-	autoIncrement := strings.EqualFold(col.GetDefault(), autoIncrementDefault)
-	def.AutoIncrement = autoIncrement
-	// Sync reports DEFAULT NULL for every nullable column, including types that
-	// show no default.
-	if !autoIncrement && col.GetDefault() != "" && col.GetGeneration() == nil &&
-		(!strings.EqualFold(col.GetDefault(), "NULL") || typeTakesDefault(col.GetType())) {
-		if expr, err := parseExpr(col.GetDefault()); err == nil {
-			def.DefaultValue = expr
-		}
-	}
+	def.AutoIncrement = strings.EqualFold(col.GetDefault(), autoIncrementDefault)
+	def.DefaultValue = columnDefault(col)
 	if col.GetOnUpdate() != "" {
 		if expr, err := parseExpr(col.GetOnUpdate()); err == nil {
 			def.OnUpdate = expr
@@ -285,6 +277,27 @@ func metadataColumnDef(col *metadata.ColumnMetadata) (*nodes.ColumnDef, error) {
 		}
 	}
 	return def, nil
+}
+
+// columnDefault parses the default the snapshot records for a column, or
+// returns nil where the catalog takes none: AUTO_INCREMENT is a flag rather
+// than a default, a generated column has no default, and sync reports DEFAULT
+// NULL even for the types that show no default.
+func columnDefault(col *metadata.ColumnMetadata) nodes.ExprNode {
+	value := col.GetDefault()
+	switch {
+	case value == "" || col.GetGeneration() != nil:
+		return nil
+	case strings.EqualFold(value, autoIncrementDefault):
+		return nil
+	case strings.EqualFold(value, "NULL") && !typeTakesDefault(col.GetType()):
+		return nil
+	}
+	expr, err := parseExpr(value)
+	if err != nil {
+		return nil
+	}
+	return expr
 }
 
 // typeTakesDefault reports whether a column type shows a DEFAULT NULL clause,
@@ -303,9 +316,7 @@ func typeTakesDefault(typ string) bool {
 }
 
 // metadataIndexConstraint builds an index from its key parts. The index type
-// holds either the kind, FULLTEXT, or the access method. A key part that is an
-// expression, or that has a length or descends, goes into IndexColumns; plain
-// columns go into Columns.
+// holds either the kind, FULLTEXT, or the access method.
 func metadataIndexConstraint(idx *metadata.IndexMetadata) *nodes.Constraint {
 	indexType := strings.ToUpper(strings.TrimSpace(idx.GetType()))
 	c := &nodes.Constraint{Name: idx.GetName()}
@@ -319,6 +330,20 @@ func metadataIndexConstraint(idx *metadata.IndexMetadata) *nodes.Constraint {
 	default:
 		c.Type, c.IndexType = nodes.ConstrIndex, indexType
 	}
+	c.Columns, c.IndexColumns = indexKeyParts(idx)
+	// A primary key is always visible.
+	if !idx.GetVisible() && !idx.GetPrimary() {
+		c.IndexOptions = append(c.IndexOptions, &nodes.IndexOption{Name: "INVISIBLE"})
+	}
+	if idx.GetComment() != "" {
+		c.IndexOptions = append(c.IndexOptions, &nodes.IndexOption{Name: "COMMENT", Value: &nodes.StringLit{Value: idx.GetComment()}})
+	}
+	return c
+}
+
+// indexKeyParts splits an index's key parts: plain column names, or, where a
+// part is an expression or has a length or descends, an IndexColumn for each.
+func indexKeyParts(idx *metadata.IndexMetadata) ([]string, []*nodes.IndexColumn) {
 	length := func(i int) int {
 		if i < len(idx.GetKeyLength()) {
 			return int(idx.GetKeyLength()[i])
@@ -332,11 +357,15 @@ func metadataIndexConstraint(idx *metadata.IndexMetadata) *nodes.Constraint {
 			plain = false
 		}
 	}
-	for i, expr := range idx.GetExpressions() {
-		if plain {
-			c.Columns = append(c.Columns, unquoteIdent(expr))
-			continue
+	if plain {
+		var columns []string
+		for _, expr := range idx.GetExpressions() {
+			columns = append(columns, unquoteIdent(expr))
 		}
+		return columns, nil
+	}
+	var keys []*nodes.IndexColumn
+	for i, expr := range idx.GetExpressions() {
 		key := &nodes.IndexColumn{Expr: &nodes.ColumnRef{Column: unquoteIdent(expr)}, Desc: descending(i)}
 		if l := length(i); l > 0 {
 			key.Length = l
@@ -347,16 +376,9 @@ func metadataIndexConstraint(idx *metadata.IndexMetadata) *nodes.Constraint {
 				key.Expr = parsed
 			}
 		}
-		c.IndexColumns = append(c.IndexColumns, key)
+		keys = append(keys, key)
 	}
-	// A primary key is always visible.
-	if !idx.GetVisible() && !idx.GetPrimary() {
-		c.IndexOptions = append(c.IndexOptions, &nodes.IndexOption{Name: "INVISIBLE"})
-	}
-	if idx.GetComment() != "" {
-		c.IndexOptions = append(c.IndexOptions, &nodes.IndexOption{Name: "COMMENT", Value: &nodes.StringLit{Value: idx.GetComment()}})
-	}
-	return c
+	return nil, keys
 }
 
 // isExpressionKey reports whether a key part is a functional expression, as

--- a/tidb/catalog/metadata_load.go
+++ b/tidb/catalog/metadata_load.go
@@ -1,0 +1,474 @@
+package catalog
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/bytebase/omni/metadata"
+	nodes "github.com/bytebase/omni/tidb/ast"
+	tidbparser "github.com/bytebase/omni/tidb/parser"
+)
+
+// LoadMetadataReport lists the snapshot objects LoadMetadata could not install
+// as the snapshot defines them. Keys are "table:<name>" and "view:<name>".
+type LoadMetadataReport struct {
+	// Degraded maps each object replaced by a stand-in to the error its
+	// definition failed with.
+	Degraded map[string]error
+	// Missing maps each object the catalog has nothing for to the error that
+	// left it out.
+	Missing map[string]error
+}
+
+// LoadMetadata installs a Bytebase schema snapshot of a TiDB database into the
+// database meta.Name, creating it if needed, and leaves that database
+// selected. Foreign key checks are off during the load, so a table may
+// reference one that installs after it.
+//
+// An object that fails to install does not stop the load: a table is replaced
+// by a stand-in with the same column names, all TEXT, and a view by one that
+// selects NULL under each of its column names. The error is non-nil only when
+// ctx is done.
+func (c *Catalog) LoadMetadata(ctx context.Context, meta *metadata.DatabaseSchemaMetadata) (*LoadMetadataReport, error) {
+	report := &LoadMetadataReport{
+		Degraded: make(map[string]error),
+		Missing:  make(map[string]error),
+	}
+	if err := ctx.Err(); err != nil {
+		return report, err
+	}
+	if name := meta.GetName(); name != "" {
+		if c.GetDatabase(name) == nil {
+			// A database without options always installs.
+			_ = c.DefineDatabase(&nodes.CreateDatabaseStmt{Name: name})
+		}
+		c.SetCurrentDatabase(name)
+	}
+	fkChecks := c.ForeignKeyChecks()
+	c.SetForeignKeyChecks(false)
+	defer c.SetForeignKeyChecks(fkChecks)
+
+	for _, o := range collectMetadataObjects(meta) {
+		if err := ctx.Err(); err != nil {
+			return report, err
+		}
+		err := c.installMetadataObject(o)
+		if err == nil {
+			continue
+		}
+		if standInErr := c.installStandIn(o); standInErr != nil {
+			report.Missing[o.key()] = standInErr
+			continue
+		}
+		report.Degraded[o.key()] = err
+	}
+	return report, nil
+}
+
+// --- Objects ---
+
+// metadataObjectKind lists the kinds in the order they install. Nothing else
+// orders them: foreign key checks are off, and a view may name an object not
+// yet installed.
+type metadataObjectKind int
+
+const (
+	metadataTable metadataObjectKind = iota
+	metadataView
+)
+
+// metadataObject is one install step. The metadata pointer matching kind is
+// set.
+type metadataObject struct {
+	kind  metadataObjectKind
+	name  string
+	table *metadata.TableMetadata
+	view  *metadata.ViewMetadata
+}
+
+// key names the object in the report.
+func (o *metadataObject) key() string {
+	if o.kind == metadataTable {
+		return "table:" + o.name
+	}
+	return "view:" + o.name
+}
+
+// --- Collecting ---
+
+// collectMetadataObjects lists the snapshot's objects in install order: by
+// kind, then name.
+func collectMetadataObjects(meta *metadata.DatabaseSchemaMetadata) []*metadataObject {
+	var out []*metadataObject
+	for _, s := range meta.GetSchemas() {
+		for _, t := range s.GetTables() {
+			if t.GetName() != "" {
+				out = append(out, &metadataObject{kind: metadataTable, name: t.GetName(), table: t})
+			}
+		}
+		for _, v := range s.GetViews() {
+			if v.GetName() != "" {
+				out = append(out, &metadataObject{kind: metadataView, name: v.GetName(), view: v})
+			}
+		}
+	}
+	slices.SortFunc(out, func(a, b *metadataObject) int {
+		return cmp.Or(cmp.Compare(a.kind, b.kind), cmp.Compare(a.name, b.name))
+	})
+	return out
+}
+
+// --- Installing ---
+
+func (c *Catalog) installMetadataObject(o *metadataObject) error {
+	if o.kind == metadataView {
+		return c.DefineView(metadataViewStmt(o.view))
+	}
+	stmt, err := metadataTableStmt(o.table)
+	if err != nil {
+		return err
+	}
+	return c.DefineTable(stmt)
+}
+
+// --- Statements ---
+
+// The snapshot carries types, defaults, and definitions as the text TiDB
+// reports for them. These builders turn that text into the statement ASTs the
+// Define* functions take.
+
+// autoIncrementDefault is what sync stores as the default of an
+// AUTO_INCREMENT column.
+const autoIncrementDefault = "AUTO_INCREMENT"
+
+// metadataTableStmt fails on a column whose type does not parse, so the table
+// gets a stand-in rather than a partial definition. A default, ON UPDATE,
+// generation, or CHECK expression that does not parse is dropped instead.
+// Partitions are left out: they do not change what the columns resolve to.
+func metadataTableStmt(t *metadata.TableMetadata) (*nodes.CreateTableStmt, error) {
+	stmt := &nodes.CreateTableStmt{Table: &nodes.TableRef{Name: t.GetName()}}
+	for _, col := range t.GetColumns() {
+		if col.GetName() == "" {
+			continue
+		}
+		def, err := metadataColumnDef(col)
+		if err != nil {
+			return nil, fmt.Errorf("column %q: %w", col.GetName(), err)
+		}
+		stmt.Columns = append(stmt.Columns, def)
+	}
+	for _, idx := range t.GetIndexes() {
+		if len(idx.GetExpressions()) > 0 {
+			stmt.Constraints = append(stmt.Constraints, metadataIndexConstraint(idx))
+		}
+	}
+	for _, fk := range t.GetForeignKeys() {
+		stmt.Constraints = append(stmt.Constraints, metadataForeignKey(fk))
+	}
+	for _, check := range t.GetCheckConstraints() {
+		if expr, err := parseExpr(check.GetExpression()); err == nil {
+			stmt.Constraints = append(stmt.Constraints, &nodes.Constraint{Type: nodes.ConstrCheck, Name: check.GetName(), Expr: expr})
+		}
+	}
+	for _, opt := range []struct{ name, value string }{
+		{"ENGINE", t.GetEngine()},
+		{"CHARSET", t.GetCharset()},
+		{"COLLATE", t.GetCollation()},
+		{"COMMENT", t.GetComment()},
+	} {
+		if opt.value != "" {
+			stmt.Options = append(stmt.Options, &nodes.TableOption{Name: opt.name, Value: opt.value})
+		}
+	}
+	return stmt, nil
+}
+
+func metadataColumnDef(col *metadata.ColumnMetadata) (*nodes.ColumnDef, error) {
+	typeName, err := parseTypeName(col.GetType())
+	if err != nil {
+		return nil, err
+	}
+	// The type text may carry its own character set and collation.
+	if typeName.Charset == "" {
+		typeName.Charset = col.GetCharacterSet()
+	}
+	if typeName.Collate == "" {
+		typeName.Collate = col.GetCollation()
+	}
+	def := &nodes.ColumnDef{Name: col.GetName(), TypeName: typeName, Comment: col.GetComment()}
+	if !col.GetNullable() {
+		def.Constraints = append(def.Constraints, &nodes.ColumnConstraint{Type: nodes.ColConstrNotNull})
+	}
+	if col.GetIsInvisible() {
+		def.Constraints = append(def.Constraints, &nodes.ColumnConstraint{Type: nodes.ColConstrInvisible})
+	}
+	autoIncrement := strings.EqualFold(col.GetDefault(), autoIncrementDefault)
+	def.AutoIncrement = autoIncrement
+	// Sync reports DEFAULT NULL for every nullable column, including types that
+	// take no DEFAULT clause, which would fail the whole table.
+	if !autoIncrement && col.GetDefault() != "" && col.GetGeneration() == nil &&
+		(!strings.EqualFold(col.GetDefault(), "NULL") || typeTakesDefault(col.GetType())) {
+		if expr, err := parseExpr(col.GetDefault()); err == nil {
+			def.DefaultValue = expr
+		}
+	}
+	if col.GetOnUpdate() != "" {
+		if expr, err := parseExpr(col.GetOnUpdate()); err == nil {
+			def.OnUpdate = expr
+		}
+	}
+	if gen := col.GetGeneration(); gen.GetExpression() != "" {
+		if expr, err := parseExpr(gen.GetExpression()); err == nil {
+			def.Generated = &nodes.GeneratedColumn{Expr: expr, Stored: gen.GetType() == metadata.GenerationMetadata_TYPE_STORED}
+		}
+	}
+	return def, nil
+}
+
+// typeTakesDefault reports whether a column type accepts a literal DEFAULT
+// clause, which the BLOB types and JSON do not.
+func typeTakesDefault(typ string) bool {
+	head := strings.ToLower(strings.TrimSpace(typ))
+	if i := strings.IndexAny(head, " ("); i >= 0 {
+		head = head[:i]
+	}
+	switch head {
+	case "blob", "tinyblob", "mediumblob", "longblob", "json":
+		return false
+	default:
+		return true
+	}
+}
+
+// metadataIndexConstraint builds an index from its key parts. The index type
+// holds either the kind, FULLTEXT, or the access method. A key part that is an
+// expression, or that has a length or descends, goes into IndexColumns; plain
+// columns go into Columns.
+func metadataIndexConstraint(idx *metadata.IndexMetadata) *nodes.Constraint {
+	indexType := strings.ToUpper(strings.TrimSpace(idx.GetType()))
+	c := &nodes.Constraint{Name: idx.GetName()}
+	switch {
+	case idx.GetPrimary():
+		c.Type, c.IndexType = nodes.ConstrPrimaryKey, indexType
+	case idx.GetUnique():
+		c.Type, c.IndexType = nodes.ConstrUnique, indexType
+	case indexType == "FULLTEXT":
+		c.Type = nodes.ConstrFulltextIndex
+	default:
+		c.Type, c.IndexType = nodes.ConstrIndex, indexType
+	}
+	length := func(i int) int {
+		if i < len(idx.GetKeyLength()) {
+			return int(idx.GetKeyLength()[i])
+		}
+		return 0
+	}
+	descending := func(i int) bool { return i < len(idx.GetDescending()) && idx.GetDescending()[i] }
+	plain := true
+	for i, expr := range idx.GetExpressions() {
+		if isExpressionKey(expr) || length(i) > 0 || descending(i) {
+			plain = false
+		}
+	}
+	for i, expr := range idx.GetExpressions() {
+		if plain {
+			c.Columns = append(c.Columns, unquoteIdent(expr))
+			continue
+		}
+		key := &nodes.IndexColumn{Expr: &nodes.ColumnRef{Column: unquoteIdent(expr)}, Desc: descending(i)}
+		if l := length(i); l > 0 {
+			key.Length = l
+		}
+		if isExpressionKey(expr) {
+			// On a parse failure the key stays a column, so the index still installs.
+			if parsed, err := parseExpr(expr); err == nil {
+				key.Expr = parsed
+			}
+		}
+		c.IndexColumns = append(c.IndexColumns, key)
+	}
+	return c
+}
+
+// isExpressionKey reports whether a key part is a functional expression, as
+// in "(lower(name))" or "lower(`name`)", rather than a column.
+func isExpressionKey(s string) bool {
+	return strings.Contains(s, "(")
+}
+
+func metadataForeignKey(fk *metadata.ForeignKeyMetadata) *nodes.Constraint {
+	return &nodes.Constraint{
+		Type:       nodes.ConstrForeignKey,
+		Name:       fk.GetName(),
+		Columns:    fk.GetColumns(),
+		RefTable:   &nodes.TableRef{Schema: fk.GetReferencedSchema(), Name: fk.GetReferencedTable()},
+		RefColumns: fk.GetReferencedColumns(),
+		OnUpdate:   referenceAction(fk.GetOnUpdate()),
+		OnDelete:   referenceAction(fk.GetOnDelete()),
+		Match:      strings.ToUpper(fk.GetMatchType()),
+	}
+}
+
+func referenceAction(action string) nodes.ReferenceAction {
+	switch strings.ToUpper(strings.TrimSpace(action)) {
+	case "RESTRICT":
+		return nodes.RefActRestrict
+	case "CASCADE":
+		return nodes.RefActCascade
+	case "SET NULL":
+		return nodes.RefActSetNull
+	case "SET DEFAULT":
+		return nodes.RefActSetDefault
+	case "NO ACTION":
+		return nodes.RefActNoAction
+	default:
+		return nodes.RefActNone
+	}
+}
+
+// metadataViewStmt keeps the view's text as it is and its parsed body when it
+// parses. DefineView installs a view whose body does not analyze, so a view
+// may name one that installs after it.
+func metadataViewStmt(v *metadata.ViewMetadata) *nodes.CreateViewStmt {
+	stmt := &nodes.CreateViewStmt{OrReplace: true, Name: &nodes.TableRef{Name: v.GetName()}, SelectText: v.GetDefinition()}
+	for _, col := range v.GetColumns() {
+		if col.GetName() != "" {
+			stmt.Columns = append(stmt.Columns, col.GetName())
+		}
+	}
+	if sel, err := parseFirstStatement[*nodes.SelectStmt](v.GetDefinition()); err == nil {
+		stmt.Select = sel
+	}
+	return stmt
+}
+
+// --- Stand-ins ---
+
+// installStandIn installs o's stand-in.
+func (c *Catalog) installStandIn(o *metadataObject) error {
+	if o.kind == metadataView {
+		return c.DefineView(standInViewStmt(o.view))
+	}
+	return c.DefineTable(standInTableStmt(o.table))
+}
+
+// standInPlaceholder names the one column of a stand-in with no column names;
+// a table or view needs a column.
+const standInPlaceholder = "__stand_in"
+
+func standInTableStmt(t *metadata.TableMetadata) *nodes.CreateTableStmt {
+	stmt := &nodes.CreateTableStmt{Table: &nodes.TableRef{Name: t.GetName()}}
+	var names []string
+	for _, col := range t.GetColumns() {
+		names = appendUniqueName(names, col.GetName())
+	}
+	if len(names) == 0 {
+		names = []string{standInPlaceholder}
+	}
+	for _, name := range names {
+		stmt.Columns = append(stmt.Columns, &nodes.ColumnDef{Name: name, TypeName: &nodes.DataType{Name: "TEXT"}})
+	}
+	return stmt
+}
+
+// standInViewStmt selects NULL under the view's own column names, else under
+// the names of the columns it reads.
+func standInViewStmt(v *metadata.ViewMetadata) *nodes.CreateViewStmt {
+	var names []string
+	for _, col := range v.GetColumns() {
+		names = appendUniqueName(names, col.GetName())
+	}
+	if len(names) == 0 {
+		for _, dep := range v.GetDependencyColumns() {
+			names = appendUniqueName(names, dep.GetColumn())
+		}
+	}
+	if len(names) == 0 {
+		names = []string{standInPlaceholder}
+	}
+	targets := make([]nodes.ExprNode, 0, len(names))
+	for _, name := range names {
+		targets = append(targets, &nodes.ResTarget{Name: name, Val: &nodes.NullLit{}})
+	}
+	return &nodes.CreateViewStmt{
+		OrReplace: true,
+		Name:      &nodes.TableRef{Name: v.GetName()},
+		Select:    &nodes.SelectStmt{TargetList: targets},
+	}
+}
+
+func appendUniqueName(names []string, name string) []string {
+	if name == "" || slices.Contains(names, name) {
+		return names
+	}
+	return append(names, name)
+}
+
+// --- Parsing snapshot text ---
+
+// parseTypeName parses a column type as TiDB reports it, such as
+// "varchar(255)", "int unsigned", or "enum('a','b')".
+func parseTypeName(typ string) (*nodes.DataType, error) {
+	if strings.TrimSpace(typ) == "" {
+		return nil, errors.New("empty type")
+	}
+	stmt, err := parseFirstStatement[*nodes.CreateTableStmt]("CREATE TABLE `probe` (`c` " + typ + ")")
+	if err != nil {
+		return nil, fmt.Errorf("type %q: %w", typ, err)
+	}
+	if len(stmt.Columns) == 0 || stmt.Columns[0].TypeName == nil {
+		return nil, fmt.Errorf("type %q: no type parsed", typ)
+	}
+	return stmt.Columns[0].TypeName, nil
+}
+
+// parseExpr parses a default, ON UPDATE, generation, or CHECK expression.
+func parseExpr(expr string) (nodes.ExprNode, error) {
+	if strings.TrimSpace(expr) == "" {
+		return nil, errors.New("empty expression")
+	}
+	sel, err := parseFirstStatement[*nodes.SelectStmt]("SELECT (" + expr + ") AS `probe`")
+	if err != nil {
+		return nil, fmt.Errorf("expression %q: %w", expr, err)
+	}
+	if len(sel.TargetList) == 0 {
+		return nil, fmt.Errorf("expression %q: no target parsed", expr)
+	}
+	target, ok := sel.TargetList[0].(*nodes.ResTarget)
+	if !ok {
+		return nil, fmt.Errorf("expression %q: parsed as %T", expr, sel.TargetList[0])
+	}
+	return target.Val, nil
+}
+
+// parseFirstStatement parses sql and returns its first statement of type T.
+func parseFirstStatement[T nodes.Node](sql string) (T, error) {
+	var zero T
+	if strings.TrimSpace(sql) == "" {
+		return zero, errors.New("empty definition")
+	}
+	list, err := tidbparser.Parse(sql)
+	if err != nil {
+		return zero, err
+	}
+	if list != nil {
+		for _, item := range list.Items {
+			if stmt, ok := item.(T); ok {
+				return stmt, nil
+			}
+		}
+	}
+	return zero, fmt.Errorf("no %T statement", zero)
+}
+
+func unquoteIdent(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' {
+		return strings.ReplaceAll(s[1:len(s)-1], "``", "`")
+	}
+	return s
+}

--- a/tidb/catalog/metadata_load_test.go
+++ b/tidb/catalog/metadata_load_test.go
@@ -238,8 +238,10 @@ func TestLoadMetadataKeepsViewColumnListsOnlyWhereNeeded(t *testing.T) {
 			{Name: "star", Definition: "SELECT * FROM users", Columns: []*metadata.ColumnMetadata{{Name: "id"}}},
 			{Name: "star_qualified", Definition: "SELECT u.* FROM users u", Columns: []*metadata.ColumnMetadata{{Name: "id"}}},
 			{Name: "expr", Definition: "SELECT count(*) FROM users", Columns: []*metadata.ColumnMetadata{{Name: "count(*)"}}},
-			// A body that does not resolve names nothing of its own.
+			// A body that does not resolve names nothing of its own. A qualified
+			// star leaves one unnamed column behind rather than none.
 			{Name: "unresolved", Definition: "SELECT * FROM missing", Columns: []*metadata.ColumnMetadata{{Name: "a"}, {Name: "b"}}},
+			{Name: "unresolved_qualified", Definition: "SELECT m.* FROM missing m", Columns: []*metadata.ColumnMetadata{{Name: "a"}}},
 			// Created as CREATE VIEW star_renamed (user_id) AS SELECT * FROM users.
 			{Name: "star_renamed", Definition: "SELECT * FROM users", Columns: []*metadata.ColumnMetadata{{Name: "user_id"}}},
 		},
@@ -252,7 +254,7 @@ func TestLoadMetadataKeepsViewColumnListsOnlyWhereNeeded(t *testing.T) {
 	}
 	// A body naming no target of its own keeps the columns it resolves to, and
 	// the snapshot names what a body that does not resolve leaves unnamed.
-	for name, want := range map[string][]string{"same": {"id"}, "star": {"id"}, "star_qualified": {"id"}, "expr": {"COUNT(*)"}, "unresolved": {"a", "b"}} {
+	for name, want := range map[string][]string{"same": {"id"}, "star": {"id"}, "star_qualified": {"id"}, "expr": {"COUNT(*)"}, "unresolved": {"a", "b"}, "unresolved_qualified": {"a"}} {
 		if v := requireView(t, c, name); v.ExplicitColumns || !slices.Equal(v.Columns, want) {
 			t.Errorf("%s = explicit %v, columns %v; want %v inferred", name, v.ExplicitColumns, v.Columns, want)
 		}

--- a/tidb/catalog/metadata_load_test.go
+++ b/tidb/catalog/metadata_load_test.go
@@ -1,0 +1,279 @@
+package catalog
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/metadata"
+)
+
+const snapshotDB = "testdb"
+
+func loadTiDBSnapshot(t *testing.T, meta *metadata.DatabaseSchemaMetadata) (*Catalog, *LoadMetadataReport) {
+	t.Helper()
+	c := New()
+	report, err := c.LoadMetadata(context.Background(), meta)
+	if err != nil {
+		t.Fatalf("LoadMetadata: %v", err)
+	}
+	return c, report
+}
+
+// requireReport fails unless exactly the given objects were replaced by
+// stand-ins and nothing is missing.
+func requireReport(t *testing.T, report *LoadMetadataReport, degraded ...string) {
+	t.Helper()
+	var got []string
+	for k := range report.Degraded {
+		got = append(got, k)
+	}
+	slices.Sort(got)
+	slices.Sort(degraded)
+	if !slices.Equal(got, degraded) || len(report.Missing) != 0 {
+		t.Errorf("degraded = %v, missing = %v; want degraded %v and nothing missing", report.Degraded, report.Missing, degraded)
+	}
+}
+
+func requireTable(t *testing.T, c *Catalog, name string) *Table {
+	t.Helper()
+	db := c.GetDatabase(snapshotDB)
+	if db == nil || db.Tables[strings.ToLower(name)] == nil {
+		t.Fatalf("table %q not in catalog", name)
+	}
+	return db.Tables[strings.ToLower(name)]
+}
+
+func requireView(t *testing.T, c *Catalog, name string) *View {
+	t.Helper()
+	db := c.GetDatabase(snapshotDB)
+	if db == nil || db.Views[strings.ToLower(name)] == nil {
+		t.Fatalf("view %q not in catalog", name)
+	}
+	return db.Views[strings.ToLower(name)]
+}
+
+func snapshot(s *metadata.SchemaMetadata) *metadata.DatabaseSchemaMetadata {
+	return &metadata.DatabaseSchemaMetadata{Name: snapshotDB, Schemas: []*metadata.SchemaMetadata{s}}
+}
+
+func TestLoadMetadataInstallsTables(t *testing.T) {
+	c := New()
+	c.SetForeignKeyChecks(true)
+	report, err := c.LoadMetadata(context.Background(), snapshot(&metadata.SchemaMetadata{Tables: []*metadata.TableMetadata{
+		{
+			// Sorts first and references z_parent.
+			Name:    "a_child",
+			Charset: "utf8mb4",
+			Comment: "children",
+			Columns: []*metadata.ColumnMetadata{
+				{Name: "id", Type: "bigint unsigned", Default: autoIncrementDefault},
+				{Name: "parent_id", Type: "bigint unsigned"},
+				{Name: "email", Type: "varchar(255)", Nullable: true, CharacterSet: "latin1"},
+				{Name: "created_at", Type: "timestamp", Default: "CURRENT_TIMESTAMP", OnUpdate: "CURRENT_TIMESTAMP"},
+				{Name: "total", Type: "int", Nullable: true, Generation: &metadata.GenerationMetadata{
+					Type: metadata.GenerationMetadata_TYPE_STORED, Expression: "parent_id + 1",
+				}},
+				// Sync reports DEFAULT NULL for every nullable column, including
+				// types that take no DEFAULT clause.
+				{Name: "payload", Type: "json", Nullable: true, Default: "NULL"},
+				{Name: "name", Type: "varchar(255)", Nullable: true, Default: "NULL"},
+			},
+			Indexes: []*metadata.IndexMetadata{
+				{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}},
+				{Name: "idx_parent_id", Type: "BTREE", Expressions: []string{"parent_id"}},
+				{Name: "idx_lower_name", Type: "BTREE", Expressions: []string{"(lower(`name`))"}},
+				{Name: "idx_prefix", Type: "BTREE", Expressions: []string{"name"}, KeyLength: []int64{10}, Descending: []bool{true}},
+			},
+			ForeignKeys: []*metadata.ForeignKeyMetadata{{
+				Name:              "fk_child_parent",
+				Columns:           []string{"parent_id"},
+				ReferencedTable:   "z_parent",
+				ReferencedColumns: []string{"id"},
+				OnDelete:          "CASCADE",
+			}},
+		},
+		{
+			Name:    "z_parent",
+			Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "bigint unsigned", Default: autoIncrementDefault}},
+			Indexes: []*metadata.IndexMetadata{{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}}},
+		},
+	}}))
+	if err != nil {
+		t.Fatalf("LoadMetadata: %v", err)
+	}
+	requireReport(t, report)
+	if c.CurrentDatabase() != snapshotDB || !c.ForeignKeyChecks() {
+		t.Errorf("current database %q, foreign key checks %v; want %s and checks back on", c.CurrentDatabase(), c.ForeignKeyChecks(), snapshotDB)
+	}
+
+	child := requireTable(t, c, "a_child")
+	if child.Comment != "children" || child.Charset != "utf8mb4" {
+		t.Errorf("a_child comment %q, charset %q", child.Comment, child.Charset)
+	}
+	if id := child.GetColumn("id"); !id.AutoIncrement || id.Nullable {
+		t.Errorf("id = auto increment %v, nullable %v", id.AutoIncrement, id.Nullable)
+	}
+	if email := child.GetColumn("email"); email.Charset != "latin1" {
+		t.Errorf("email charset = %q, want latin1", email.Charset)
+	}
+	if created := child.GetColumn("created_at"); created.Default == nil || created.OnUpdate == "" {
+		t.Errorf("created_at lost its default or ON UPDATE: %+v", created)
+	}
+	if gen := child.GetColumn("total").Generated; gen == nil || !gen.Stored {
+		t.Errorf("total generated = %+v, want stored", gen)
+	}
+	if payload := child.GetColumn("payload"); payload.Default != nil {
+		t.Errorf("payload default = %q, want none", *payload.Default)
+	}
+	if name := child.GetColumn("name"); name.Default == nil {
+		t.Error("name lost its DEFAULT NULL")
+	}
+	indexes := make(map[string]*Index)
+	for _, idx := range child.Indexes {
+		indexes[idx.Name] = idx
+	}
+	if idx := indexes["idx_lower_name"]; idx == nil || len(idx.Columns) != 1 || !strings.Contains(strings.ToLower(idx.Columns[0].Expr), "lower(") {
+		t.Errorf("idx_lower_name = %+v, want the lower() expression", idx)
+	}
+	if idx := indexes["idx_prefix"]; idx == nil || len(idx.Columns) != 1 || idx.Columns[0].Length != 10 || !idx.Columns[0].Descending {
+		t.Errorf("idx_prefix = %+v, want name(10) DESC", idx)
+	}
+	var fk *Constraint
+	for _, con := range child.Constraints {
+		if con.Type == ConForeignKey && con.Name == "fk_child_parent" {
+			fk = con
+		}
+	}
+	if fk == nil || !strings.EqualFold(fk.OnDelete, "CASCADE") {
+		t.Errorf("fk_child_parent = %+v, want ON DELETE CASCADE", fk)
+	}
+}
+
+func TestLoadMetadataInstallsViewsInAnyOrder(t *testing.T) {
+	// a_view reads z_view, which installs after it.
+	c, report := loadTiDBSnapshot(t, snapshot(&metadata.SchemaMetadata{
+		Tables: []*metadata.TableMetadata{{
+			Name:    "users",
+			Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}, {Name: "name", Type: "varchar(255)", Nullable: true}},
+		}},
+		Views: []*metadata.ViewMetadata{
+			{Name: "a_view", Definition: "SELECT id FROM z_view"},
+			{Name: "z_view", Definition: "SELECT id, name FROM users"},
+		},
+	}))
+	requireReport(t, report)
+	// The columns come from analyzing the parsed body.
+	if v := requireView(t, c, "z_view"); !slices.Equal(v.Columns, []string{"id", "name"}) {
+		t.Errorf("z_view columns = %v, want id, name", v.Columns)
+	}
+	requireView(t, c, "a_view")
+}
+
+func TestLoadMetadataStandsInForFailedTables(t *testing.T) {
+	c, report := loadTiDBSnapshot(t, snapshot(&metadata.SchemaMetadata{Tables: []*metadata.TableMetadata{{
+		Name:    "broken",
+		Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}, {Name: "bad", Type: "varchar((("}},
+	}}}))
+	requireReport(t, report, "table:broken")
+	cols := requireTable(t, c, "broken").Columns
+	if len(cols) != 2 {
+		t.Fatalf("stand-in has %d columns, want 2", len(cols))
+	}
+	for _, col := range cols {
+		if !strings.EqualFold(col.DataType, "text") {
+			t.Errorf("stand-in column %s is %s, want text", col.Name, col.DataType)
+		}
+	}
+}
+
+func TestStandInStatements(t *testing.T) {
+	c := New()
+	if _, err := c.LoadMetadata(context.Background(), snapshot(&metadata.SchemaMetadata{})); err != nil {
+		t.Fatalf("LoadMetadata: %v", err)
+	}
+	for name, err := range map[string]error{
+		"empty": c.DefineTable(standInTableStmt(&metadata.TableMetadata{Name: "empty"})),
+		"pv":    c.DefineView(standInViewStmt(&metadata.ViewMetadata{Name: "pv", Columns: []*metadata.ColumnMetadata{{Name: "x"}, {Name: "y"}}})),
+		"dv":    c.DefineView(standInViewStmt(&metadata.ViewMetadata{Name: "dv", DependencyColumns: []*metadata.DependencyColumn{{Column: "id"}}})),
+	} {
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+	}
+	if cols := requireTable(t, c, "empty").Columns; len(cols) != 1 || cols[0].Name != standInPlaceholder {
+		t.Errorf("empty stand-in columns = %+v, want the placeholder", cols)
+	}
+	if cols := requireView(t, c, "pv").Columns; len(cols) != 2 {
+		t.Errorf("pv stand-in has %d columns, want 2", len(cols))
+	}
+	if cols := requireView(t, c, "dv").Columns; !slices.Equal(cols, []string{"id"}) {
+		t.Errorf("dv stand-in columns = %v, want the column it reads", cols)
+	}
+}
+
+func TestLoadMetadataStopsWhenContextIsDone(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		checks int
+		meta   *metadata.DatabaseSchemaMetadata
+	}{
+		{name: "before planning", checks: 0, meta: snapshot(&metadata.SchemaMetadata{})},
+		{name: "before an install", checks: 1, meta: snapshot(&metadata.SchemaMetadata{Tables: []*metadata.TableMetadata{{Name: "t"}}})},
+	} {
+		if _, err := New().LoadMetadata(&doneAfter{Context: context.Background(), checks: tt.checks}, tt.meta); err != context.Canceled {
+			t.Errorf("%s: err = %v, want context.Canceled", tt.name, err)
+		}
+	}
+}
+
+// doneAfter is a context that is done once Err has been called checks times.
+type doneAfter struct {
+	context.Context
+	checks int
+}
+
+func (c *doneAfter) Err() error {
+	if c.checks == 0 {
+		return context.Canceled
+	}
+	c.checks--
+	return nil
+}
+
+func TestParseTypeName(t *testing.T) {
+	for typ, want := range map[string]string{
+		"int":                          "INT",
+		"bigint(20) unsigned zerofill": "BIGINT",
+		"varchar(255)":                 "VARCHAR",
+		"decimal(10,2)":                "DECIMAL",
+		"datetime(6)":                  "DATETIME",
+		"json":                         "JSON",
+		"enum('a','b','c')":            "ENUM",
+		"set('x','y')":                 "SET",
+	} {
+		dt, err := parseTypeName(typ)
+		if err != nil || !strings.EqualFold(dt.Name, want) {
+			t.Errorf("parseTypeName(%q) = %v, %v; want %s", typ, dt, err, want)
+		}
+	}
+	for _, typ := range []string{"", "not a real type ((("} {
+		if _, err := parseTypeName(typ); err == nil {
+			t.Errorf("parseTypeName(%q) succeeded, want an error", typ)
+		}
+	}
+}
+
+func TestParseExpr(t *testing.T) {
+	for _, expr := range []string{`'hello'`, `CURRENT_TIMESTAMP`, `NULL`, `a + b`, `CONCAT('x', 'y')`} {
+		if _, err := parseExpr(expr); err != nil {
+			t.Errorf("parseExpr(%q): %v", expr, err)
+		}
+	}
+	for _, expr := range []string{"", "(((", "this is not sql at all ###"} {
+		if _, err := parseExpr(expr); err == nil {
+			t.Errorf("parseExpr(%q) succeeded, want an error", expr)
+		}
+	}
+}

--- a/tidb/catalog/metadata_load_test.go
+++ b/tidb/catalog/metadata_load_test.go
@@ -136,6 +136,14 @@ func TestLoadMetadataInstallsTables(t *testing.T) {
 	if gen := child.GetColumn("total").Generated; gen == nil || !gen.Stored {
 		t.Errorf("total generated = %+v, want stored", gen)
 	}
+	// The loaded expression is the one a CREATE TABLE gives, carrying none of
+	// the parentheses the parse probe adds.
+	if _, err := c.Exec("CREATE TABLE ddl (parent_id BIGINT UNSIGNED, total INT AS (parent_id + 1) STORED);", nil); err != nil {
+		t.Fatalf("CREATE TABLE: %v", err)
+	}
+	if loaded, fromDDL := child.GetColumn("total").Generated, requireTable(t, c, "ddl").GetColumn("total").Generated; loaded == nil || fromDDL == nil || loaded.Expr != fromDDL.Expr {
+		t.Errorf("generated expression = %+v, want the DDL's %+v", loaded, fromDDL)
+	}
 	for _, name := range []string{"payload", "notes"} {
 		if col := child.GetColumn(name); col.Default != nil {
 			t.Errorf("%s default = %q, want none", name, *col.Default)
@@ -162,6 +170,10 @@ func TestLoadMetadataInstallsTables(t *testing.T) {
 	}
 	if idx := indexes["idx_hidden"]; idx == nil || idx.Comment != "rarely used" {
 		t.Errorf("idx_hidden = %+v, want its comment", idx)
+	}
+	// The access method a key without USING gets stays unwritten.
+	if idx := indexes["idx_parent_id"]; idx == nil || idx.IndexType != "" {
+		t.Errorf("idx_parent_id = %+v, want no index type", idx)
 	}
 	var fk *Constraint
 	for _, con := range child.Constraints {
@@ -221,16 +233,19 @@ func TestLoadMetadataKeepsViewColumnListsOnlyWhereNeeded(t *testing.T) {
 			{Name: "star", Definition: "SELECT * FROM users", Columns: []*metadata.ColumnMetadata{{Name: "id"}}},
 			{Name: "star_qualified", Definition: "SELECT u.* FROM users u", Columns: []*metadata.ColumnMetadata{{Name: "id"}}},
 			{Name: "expr", Definition: "SELECT count(*) FROM users", Columns: []*metadata.ColumnMetadata{{Name: "count(*)"}}},
+			// A body that does not resolve names nothing of its own.
+			{Name: "unresolved", Definition: "SELECT * FROM missing", Columns: []*metadata.ColumnMetadata{{Name: "a"}, {Name: "b"}}},
 		},
 	}))
 	requireReport(t, report)
 	if v := requireView(t, c, "renamed"); !v.ExplicitColumns || !slices.Equal(v.Columns, []string{"user_id"}) {
 		t.Errorf("renamed = explicit %v, columns %v; want the snapshot's user_id", v.ExplicitColumns, v.Columns)
 	}
-	// A body naming no target of its own keeps the columns it resolves to.
-	for _, name := range []string{"same", "star", "star_qualified", "expr"} {
-		if v := requireView(t, c, name); v.ExplicitColumns {
-			t.Errorf("%s = explicit columns %v, want the body's", name, v.Columns)
+	// A body naming no target of its own keeps the columns it resolves to, and
+	// the snapshot names what a body that does not resolve leaves unnamed.
+	for name, want := range map[string][]string{"same": {"id"}, "star": {"id"}, "star_qualified": {"id"}, "expr": {"COUNT(*)"}, "unresolved": {"a", "b"}} {
+		if v := requireView(t, c, name); v.ExplicitColumns || !slices.Equal(v.Columns, want) {
+			t.Errorf("%s = explicit %v, columns %v; want %v inferred", name, v.ExplicitColumns, v.Columns, want)
 		}
 	}
 }

--- a/tidb/catalog/metadata_load_test.go
+++ b/tidb/catalog/metadata_load_test.go
@@ -122,6 +122,22 @@ func TestLoadMetadataInstallsTables(t *testing.T) {
 		t.Errorf("database charset %q, collation %q; want the snapshot's latin1, latin1_bin", db.Charset, db.Collation)
 	}
 
+	// Loading into an existing database adds to it and takes the snapshot's
+	// defaults, so a table that overrides neither resolves the same as it would
+	// in an empty catalog.
+	second := snapshot(&metadata.SchemaMetadata{Tables: []*metadata.TableMetadata{
+		{Name: "u", Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}}},
+	}})
+	second.CharacterSet, second.Collation = "utf8mb4", "utf8mb4_bin"
+	if _, err := c.LoadMetadata(context.Background(), second); err != nil {
+		t.Fatalf("second LoadMetadata: %v", err)
+	}
+	requireTable(t, c, "a_child")
+	requireTable(t, c, "u")
+	if db := c.GetDatabase(snapshotDB); db.Charset != "utf8mb4" || db.Collation != "utf8mb4_bin" {
+		t.Errorf("database charset %q, collation %q; want the second snapshot's utf8mb4, utf8mb4_bin", db.Charset, db.Collation)
+	}
+
 	child := requireTable(t, c, "a_child")
 	if child.Comment != "children" || child.Charset != "utf8mb4" {
 		t.Errorf("a_child comment %q, charset %q", child.Comment, child.Charset)

--- a/tidb/catalog/metadata_load_test.go
+++ b/tidb/catalog/metadata_load_test.go
@@ -82,6 +82,8 @@ func TestLoadMetadataInstallsTables(t *testing.T) {
 				{Name: "payload", Type: "json", Nullable: true, Default: "NULL"},
 				{Name: "notes", Type: "text", Nullable: true, Default: "NULL"},
 				{Name: "name", Type: "varchar(255)", Nullable: true, Default: "NULL"},
+				// Sync quotes a literal default, so it loads as a literal.
+				{Name: "label", Type: "varchar(32)", Nullable: true, Default: "'hello world'"},
 			},
 			Indexes: []*metadata.IndexMetadata{
 				{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}},
@@ -151,6 +153,9 @@ func TestLoadMetadataInstallsTables(t *testing.T) {
 	}
 	if name := child.GetColumn("name"); name.Default == nil {
 		t.Error("name lost its DEFAULT NULL")
+	}
+	if label := child.GetColumn("label"); label.Default == nil || !strings.Contains(*label.Default, "hello world") {
+		t.Errorf("label default = %v, want the quoted literal", label.Default)
 	}
 	indexes := make(map[string]*Index)
 	for _, idx := range child.Indexes {
@@ -235,11 +240,15 @@ func TestLoadMetadataKeepsViewColumnListsOnlyWhereNeeded(t *testing.T) {
 			{Name: "expr", Definition: "SELECT count(*) FROM users", Columns: []*metadata.ColumnMetadata{{Name: "count(*)"}}},
 			// A body that does not resolve names nothing of its own.
 			{Name: "unresolved", Definition: "SELECT * FROM missing", Columns: []*metadata.ColumnMetadata{{Name: "a"}, {Name: "b"}}},
+			// Created as CREATE VIEW star_renamed (user_id) AS SELECT * FROM users.
+			{Name: "star_renamed", Definition: "SELECT * FROM users", Columns: []*metadata.ColumnMetadata{{Name: "user_id"}}},
 		},
 	}))
 	requireReport(t, report)
-	if v := requireView(t, c, "renamed"); !v.ExplicitColumns || !slices.Equal(v.Columns, []string{"user_id"}) {
-		t.Errorf("renamed = explicit %v, columns %v; want the snapshot's user_id", v.ExplicitColumns, v.Columns)
+	for _, name := range []string{"renamed", "star_renamed"} {
+		if v := requireView(t, c, name); !v.ExplicitColumns || !slices.Equal(v.Columns, []string{"user_id"}) {
+			t.Errorf("%s = explicit %v, columns %v; want the snapshot's user_id", name, v.ExplicitColumns, v.Columns)
+		}
 	}
 	// A body naming no target of its own keeps the columns it resolves to, and
 	// the snapshot names what a body that does not resolve leaves unnamed.

--- a/tidb/catalog/metadata_load_test.go
+++ b/tidb/catalog/metadata_load_test.go
@@ -78,8 +78,9 @@ func TestLoadMetadataInstallsTables(t *testing.T) {
 					Type: metadata.GenerationMetadata_TYPE_STORED, Expression: "parent_id + 1",
 				}},
 				// Sync reports DEFAULT NULL for every nullable column, including
-				// types that take no DEFAULT clause.
+				// types that show no default.
 				{Name: "payload", Type: "json", Nullable: true, Default: "NULL"},
+				{Name: "notes", Type: "text", Nullable: true, Default: "NULL"},
 				{Name: "name", Type: "varchar(255)", Nullable: true, Default: "NULL"},
 			},
 			Indexes: []*metadata.IndexMetadata{
@@ -135,8 +136,10 @@ func TestLoadMetadataInstallsTables(t *testing.T) {
 	if gen := child.GetColumn("total").Generated; gen == nil || !gen.Stored {
 		t.Errorf("total generated = %+v, want stored", gen)
 	}
-	if payload := child.GetColumn("payload"); payload.Default != nil {
-		t.Errorf("payload default = %q, want none", *payload.Default)
+	for _, name := range []string{"payload", "notes"} {
+		if col := child.GetColumn(name); col.Default != nil {
+			t.Errorf("%s default = %q, want none", name, *col.Default)
+		}
 	}
 	if name := child.GetColumn("name"); name.Default == nil {
 		t.Error("name lost its DEFAULT NULL")
@@ -205,6 +208,24 @@ func TestLoadMetadataInstallsViewsInAnyOrder(t *testing.T) {
 		if v := requireView(t, c, name); v.AnalyzedQuery == nil {
 			t.Errorf("%s was not analyzed once the view it reads installed", name)
 		}
+	}
+}
+
+func TestLoadMetadataKeepsViewColumnListsOnlyWhereNeeded(t *testing.T) {
+	c, report := loadTiDBSnapshot(t, snapshot(&metadata.SchemaMetadata{
+		Tables: []*metadata.TableMetadata{{Name: "users", Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}}}},
+		Views: []*metadata.ViewMetadata{
+			// Created as CREATE VIEW renamed (user_id) AS SELECT id FROM users.
+			{Name: "renamed", Definition: "SELECT id FROM users", Columns: []*metadata.ColumnMetadata{{Name: "user_id"}}},
+			{Name: "same", Definition: "SELECT id FROM users", Columns: []*metadata.ColumnMetadata{{Name: "ID"}}},
+		},
+	}))
+	requireReport(t, report)
+	if v := requireView(t, c, "renamed"); !v.ExplicitColumns || !slices.Equal(v.Columns, []string{"user_id"}) {
+		t.Errorf("renamed = explicit %v, columns %v; want the snapshot's user_id", v.ExplicitColumns, v.Columns)
+	}
+	if v := requireView(t, c, "same"); v.ExplicitColumns {
+		t.Errorf("same = explicit columns %v, want the body's", v.Columns)
 	}
 }
 

--- a/tidb/catalog/metadata_load_test.go
+++ b/tidb/catalog/metadata_load_test.go
@@ -218,14 +218,20 @@ func TestLoadMetadataKeepsViewColumnListsOnlyWhereNeeded(t *testing.T) {
 			// Created as CREATE VIEW renamed (user_id) AS SELECT id FROM users.
 			{Name: "renamed", Definition: "SELECT id FROM users", Columns: []*metadata.ColumnMetadata{{Name: "user_id"}}},
 			{Name: "same", Definition: "SELECT id FROM users", Columns: []*metadata.ColumnMetadata{{Name: "ID"}}},
+			{Name: "star", Definition: "SELECT * FROM users", Columns: []*metadata.ColumnMetadata{{Name: "id"}}},
+			{Name: "star_qualified", Definition: "SELECT u.* FROM users u", Columns: []*metadata.ColumnMetadata{{Name: "id"}}},
+			{Name: "expr", Definition: "SELECT count(*) FROM users", Columns: []*metadata.ColumnMetadata{{Name: "count(*)"}}},
 		},
 	}))
 	requireReport(t, report)
 	if v := requireView(t, c, "renamed"); !v.ExplicitColumns || !slices.Equal(v.Columns, []string{"user_id"}) {
 		t.Errorf("renamed = explicit %v, columns %v; want the snapshot's user_id", v.ExplicitColumns, v.Columns)
 	}
-	if v := requireView(t, c, "same"); v.ExplicitColumns {
-		t.Errorf("same = explicit columns %v, want the body's", v.Columns)
+	// A body naming no target of its own keeps the columns it resolves to.
+	for _, name := range []string{"same", "star", "star_qualified", "expr"} {
+		if v := requireView(t, c, name); v.ExplicitColumns {
+			t.Errorf("%s = explicit columns %v, want the body's", name, v.Columns)
+		}
 	}
 }
 

--- a/tidb/catalog/metadata_load_test.go
+++ b/tidb/catalog/metadata_load_test.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -61,12 +62,13 @@ func snapshot(s *metadata.SchemaMetadata) *metadata.DatabaseSchemaMetadata {
 func TestLoadMetadataInstallsTables(t *testing.T) {
 	c := New()
 	c.SetForeignKeyChecks(true)
-	report, err := c.LoadMetadata(context.Background(), snapshot(&metadata.SchemaMetadata{Tables: []*metadata.TableMetadata{
+	meta := snapshot(&metadata.SchemaMetadata{Tables: []*metadata.TableMetadata{
 		{
 			// Sorts first and references z_parent.
-			Name:    "a_child",
-			Charset: "utf8mb4",
-			Comment: "children",
+			Name:           "a_child",
+			Charset:        "utf8mb4",
+			Comment:        "children",
+			PrimaryKeyType: "CLUSTERED",
 			Columns: []*metadata.ColumnMetadata{
 				{Name: "id", Type: "bigint unsigned", Default: autoIncrementDefault},
 				{Name: "parent_id", Type: "bigint unsigned"},
@@ -85,6 +87,8 @@ func TestLoadMetadataInstallsTables(t *testing.T) {
 				{Name: "idx_parent_id", Type: "BTREE", Expressions: []string{"parent_id"}},
 				{Name: "idx_lower_name", Type: "BTREE", Expressions: []string{"(lower(`name`))"}},
 				{Name: "idx_prefix", Type: "BTREE", Expressions: []string{"name"}, KeyLength: []int64{10}, Descending: []bool{true}},
+				{Name: "idx_shown", Type: "BTREE", Expressions: []string{"parent_id"}, Visible: true},
+				{Name: "idx_hidden", Type: "BTREE", Expressions: []string{"parent_id"}, Comment: "rarely used"},
 			},
 			ForeignKeys: []*metadata.ForeignKeyMetadata{{
 				Name:              "fk_child_parent",
@@ -95,17 +99,24 @@ func TestLoadMetadataInstallsTables(t *testing.T) {
 			}},
 		},
 		{
-			Name:    "z_parent",
-			Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "bigint unsigned", Default: autoIncrementDefault}},
-			Indexes: []*metadata.IndexMetadata{{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}}},
+			Name:           "z_parent",
+			Columns:        []*metadata.ColumnMetadata{{Name: "id", Type: "bigint unsigned", Default: autoIncrementDefault}},
+			Indexes:        []*metadata.IndexMetadata{{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}}},
+			PrimaryKeyType: "NONCLUSTERED",
 		},
-	}}))
+	}})
+	meta.CharacterSet, meta.Collation = "latin1", "latin1_bin"
+	report, err := c.LoadMetadata(context.Background(), meta)
 	if err != nil {
 		t.Fatalf("LoadMetadata: %v", err)
 	}
 	requireReport(t, report)
 	if c.CurrentDatabase() != snapshotDB || !c.ForeignKeyChecks() {
 		t.Errorf("current database %q, foreign key checks %v; want %s and checks back on", c.CurrentDatabase(), c.ForeignKeyChecks(), snapshotDB)
+	}
+
+	if db := c.GetDatabase(snapshotDB); db.Charset != "latin1" || db.Collation != "latin1_bin" {
+		t.Errorf("database charset %q, collation %q; want the snapshot's latin1, latin1_bin", db.Charset, db.Collation)
 	}
 
 	child := requireTable(t, c, "a_child")
@@ -140,6 +151,15 @@ func TestLoadMetadataInstallsTables(t *testing.T) {
 	if idx := indexes["idx_prefix"]; idx == nil || len(idx.Columns) != 1 || idx.Columns[0].Length != 10 || !idx.Columns[0].Descending {
 		t.Errorf("idx_prefix = %+v, want name(10) DESC", idx)
 	}
+	// The primary key is visible though the snapshot does not say so.
+	for name, visible := range map[string]bool{"PRIMARY": true, "idx_shown": true, "idx_hidden": false} {
+		if idx := indexes[name]; idx == nil || idx.Visible != visible {
+			t.Errorf("%s = %+v, want visible %v", name, idx, visible)
+		}
+	}
+	if idx := indexes["idx_hidden"]; idx == nil || idx.Comment != "rarely used" {
+		t.Errorf("idx_hidden = %+v, want its comment", idx)
+	}
 	var fk *Constraint
 	for _, con := range child.Constraints {
 		if con.Type == ConForeignKey && con.Name == "fk_child_parent" {
@@ -149,17 +169,30 @@ func TestLoadMetadataInstallsTables(t *testing.T) {
 	if fk == nil || !strings.EqualFold(fk.OnDelete, "CASCADE") {
 		t.Errorf("fk_child_parent = %+v, want ON DELETE CASCADE", fk)
 	}
+	clustered := func(table string) string {
+		for _, con := range requireTable(t, c, table).Constraints {
+			if con.Type == ConPrimaryKey && con.Clustered != nil {
+				return strconv.FormatBool(*con.Clustered)
+			}
+		}
+		return "unset"
+	}
+	if got := clustered("a_child") + " " + clustered("z_parent"); got != "true false" {
+		t.Errorf("primary keys clustered = %s, want true false", got)
+	}
 }
 
 func TestLoadMetadataInstallsViewsInAnyOrder(t *testing.T) {
-	// a_view reads z_view, which installs after it.
+	// Each view reads the next, which installs after it, and m_view's columns
+	// come only from analyzing its body.
 	c, report := loadTiDBSnapshot(t, snapshot(&metadata.SchemaMetadata{
 		Tables: []*metadata.TableMetadata{{
 			Name:    "users",
 			Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}, {Name: "name", Type: "varchar(255)", Nullable: true}},
 		}},
 		Views: []*metadata.ViewMetadata{
-			{Name: "a_view", Definition: "SELECT id FROM z_view"},
+			{Name: "a_view", Definition: "SELECT id FROM m_view"},
+			{Name: "m_view", Definition: "SELECT * FROM z_view"},
 			{Name: "z_view", Definition: "SELECT id, name FROM users"},
 		},
 	}))
@@ -168,15 +201,27 @@ func TestLoadMetadataInstallsViewsInAnyOrder(t *testing.T) {
 	if v := requireView(t, c, "z_view"); !slices.Equal(v.Columns, []string{"id", "name"}) {
 		t.Errorf("z_view columns = %v, want id, name", v.Columns)
 	}
-	requireView(t, c, "a_view")
+	for _, name := range []string{"a_view", "m_view"} {
+		if v := requireView(t, c, name); v.AnalyzedQuery == nil {
+			t.Errorf("%s was not analyzed once the view it reads installed", name)
+		}
+	}
 }
 
-func TestLoadMetadataStandsInForFailedTables(t *testing.T) {
-	c, report := loadTiDBSnapshot(t, snapshot(&metadata.SchemaMetadata{Tables: []*metadata.TableMetadata{{
-		Name:    "broken",
-		Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}, {Name: "bad", Type: "varchar((("}},
-	}}}))
-	requireReport(t, report, "table:broken")
+func TestLoadMetadataStandsInForFailedObjects(t *testing.T) {
+	c, report := loadTiDBSnapshot(t, snapshot(&metadata.SchemaMetadata{
+		Tables: []*metadata.TableMetadata{{
+			Name:    "broken",
+			Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "int"}, {Name: "bad", Type: "varchar((("}},
+		}},
+		Views: []*metadata.ViewMetadata{
+			{Name: "bad_view", Definition: "SELEC nonsense", Columns: []*metadata.ColumnMetadata{{Name: "x"}}},
+		},
+	}))
+	requireReport(t, report, "table:broken", "view:bad_view")
+	if cols := requireView(t, c, "bad_view").Columns; !slices.Equal(cols, []string{"x"}) {
+		t.Errorf("bad_view stand-in columns = %v, want x", cols)
+	}
 	cols := requireTable(t, c, "broken").Columns
 	if len(cols) != 2 {
 		t.Fatalf("stand-in has %d columns, want 2", len(cols))
@@ -221,6 +266,10 @@ func TestLoadMetadataStopsWhenContextIsDone(t *testing.T) {
 	}{
 		{name: "before planning", checks: 0, meta: snapshot(&metadata.SchemaMetadata{})},
 		{name: "before an install", checks: 1, meta: snapshot(&metadata.SchemaMetadata{Tables: []*metadata.TableMetadata{{Name: "t"}}})},
+		{name: "before a view reinstall", checks: 3, meta: snapshot(&metadata.SchemaMetadata{Views: []*metadata.ViewMetadata{
+			{Name: "a", Definition: "SELECT id FROM z"},
+			{Name: "z", Definition: "SELECT 1 AS id"},
+		}})},
 	} {
 		if _, err := New().LoadMetadata(&doneAfter{Context: context.Background(), checks: tt.checks}, tt.meta); err != context.Canceled {
 			t.Errorf("%s: err = %v, want context.Canceled", tt.name, err)

--- a/tidb/catalog/viewcmds.go
+++ b/tidb/catalog/viewcmds.go
@@ -189,14 +189,18 @@ func extractViewColumns(sel *nodes.SelectStmt) []string {
 	sel = nodes.LeftmostQueryLeaf(sel)
 	var cols []string
 	for _, target := range sel.TargetList {
-		rt, ok := target.(*nodes.ResTarget)
-		if !ok {
-			continue
-		}
-		if rt.Name != "" {
-			cols = append(cols, rt.Name)
-		} else if cr, ok := rt.Val.(*nodes.ColumnRef); ok {
-			cols = append(cols, cr.Column)
+		switch t := target.(type) {
+		case *nodes.ResTarget:
+			if t.Name != "" {
+				cols = append(cols, t.Name)
+			} else if cr, ok := t.Val.(*nodes.ColumnRef); ok {
+				cols = append(cols, cr.Column)
+			}
+		case *nodes.ColumnRef:
+			// An unaliased column parses as a bare column reference.
+			if !t.Star {
+				cols = append(cols, t.Column)
+			}
 		}
 	}
 	return cols

--- a/trino/catalog/metadata_load.go
+++ b/trino/catalog/metadata_load.go
@@ -3,19 +3,20 @@ package catalog
 import "github.com/bytebase/omni/metadata"
 
 // LoadMetadata adds a Bytebase schema snapshot of one Trino catalog to c, as
-// the catalog named meta.Name with its schemas, tables, and views. A snapshot
-// names an object as the connector reports it, not as SQL spells it, so the
-// names go in as they are: a statement resolves a mixed-case one in quotes, the
-// way Trino does.
+// the catalog named meta.Name with its schemas, tables, and views. Names go in
+// folded, as Trino folds an unquoted identifier, so a statement resolves them
+// as it spells them: a table the snapshot records as Employees resolves, and
+// completes, as employees. Bytebase's Trino completer is built on that, and
+// stores no case of its own.
 func (c *Catalog) LoadMetadata(meta *metadata.DatabaseSchemaMetadata) {
-	database := c.EnsureCatalog(meta.GetName())
+	database := c.EnsureCatalog(Normalize(meta.GetName()))
 	for _, s := range meta.GetSchemas() {
-		schema := database.EnsureSchema(s.GetName())
+		schema := database.EnsureSchema(Normalize(s.GetName()))
 		for _, t := range s.GetTables() {
-			schema.AddTable(t.GetName(), metadataColumns(t.GetColumns())...)
+			schema.AddTable(Normalize(t.GetName()), metadataColumns(t.GetColumns())...)
 		}
 		for _, v := range s.GetViews() {
-			schema.AddView(v.GetName(), metadataColumns(v.GetColumns())...).Definition = v.GetDefinition()
+			schema.AddView(Normalize(v.GetName()), metadataColumns(v.GetColumns())...).Definition = v.GetDefinition()
 		}
 	}
 }
@@ -24,7 +25,7 @@ func metadataColumns(columns []*metadata.ColumnMetadata) []*Column {
 	out := make([]*Column, 0, len(columns))
 	for _, col := range columns {
 		if col.GetName() != "" {
-			out = append(out, NewColumn(col.GetName(), col.GetType(), col.GetNullable()))
+			out = append(out, NewColumn(Normalize(col.GetName()), col.GetType(), col.GetNullable()))
 		}
 	}
 	return out

--- a/trino/catalog/metadata_load.go
+++ b/trino/catalog/metadata_load.go
@@ -3,17 +3,19 @@ package catalog
 import "github.com/bytebase/omni/metadata"
 
 // LoadMetadata adds a Bytebase schema snapshot of one Trino catalog to c, as
-// the catalog named meta.Name with its schemas, tables, and views. Names are
-// normalized as Trino resolves them.
+// the catalog named meta.Name with its schemas, tables, and views. A snapshot
+// names an object as the connector reports it, not as SQL spells it, so the
+// names go in as they are: a statement resolves a mixed-case one in quotes, the
+// way Trino does.
 func (c *Catalog) LoadMetadata(meta *metadata.DatabaseSchemaMetadata) {
-	database := c.EnsureCatalog(Normalize(meta.GetName()))
+	database := c.EnsureCatalog(meta.GetName())
 	for _, s := range meta.GetSchemas() {
-		schema := database.EnsureSchema(Normalize(s.GetName()))
+		schema := database.EnsureSchema(s.GetName())
 		for _, t := range s.GetTables() {
-			schema.AddTable(Normalize(t.GetName()), metadataColumns(t.GetColumns())...)
+			schema.AddTable(t.GetName(), metadataColumns(t.GetColumns())...)
 		}
 		for _, v := range s.GetViews() {
-			schema.AddView(Normalize(v.GetName()), metadataColumns(v.GetColumns())...).Definition = v.GetDefinition()
+			schema.AddView(v.GetName(), metadataColumns(v.GetColumns())...).Definition = v.GetDefinition()
 		}
 	}
 }
@@ -22,7 +24,7 @@ func metadataColumns(columns []*metadata.ColumnMetadata) []*Column {
 	out := make([]*Column, 0, len(columns))
 	for _, col := range columns {
 		if col.GetName() != "" {
-			out = append(out, NewColumn(Normalize(col.GetName()), col.GetType(), col.GetNullable()))
+			out = append(out, NewColumn(col.GetName(), col.GetType(), col.GetNullable()))
 		}
 	}
 	return out

--- a/trino/catalog/metadata_load.go
+++ b/trino/catalog/metadata_load.go
@@ -1,0 +1,29 @@
+package catalog
+
+import "github.com/bytebase/omni/metadata"
+
+// LoadMetadata adds a Bytebase schema snapshot of one Trino catalog to c, as
+// the catalog named meta.Name with its schemas, tables, and views. Names are
+// normalized as Trino resolves them.
+func (c *Catalog) LoadMetadata(meta *metadata.DatabaseSchemaMetadata) {
+	database := c.EnsureCatalog(Normalize(meta.GetName()))
+	for _, s := range meta.GetSchemas() {
+		schema := database.EnsureSchema(Normalize(s.GetName()))
+		for _, t := range s.GetTables() {
+			schema.AddTable(Normalize(t.GetName()), metadataColumns(t.GetColumns())...)
+		}
+		for _, v := range s.GetViews() {
+			schema.AddView(Normalize(v.GetName()), metadataColumns(v.GetColumns())...).Definition = v.GetDefinition()
+		}
+	}
+}
+
+func metadataColumns(columns []*metadata.ColumnMetadata) []*Column {
+	out := make([]*Column, 0, len(columns))
+	for _, col := range columns {
+		if col.GetName() != "" {
+			out = append(out, NewColumn(Normalize(col.GetName()), col.GetType(), col.GetNullable()))
+		}
+	}
+	return out
+}

--- a/trino/catalog/metadata_load.go
+++ b/trino/catalog/metadata_load.go
@@ -13,10 +13,14 @@ func (c *Catalog) LoadMetadata(meta *metadata.DatabaseSchemaMetadata) {
 	for _, s := range meta.GetSchemas() {
 		schema := database.EnsureSchema(Normalize(s.GetName()))
 		for _, t := range s.GetTables() {
-			schema.AddTable(Normalize(t.GetName()), metadataColumns(t.GetColumns())...)
+			if t.GetName() != "" {
+				schema.AddTable(Normalize(t.GetName()), metadataColumns(t.GetColumns())...)
+			}
 		}
 		for _, v := range s.GetViews() {
-			schema.AddView(Normalize(v.GetName()), metadataColumns(v.GetColumns())...).Definition = v.GetDefinition()
+			if v.GetName() != "" {
+				schema.AddView(Normalize(v.GetName()), metadataColumns(v.GetColumns())...).Definition = v.GetDefinition()
+			}
 		}
 	}
 }

--- a/trino/catalog/metadata_load_test.go
+++ b/trino/catalog/metadata_load_test.go
@@ -1,0 +1,49 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/bytebase/omni/metadata"
+)
+
+func TestLoadMetadata(t *testing.T) {
+	c := New()
+	c.LoadMetadata(&metadata.DatabaseSchemaMetadata{
+		Name: "Hive",
+		Schemas: []*metadata.SchemaMetadata{{
+			Name: "Sales",
+			Tables: []*metadata.TableMetadata{{
+				Name:    "Orders",
+				Columns: []*metadata.ColumnMetadata{{Name: "ID", Type: "bigint"}, {Name: "note", Type: "varchar", Nullable: true}},
+			}},
+			Views: []*metadata.ViewMetadata{{
+				Name:       "Recent",
+				Definition: "SELECT id FROM orders",
+				Columns:    []*metadata.ColumnMetadata{{Name: "id", Type: "bigint"}},
+			}},
+		}},
+	})
+
+	database := c.GetCatalog(Normalize("Hive"))
+	if database == nil {
+		t.Fatalf("catalog not loaded; catalogs %v", c.Catalogs())
+	}
+	schema := database.GetSchema(Normalize("Sales"))
+	if schema == nil {
+		t.Fatalf("schema not loaded; schemas %v", database.Schemas())
+	}
+	table := schema.GetTable(Normalize("Orders"))
+	if table == nil || len(table.Columns()) != 2 {
+		t.Fatalf("table = %+v, want Orders with two columns", table)
+	}
+	if id := table.GetColumn(Normalize("ID")); id == nil || id.Type != "bigint" || id.Nullable {
+		t.Errorf("ID = %+v, want a non-null bigint", id)
+	}
+	if note := table.GetColumn(Normalize("note")); note == nil || !note.Nullable {
+		t.Errorf("note = %+v, want a nullable column", note)
+	}
+	view := schema.GetView(Normalize("Recent"))
+	if view == nil || view.Definition != "SELECT id FROM orders" || len(view.Columns()) != 1 {
+		t.Errorf("view = %+v, want Recent with its definition and one column", view)
+	}
+}

--- a/trino/catalog/metadata_load_test.go
+++ b/trino/catalog/metadata_load_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/bytebase/omni/metadata"
 )
 
+// The snapshot's names go in folded, so every lookup here spells them the way
+// a statement does.
 func TestLoadMetadata(t *testing.T) {
 	c := New()
 	c.LoadMetadata(&metadata.DatabaseSchemaMetadata{
@@ -24,30 +26,25 @@ func TestLoadMetadata(t *testing.T) {
 		}},
 	})
 
-	database := c.GetCatalog("Hive")
+	database := c.GetCatalog(Normalize("Hive"))
 	if database == nil {
 		t.Fatalf("catalog not loaded; catalogs %v", c.Catalogs())
 	}
-	schema := database.GetSchema("Sales")
+	schema := database.GetSchema(Normalize("Sales"))
 	if schema == nil {
 		t.Fatalf("schema not loaded; schemas %v", database.Schemas())
 	}
-	table := schema.GetTable("Orders")
+	table := schema.GetTable(Normalize("Orders"))
 	if table == nil || len(table.Columns()) != 2 {
 		t.Fatalf("table = %+v, want Orders with two columns", table)
 	}
-	if id := table.GetColumn("ID"); id == nil || id.Type != "bigint" || id.Nullable {
+	if id := table.GetColumn(Normalize("ID")); id == nil || id.Type != "bigint" || id.Nullable {
 		t.Errorf("ID = %+v, want a non-null bigint", id)
 	}
-	if note := table.GetColumn("note"); note == nil || !note.Nullable {
+	if note := table.GetColumn(Normalize("note")); note == nil || !note.Nullable {
 		t.Errorf("note = %+v, want a nullable column", note)
 	}
-	// A statement spelling the name unquoted resolves it folded, so it must not
-	// find the mixed-case one.
-	if schema.GetTable(Normalize("Orders")) != nil {
-		t.Error("the folded name resolves the table the connector reports as Orders")
-	}
-	view := schema.GetView("Recent")
+	view := schema.GetView(Normalize("Recent"))
 	if view == nil || view.Definition != "SELECT id FROM orders" || len(view.Columns()) != 1 {
 		t.Errorf("view = %+v, want Recent with its definition and one column", view)
 	}

--- a/trino/catalog/metadata_load_test.go
+++ b/trino/catalog/metadata_load_test.go
@@ -17,12 +17,12 @@ func TestLoadMetadata(t *testing.T) {
 			Tables: []*metadata.TableMetadata{{
 				Name:    "Orders",
 				Columns: []*metadata.ColumnMetadata{{Name: "ID", Type: "bigint"}, {Name: "note", Type: "varchar", Nullable: true}},
-			}},
+			}, {Name: ""}},
 			Views: []*metadata.ViewMetadata{{
 				Name:       "Recent",
 				Definition: "SELECT id FROM orders",
 				Columns:    []*metadata.ColumnMetadata{{Name: "id", Type: "bigint"}},
-			}},
+			}, {Name: ""}},
 		}},
 	})
 
@@ -47,5 +47,9 @@ func TestLoadMetadata(t *testing.T) {
 	view := schema.GetView(Normalize("Recent"))
 	if view == nil || view.Definition != "SELECT id FROM orders" || len(view.Columns()) != 1 {
 		t.Errorf("view = %+v, want Recent with its definition and one column", view)
+	}
+	// An unnamed relation would complete as a blank candidate.
+	if len(schema.Tables()) != 1 || len(schema.Views()) != 1 {
+		t.Errorf("tables %v, views %v; want only the named ones", schema.Tables(), schema.Views())
 	}
 }

--- a/trino/catalog/metadata_load_test.go
+++ b/trino/catalog/metadata_load_test.go
@@ -24,25 +24,30 @@ func TestLoadMetadata(t *testing.T) {
 		}},
 	})
 
-	database := c.GetCatalog(Normalize("Hive"))
+	database := c.GetCatalog("Hive")
 	if database == nil {
 		t.Fatalf("catalog not loaded; catalogs %v", c.Catalogs())
 	}
-	schema := database.GetSchema(Normalize("Sales"))
+	schema := database.GetSchema("Sales")
 	if schema == nil {
 		t.Fatalf("schema not loaded; schemas %v", database.Schemas())
 	}
-	table := schema.GetTable(Normalize("Orders"))
+	table := schema.GetTable("Orders")
 	if table == nil || len(table.Columns()) != 2 {
 		t.Fatalf("table = %+v, want Orders with two columns", table)
 	}
-	if id := table.GetColumn(Normalize("ID")); id == nil || id.Type != "bigint" || id.Nullable {
+	if id := table.GetColumn("ID"); id == nil || id.Type != "bigint" || id.Nullable {
 		t.Errorf("ID = %+v, want a non-null bigint", id)
 	}
-	if note := table.GetColumn(Normalize("note")); note == nil || !note.Nullable {
+	if note := table.GetColumn("note"); note == nil || !note.Nullable {
 		t.Errorf("note = %+v, want a nullable column", note)
 	}
-	view := schema.GetView(Normalize("Recent"))
+	// A statement spelling the name unquoted resolves it folded, so it must not
+	// find the mixed-case one.
+	if schema.GetTable(Normalize("Orders")) != nil {
+		t.Error("the folded name resolves the table the connector reports as Orders")
+	}
+	view := schema.GetView("Recent")
 	if view == nil || view.Definition != "SELECT id FROM orders" || len(view.Columns()) != 1 {
 		t.Errorf("view = %+v, want Recent with its definition and one column", view)
 	}


### PR DESCRIPTION
Adds `LoadMetadata` to the TiDB, Trino, MongoDB, and PartiQL catalogs, so Bytebase's completion and query span for these engines stop building catalogs themselves. This follows #414 (PostgreSQL) and #416 (MySQL).

## Per engine

- **TiDB** (`tidb/catalog`) installs tables and views into the snapshot's database, the same way #416 does for MySQL:
  - the database takes the snapshot's character set and collation;
  - foreign key checks are off during the load;
  - `DEFAULT NULL` stays off the types TiDB shows no default for: BLOB, TEXT, and JSON;
  - indexes keep their visibility and comments, and the primary key keeps its `CLUSTERED` or `NONCLUSTERED` mode;
  - a view that names a view installed after it is reanalyzed once that view is in;
  - a view gets the snapshot's columns as its column list only where they differ from the names its body gives;
  - a table that fails gets a `TEXT` stand-in;
  - a view that fails gets one that selects `NULL`, and that includes a view whose definition does not parse;
  - a report lists both.

  TiDB has no triggers, events, or stored routines. Bytebase's TiDB completion rendered DDL text and ran it. This loader builds the statements directly, so it keeps indexes, constraints, defaults, and generated columns.

  `extractViewColumns` now also names the bare column references TiDB's parser yields for unaliased columns, as the MySQL catalog's does.
- **Trino** (`trino/catalog`) adds the snapshot as the catalog `meta.Name`, with its schemas, tables, and views. It keeps column types, nullability, and view definitions, and normalizes names the way Trino resolves them.
- **MongoDB** (`mongo/catalog`) adds each collection, which sync reports as a table.
- **PartiQL** (`partiql/catalog`) adds each table.

## Testing

- `go test -short ./tidb/... ./trino/... ./mongo/... ./partiql/...`
- Mutation-checked: removing any of these rules makes a test fail.
  - **TiDB:**
    - database setup:
      - creating the database with its character set and collation;
      - turning foreign key checks off and back on;
    - the context checks;
    - both stand-ins, and the view parse check;
    - views:
      - reanalyzing views until a pass makes no progress;
      - setting the column list only where the names differ;
    - columns:
      - no `DEFAULT NULL` on JSON and TEXT, and `AUTO_INCREMENT`;
      - the column character set, `ON UPDATE`, and generated columns;
    - indexes:
      - functional and prefix key parts;
      - index visibility and comments;
      - the clustered primary key;
    - parsed view bodies, foreign keys, and table options.
  - **Trino:** views, column normalization, and nullability.
  - **MongoDB:** skipping empty names.
  - **PartiQL:** tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
