### PR TITLE
redshift/catalog: load a Bytebase metadata snapshot

### DIFF
--- a/redshift/catalog/metadata_load.go
+++ b/redshift/catalog/metadata_load.go
@@ -19,6 +19,11 @@ import (
 // fails to install is left out.
 func (c *Catalog) LoadMetadata(meta *metadata.DatabaseSchemaMetadata) {
 	defer c.SetSearchPath(slices.Clone(c.searchPath))
+	type matView struct {
+		schema string
+		mv     *metadata.MaterializedViewMetadata
+	}
+	var matViews []matView
 	for _, s := range meta.GetSchemas() {
 		schema := s.GetName()
 		c.execMetadataDDL(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s;", metadataQuoteIdent(schema)))
@@ -31,16 +36,32 @@ func (c *Catalog) LoadMetadata(meta *metadata.DatabaseSchemaMetadata) {
 		for _, v := range s.GetViews() {
 			c.execMetadataDDL(metadataViewDDL("VIEW", schema, v.GetName(), v.GetColumns()))
 		}
-		for _, mv := range s.GetMaterializedViews() {
-			// The definition may name relations of its own schema unqualified.
-			c.SetSearchPath([]string{schema, "public"})
-			if mv.GetDefinition() == "" || !c.execMetadataDDL(metadataMatViewDDL(schema, mv.GetName(), mv.GetDefinition())) {
-				c.execMetadataDDL(metadataViewDDL("MATERIALIZED VIEW", schema, mv.GetName(), nil))
-			}
-		}
 		for _, seq := range s.GetSequences() {
 			c.execMetadataDDL(fmt.Sprintf("CREATE SEQUENCE %s.%s;", metadataQuoteIdent(schema), metadataQuoteIdent(seq.GetName())))
 		}
+		for _, mv := range s.GetMaterializedViews() {
+			matViews = append(matViews, matView{schema, mv})
+		}
+	}
+	// A materialized view's definition may name any relation, another
+	// materialized view included, so definitions install last and the failed
+	// ones retry while a pass installs more. The rest install like views.
+	for len(matViews) > 0 {
+		var failed []matView
+		for _, m := range matViews {
+			// The definition may name relations of its own schema unqualified.
+			c.SetSearchPath([]string{m.schema, "public"})
+			if m.mv.GetDefinition() == "" || !c.execMetadataDDL(metadataMatViewDDL(m.schema, m.mv.GetName(), m.mv.GetDefinition())) {
+				failed = append(failed, m)
+			}
+		}
+		if len(failed) == len(matViews) {
+			for _, m := range failed {
+				c.execMetadataDDL(metadataViewDDL("MATERIALIZED VIEW", m.schema, m.mv.GetName(), nil))
+			}
+			break
+		}
+		matViews = failed
 	}
 }
 

--- a/redshift/catalog/metadata_load.go
+++ b/redshift/catalog/metadata_load.go
@@ -1,0 +1,356 @@
+package catalog
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/bytebase/omni/metadata"
+	nodes "github.com/bytebase/omni/redshift/ast"
+	pgparser "github.com/bytebase/omni/redshift/parser"
+)
+
+// LoadMetadata installs the schemas, tables, views, materialized views, and
+// sequences of a Bytebase schema snapshot into c, as completion needs them.
+// Columns take a coarse type and a view selects NULL under its column names,
+// so no object depends on another. A materialized view installs from its
+// definition when that runs, and like a view otherwise. An object that still
+// fails to install is left out.
+func (c *Catalog) LoadMetadata(meta *metadata.DatabaseSchemaMetadata) {
+	defer c.SetSearchPath(slices.Clone(c.searchPath))
+	for _, s := range meta.GetSchemas() {
+		schema := s.GetName()
+		c.execMetadataDDL(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s;", metadataQuoteIdent(schema)))
+		for _, t := range s.GetTables() {
+			c.execMetadataDDL(metadataTableDDL(schema, t.GetName(), t.GetColumns()))
+		}
+		for _, t := range s.GetExternalTables() {
+			c.execMetadataDDL(metadataTableDDL(schema, t.GetName(), t.GetColumns()))
+		}
+		for _, v := range s.GetViews() {
+			c.execMetadataDDL(metadataViewDDL("VIEW", schema, v.GetName(), v.GetColumns()))
+		}
+		for _, mv := range s.GetMaterializedViews() {
+			// The definition may name relations of its own schema unqualified.
+			c.SetSearchPath([]string{schema, "public"})
+			if mv.GetDefinition() == "" || !c.execMetadataDDL(metadataMatViewDDL(schema, mv.GetName(), mv.GetDefinition())) {
+				c.execMetadataDDL(metadataViewDDL("MATERIALIZED VIEW", schema, mv.GetName(), nil))
+			}
+		}
+		for _, seq := range s.GetSequences() {
+			c.execMetadataDDL(fmt.Sprintf("CREATE SEQUENCE %s.%s;", metadataQuoteIdent(schema), metadataQuoteIdent(seq.GetName())))
+		}
+	}
+}
+
+// UseMetadata makes c resolve a relation it does not have from a Bytebase
+// schema snapshot, when a statement first names it, and installs the
+// snapshot's functions. A view resolves to its definition, with each
+// unqualified relation in it qualified by the schema it resolves to from the
+// view's own schema, so the definition reads the same under c's search path.
+func (c *Catalog) UseMetadata(meta *metadata.DatabaseSchemaMetadata) {
+	c.SetRelationResolver(newMetadataResolver(meta))
+	for _, s := range meta.GetSchemas() {
+		if len(s.GetFunctions()) == 0 {
+			continue
+		}
+		// A function installs only into a schema c has.
+		c.execMetadataDDL(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s;", metadataQuoteIdent(s.GetName())))
+		for _, fn := range s.GetFunctions() {
+			if def := strings.TrimSpace(fn.GetDefinition()); def != "" {
+				// A function that does not install is left out.
+				c.execMetadataDDL(def)
+			}
+		}
+	}
+}
+
+// execMetadataDDL runs sql and reports whether every statement in it ran.
+// Exec fails only on SQL that does not parse; a statement that fails reports
+// its error in its result.
+func (c *Catalog) execMetadataDDL(sql string) bool {
+	results, err := c.Exec(sql, nil)
+	if err != nil {
+		return false
+	}
+	for _, r := range results {
+		if r.Error != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// metadataPlaceholderColumn names the one column of a view or resolved table
+// the snapshot lists no columns for, since each needs one.
+const metadataPlaceholderColumn = "__stand_in"
+
+func metadataTableDDL(schema, name string, columns []*metadata.ColumnMetadata) string {
+	defs := make([]string, 0, len(columns))
+	for _, col := range columns {
+		if col.GetName() != "" {
+			defs = append(defs, metadataQuoteIdent(col.GetName())+" "+coarseType(col.GetType()))
+		}
+	}
+	return fmt.Sprintf("CREATE TABLE %s.%s (%s);", metadataQuoteIdent(schema), metadataQuoteIdent(name), strings.Join(defs, ", "))
+}
+
+func metadataViewDDL(kind, schema, name string, columns []*metadata.ColumnMetadata) string {
+	targets := make([]string, 0, len(columns))
+	for _, col := range columns {
+		if col.GetName() != "" {
+			targets = append(targets, fmt.Sprintf("CAST(NULL AS %s) AS %s", coarseType(col.GetType()), metadataQuoteIdent(col.GetName())))
+		}
+	}
+	if len(targets) == 0 {
+		targets = append(targets, "1 AS "+metadataPlaceholderColumn)
+	}
+	return fmt.Sprintf("CREATE %s %s.%s AS SELECT %s;", kind, metadataQuoteIdent(schema), metadataQuoteIdent(name), strings.Join(targets, ", "))
+}
+
+// metadataMatViewDDL takes a definition that is either the full CREATE
+// statement or its query.
+func metadataMatViewDDL(schema, name, definition string) string {
+	definition = strings.TrimSuffix(strings.TrimSpace(definition), ";")
+	if strings.HasPrefix(strings.ToUpper(definition), "CREATE ") {
+		return definition + ";"
+	}
+	return fmt.Sprintf("CREATE MATERIALIZED VIEW %s.%s AS %s;", metadataQuoteIdent(schema), metadataQuoteIdent(name), definition)
+}
+
+// coarseType maps a column type to the few types completion and lineage need,
+// so no type the catalog lacks can fail an install.
+func coarseType(typ string) string {
+	lower := strings.ToLower(strings.TrimSpace(typ))
+	switch {
+	case strings.Contains(lower, "bigint"):
+		return "bigint"
+	case strings.Contains(lower, "int"):
+		return "integer"
+	case strings.Contains(lower, "bool"):
+		return "boolean"
+	case strings.Contains(lower, "char"), strings.Contains(lower, "text"), strings.Contains(lower, "string"):
+		return "text"
+	case strings.Contains(lower, "numeric"), strings.Contains(lower, "decimal"):
+		return "numeric"
+	case strings.Contains(lower, "double"):
+		return "double precision"
+	case strings.Contains(lower, "float"), strings.Contains(lower, "real"):
+		return "real"
+	case strings.Contains(lower, "date"):
+		return "date"
+	case strings.Contains(lower, "time"):
+		return "timestamp"
+	default:
+		return "text"
+	}
+}
+
+func metadataQuoteIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+// metadataResolver resolves relations from a snapshot, matching names exactly
+// as Redshift sync reports them.
+type metadataResolver struct {
+	// schemas maps a schema name to its relations and sequences by name.
+	schemas map[string]map[string]metadataRelation
+}
+
+type metadataRelation struct {
+	kind       byte
+	columns    []*metadata.ColumnMetadata
+	definition string
+	sequence   bool
+}
+
+func newMetadataResolver(meta *metadata.DatabaseSchemaMetadata) *metadataResolver {
+	r := &metadataResolver{schemas: make(map[string]map[string]metadataRelation)}
+	for _, s := range meta.GetSchemas() {
+		// Relations share one namespace; on a clash, the kind added last wins,
+		// tables first.
+		relations := make(map[string]metadataRelation)
+		for _, seq := range s.GetSequences() {
+			relations[seq.GetName()] = metadataRelation{kind: RelationKindTable, sequence: true}
+		}
+		for _, mv := range s.GetMaterializedViews() {
+			relations[mv.GetName()] = metadataRelation{kind: RelationKindMaterializedView, definition: mv.GetDefinition()}
+		}
+		for _, v := range s.GetViews() {
+			relations[v.GetName()] = metadataRelation{kind: RelationKindView, columns: v.GetColumns(), definition: v.GetDefinition()}
+		}
+		for _, t := range s.GetExternalTables() {
+			relations[t.GetName()] = metadataRelation{kind: RelationKindTable, columns: t.GetColumns()}
+		}
+		for _, t := range s.GetTables() {
+			relations[t.GetName()] = metadataRelation{kind: RelationKindTable, columns: t.GetColumns()}
+		}
+		r.schemas[s.GetName()] = relations
+	}
+	return r
+}
+
+func (r *metadataResolver) ResolveRelation(schemaName, relationName string, searchPath []string) (*RelationSpec, error) {
+	if schemaName == "" {
+		schemaName = r.search(searchPath, relationName)
+	}
+	rel, ok := r.schemas[schemaName][relationName]
+	if !ok {
+		return nil, nil
+	}
+	spec := &RelationSpec{SchemaName: schemaName, Name: relationName, Kind: rel.kind}
+	switch definition := strings.TrimSpace(rel.definition); {
+	case rel.sequence:
+		spec.Columns = []RelationColumnSpec{{Name: "last_value", Type: "bigint"}, {Name: "log_cnt", Type: "bigint"}, {Name: "is_called", Type: "boolean"}}
+	case rel.kind != RelationKindTable && definition != "":
+		spec.Definition = r.qualify(definition, schemaName)
+	default:
+		// A view without a definition resolves as a table of its columns.
+		spec.Kind = RelationKindTable
+		spec.Columns = metadataColumnSpecs(rel.columns)
+	}
+	return spec, nil
+}
+
+// search returns the first schema on searchPath with a relation or sequence
+// named name.
+func (r *metadataResolver) search(searchPath []string, name string) string {
+	for _, schema := range searchPath {
+		if _, ok := r.schemas[schema][name]; ok {
+			return schema
+		}
+	}
+	return ""
+}
+
+func metadataColumnSpecs(columns []*metadata.ColumnMetadata) []RelationColumnSpec {
+	specs := make([]RelationColumnSpec, 0, len(columns))
+	for _, col := range columns {
+		if col.GetName() != "" {
+			specs = append(specs, RelationColumnSpec{Name: col.GetName(), Type: coarseType(col.GetType())})
+		}
+	}
+	if len(specs) == 0 {
+		specs = append(specs, RelationColumnSpec{Name: metadataPlaceholderColumn, Type: "text"})
+	}
+	return specs
+}
+
+// qualify schema-qualifies each relation a view definition names without a
+// schema, resolving it from the view's own schema. A definition that does not
+// parse stays as it is.
+func (r *metadataResolver) qualify(definition, schema string) string {
+	list, err := pgparser.Parse(definition)
+	if err != nil || list == nil || len(list.Items) != 1 {
+		return definition
+	}
+	var query nodes.Node
+	switch stmt := unwrapRawStmt(list.Items[0]).(type) {
+	case *nodes.ViewStmt:
+		query = stmt.Query
+	case *nodes.CreateTableAsStmt:
+		query = stmt.Query
+	case *nodes.SelectStmt:
+		query = stmt
+	default:
+	}
+	if query == nil {
+		return definition
+	}
+	searchPath := []string{"public"}
+	if schema != "" {
+		searchPath = []string{schema, "public"}
+	}
+	var edits []qualification
+	r.collectQualifications(searchPath, query, map[string]bool{}, &edits)
+	// Insert from the end so earlier offsets stay valid.
+	slices.SortFunc(edits, func(a, b qualification) int { return b.offset - a.offset })
+	for _, edit := range edits {
+		if edit.offset >= 0 && edit.offset <= len(definition) {
+			definition = definition[:edit.offset] + metadataQuoteIdent(edit.schema) + "." + definition[edit.offset:]
+		}
+	}
+	return definition
+}
+
+// qualification inserts schema before the relation name at offset.
+type qualification struct {
+	offset int
+	schema string
+}
+
+// collectQualifications finds the unqualified relation names in node that are
+// not CTE references and resolve along searchPath.
+func (r *metadataResolver) collectQualifications(searchPath []string, node nodes.Node, ctes map[string]bool, edits *[]qualification) {
+	if node == nil {
+		return
+	}
+	if sel, ok := node.(*nodes.SelectStmt); ok {
+		r.collectSelectQualifications(searchPath, sel, ctes, edits)
+		return
+	}
+	nodes.Inspect(node, func(n nodes.Node) bool {
+		if sel, ok := n.(*nodes.SelectStmt); ok && n != node {
+			r.collectSelectQualifications(searchPath, sel, ctes, edits)
+			return false
+		}
+		rv, ok := n.(*nodes.RangeVar)
+		if !ok || rv == nil || rv.Relname == "" || rv.Schemaname != "" || rv.Catalogname != "" || rv.Loc.Start < 0 || ctes[strings.ToLower(rv.Relname)] {
+			return true
+		}
+		if schema := r.search(searchPath, rv.Relname); schema != "" {
+			*edits = append(*edits, qualification{offset: rv.Loc.Start, schema: schema})
+		}
+		return true
+	})
+}
+
+// collectSelectQualifications scopes the CTEs a SELECT declares: a recursive
+// WITH sees all of them in every CTE, and otherwise each CTE sees only the
+// ones before it.
+func (r *metadataResolver) collectSelectQualifications(searchPath []string, sel *nodes.SelectStmt, ctes map[string]bool, edits *[]qualification) {
+	local := maps.Clone(ctes)
+	if sel.WithClause != nil && sel.WithClause.Ctes != nil {
+		scope := maps.Clone(ctes)
+		if sel.WithClause.Recursive {
+			for _, item := range sel.WithClause.Ctes.Items {
+				if cte, ok := item.(*nodes.CommonTableExpr); ok && cte.Ctename != "" {
+					scope[strings.ToLower(cte.Ctename)] = true
+				}
+			}
+		}
+		for _, item := range sel.WithClause.Ctes.Items {
+			cte, ok := item.(*nodes.CommonTableExpr)
+			if !ok || cte.Ctename == "" {
+				continue
+			}
+			r.collectQualifications(searchPath, cte.Ctequery, scope, edits)
+			name := strings.ToLower(cte.Ctename)
+			scope[name] = true
+			local[name] = true
+		}
+	}
+	for _, n := range []nodes.Node{sel.WhereClause, sel.HavingClause, sel.QualifyClause, sel.LimitOffset, sel.LimitCount} {
+		if n != nil {
+			r.collectQualifications(searchPath, n, local, edits)
+		}
+	}
+	if sel.IntoClause != nil {
+		r.collectQualifications(searchPath, sel.IntoClause, local, edits)
+	}
+	if sel.Larg != nil {
+		r.collectQualifications(searchPath, sel.Larg, local, edits)
+	}
+	if sel.Rarg != nil {
+		r.collectQualifications(searchPath, sel.Rarg, local, edits)
+	}
+	for _, list := range []*nodes.List{sel.DistinctClause, sel.TargetList, sel.FromClause, sel.GroupClause, sel.WindowClause, sel.ExcludeList, sel.ValuesLists, sel.SortClause, sel.LockingClause} {
+		if list == nil {
+			continue
+		}
+		for _, item := range list.Items {
+			r.collectQualifications(searchPath, item, local, edits)
+		}
+	}
+}

--- a/redshift/catalog/metadata_load.go
+++ b/redshift/catalog/metadata_load.go
@@ -126,7 +126,7 @@ func coarseType(typ string) string {
 	switch {
 	case strings.Contains(lower, "interval"):
 		return "interval"
-	case strings.Contains(lower, "bigint"):
+	case strings.Contains(lower, "bigint"), strings.Contains(lower, "int8"):
 		return "bigint"
 	case strings.Contains(lower, "int"):
 		return "integer"
@@ -136,10 +136,10 @@ func coarseType(typ string) string {
 		return "text"
 	case strings.Contains(lower, "numeric"), strings.Contains(lower, "decimal"):
 		return "numeric"
-	case strings.Contains(lower, "double"):
-		return "double precision"
-	case strings.Contains(lower, "float"), strings.Contains(lower, "real"):
+	case strings.Contains(lower, "real"), strings.Contains(lower, "float4"):
 		return "real"
+	case strings.Contains(lower, "double"), strings.Contains(lower, "float"):
+		return "double precision"
 	case strings.Contains(lower, "date"):
 		return "date"
 	case strings.Contains(lower, "timestamp"):

--- a/redshift/catalog/metadata_load.go
+++ b/redshift/catalog/metadata_load.go
@@ -142,8 +142,10 @@ func coarseType(typ string) string {
 		return "real"
 	case strings.Contains(lower, "date"):
 		return "date"
-	case strings.Contains(lower, "time"):
+	case strings.Contains(lower, "timestamp"):
 		return "timestamp"
+	case strings.Contains(lower, "time"):
+		return "time"
 	default:
 		return "text"
 	}
@@ -202,13 +204,18 @@ func (r *metadataResolver) ResolveRelation(schemaName, relationName string, sear
 		return nil, nil
 	}
 	spec := &RelationSpec{SchemaName: schemaName, Name: relationName, Kind: rel.kind}
-	switch definition := strings.TrimSpace(rel.definition); {
+	definition, parsed := "", false
+	if rel.kind != RelationKindTable {
+		definition, parsed = r.qualify(rel.definition, schemaName)
+	}
+	switch {
 	case rel.sequence:
 		spec.Columns = []RelationColumnSpec{{Name: "last_value", Type: "bigint"}, {Name: "log_cnt", Type: "bigint"}, {Name: "is_called", Type: "boolean"}}
-	case rel.kind != RelationKindTable && definition != "":
-		spec.Definition = r.qualify(definition, schemaName)
+	case parsed:
+		spec.Definition = definition
 	default:
-		// A view without a definition resolves as a table of its columns.
+		// A view whose definition is empty or does not parse resolves as a
+		// table of its columns.
 		spec.Kind = RelationKindTable
 		spec.Columns = metadataColumnSpecs(rel.columns)
 	}
@@ -240,12 +247,12 @@ func metadataColumnSpecs(columns []*metadata.ColumnMetadata) []RelationColumnSpe
 }
 
 // qualify schema-qualifies each relation a view definition names without a
-// schema, resolving it from the view's own schema. A definition that does not
-// parse stays as it is.
-func (r *metadataResolver) qualify(definition, schema string) string {
+// schema, resolving it from the view's own schema. It reports whether the
+// definition parses as one query.
+func (r *metadataResolver) qualify(definition, schema string) (string, bool) {
 	list, err := pgparser.Parse(definition)
 	if err != nil || list == nil || len(list.Items) != 1 {
-		return definition
+		return "", false
 	}
 	var query nodes.Node
 	switch stmt := unwrapRawStmt(list.Items[0]).(type) {
@@ -258,7 +265,7 @@ func (r *metadataResolver) qualify(definition, schema string) string {
 	default:
 	}
 	if query == nil {
-		return definition
+		return "", false
 	}
 	searchPath := []string{"public"}
 	if schema != "" {
@@ -273,7 +280,7 @@ func (r *metadataResolver) qualify(definition, schema string) string {
 			definition = definition[:edit.offset] + metadataQuoteIdent(edit.schema) + "." + definition[edit.offset:]
 		}
 	}
-	return definition
+	return definition, true
 }
 
 // qualification inserts schema before the relation name at offset.

--- a/redshift/catalog/metadata_load.go
+++ b/redshift/catalog/metadata_load.go
@@ -11,19 +11,29 @@ import (
 	pgparser "github.com/bytebase/omni/redshift/parser"
 )
 
+// --- Loading a snapshot ---
+
 // LoadMetadata installs the schemas, tables, views, materialized views, and
 // sequences of a Bytebase schema snapshot into c, as completion needs them.
 // Columns take a coarse type and a view selects NULL under its column names,
 // so no object depends on another. A materialized view installs from its
-// definition when that runs, and like a view otherwise. An object that still
-// fails to install is left out.
+// definition once the relations it names are in, and like a view otherwise. An
+// object that still fails to install is left out.
 func (c *Catalog) LoadMetadata(meta *metadata.DatabaseSchemaMetadata) {
 	defer c.SetSearchPath(slices.Clone(c.searchPath))
-	type matView struct {
-		schema string
-		mv     *metadata.MaterializedViewMetadata
-	}
-	var matViews []matView
+	c.installMetadataMatViews(c.installMetadataRelations(meta))
+}
+
+// metadataMatView is a materialized view waiting for what its definition names.
+type metadataMatView struct {
+	schema string
+	mv     *metadata.MaterializedViewMetadata
+}
+
+// installMetadataRelations installs the schemas, tables, views, and sequences a
+// materialized view's definition may name, and returns the materialized views.
+func (c *Catalog) installMetadataRelations(meta *metadata.DatabaseSchemaMetadata) []metadataMatView {
+	var matViews []metadataMatView
 	for _, s := range meta.GetSchemas() {
 		schema := s.GetName()
 		c.execMetadataDDL(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s;", metadataQuoteIdent(schema)))
@@ -40,14 +50,18 @@ func (c *Catalog) LoadMetadata(meta *metadata.DatabaseSchemaMetadata) {
 			c.execMetadataDDL(fmt.Sprintf("CREATE SEQUENCE %s.%s;", metadataQuoteIdent(schema), metadataQuoteIdent(seq.GetName())))
 		}
 		for _, mv := range s.GetMaterializedViews() {
-			matViews = append(matViews, matView{schema, mv})
+			matViews = append(matViews, metadataMatView{schema, mv})
 		}
 	}
-	// A materialized view's definition may name any relation, another
-	// materialized view included, so definitions install last and the failed
-	// ones retry while a pass installs more. The rest install like views.
+	return matViews
+}
+
+// installMetadataMatViews installs each definition, retrying the failed ones
+// while a pass installs more, since a definition may name another materialized
+// view. Once a pass installs none, the rest install like views.
+func (c *Catalog) installMetadataMatViews(matViews []metadataMatView) {
 	for len(matViews) > 0 {
-		var failed []matView
+		var failed []metadataMatView
 		for _, m := range matViews {
 			// The definition may name relations of its own schema unqualified.
 			c.SetSearchPath([]string{m.schema, "public"})
@@ -59,7 +73,7 @@ func (c *Catalog) LoadMetadata(meta *metadata.DatabaseSchemaMetadata) {
 			for _, m := range failed {
 				c.execMetadataDDL(metadataViewDDL("MATERIALIZED VIEW", m.schema, m.mv.GetName(), nil))
 			}
-			break
+			return
 		}
 		matViews = failed
 	}
@@ -102,6 +116,8 @@ func (c *Catalog) execMetadataDDL(sql string) bool {
 	}
 	return true
 }
+
+// --- DDL text ---
 
 // metadataPlaceholderColumn names the one column of a view or resolved table
 // the snapshot lists no columns for, since each needs one.
@@ -175,6 +191,8 @@ func coarseType(typ string) string {
 func metadataQuoteIdent(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
+
+// --- Resolving relations lazily ---
 
 // metadataResolver resolves relations from a snapshot, matching names exactly
 // as Redshift sync reports them.
@@ -266,6 +284,8 @@ func metadataColumnSpecs(columns []*metadata.ColumnMetadata) []RelationColumnSpe
 	}
 	return specs
 }
+
+// --- Qualifying a view definition ---
 
 // qualify schema-qualifies each relation a view definition names without a
 // schema, resolving it from the view's own schema. It reports whether the

--- a/redshift/catalog/metadata_load.go
+++ b/redshift/catalog/metadata_load.go
@@ -124,6 +124,8 @@ func metadataMatViewDDL(schema, name, definition string) string {
 func coarseType(typ string) string {
 	lower := strings.ToLower(strings.TrimSpace(typ))
 	switch {
+	case strings.Contains(lower, "interval"):
+		return "interval"
 	case strings.Contains(lower, "bigint"):
 		return "bigint"
 	case strings.Contains(lower, "int"):
@@ -281,7 +283,8 @@ type qualification struct {
 }
 
 // collectQualifications finds the unqualified relation names in node that are
-// not CTE references and resolve along searchPath.
+// not CTE references and resolve along searchPath. CTE names match as parsed:
+// unquoted names folded to lower case, quoted ones as written.
 func (r *metadataResolver) collectQualifications(searchPath []string, node nodes.Node, ctes map[string]bool, edits *[]qualification) {
 	if node == nil {
 		return
@@ -296,7 +299,7 @@ func (r *metadataResolver) collectQualifications(searchPath []string, node nodes
 			return false
 		}
 		rv, ok := n.(*nodes.RangeVar)
-		if !ok || rv == nil || rv.Relname == "" || rv.Schemaname != "" || rv.Catalogname != "" || rv.Loc.Start < 0 || ctes[strings.ToLower(rv.Relname)] {
+		if !ok || rv == nil || rv.Relname == "" || rv.Schemaname != "" || rv.Catalogname != "" || rv.Loc.Start < 0 || ctes[rv.Relname] {
 			return true
 		}
 		if schema := r.search(searchPath, rv.Relname); schema != "" {
@@ -316,7 +319,7 @@ func (r *metadataResolver) collectSelectQualifications(searchPath []string, sel 
 		if sel.WithClause.Recursive {
 			for _, item := range sel.WithClause.Ctes.Items {
 				if cte, ok := item.(*nodes.CommonTableExpr); ok && cte.Ctename != "" {
-					scope[strings.ToLower(cte.Ctename)] = true
+					scope[cte.Ctename] = true
 				}
 			}
 		}
@@ -326,9 +329,8 @@ func (r *metadataResolver) collectSelectQualifications(searchPath []string, sel 
 				continue
 			}
 			r.collectQualifications(searchPath, cte.Ctequery, scope, edits)
-			name := strings.ToLower(cte.Ctename)
-			scope[name] = true
-			local[name] = true
+			scope[cte.Ctename] = true
+			local[cte.Ctename] = true
 		}
 	}
 	for _, n := range []nodes.Node{sel.WhereClause, sel.HavingClause, sel.QualifyClause, sel.LimitOffset, sel.LimitCount} {

--- a/redshift/catalog/metadata_load_test.go
+++ b/redshift/catalog/metadata_load_test.go
@@ -1,0 +1,195 @@
+package catalog
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/bytebase/omni/metadata"
+)
+
+func redshiftSnapshot() *metadata.DatabaseSchemaMetadata {
+	return &metadata.DatabaseSchemaMetadata{
+		Name: "dev",
+		Schemas: []*metadata.SchemaMetadata{{
+			Name: "sales",
+			Tables: []*metadata.TableMetadata{
+				{
+					Name: "orders",
+					Columns: []*metadata.ColumnMetadata{
+						{Name: "id", Type: "bigint"},
+						{Name: "note", Type: "character varying(256)"},
+						{Name: "geo", Type: "geometry"},
+					},
+				},
+				{Name: "empty"},
+			},
+			ExternalTables: []*metadata.ExternalTableMetadata{{
+				Name:    "clicks",
+				Columns: []*metadata.ColumnMetadata{{Name: "at", Type: "timestamp without time zone"}},
+			}},
+			Views: []*metadata.ViewMetadata{
+				{Name: "recent", Definition: "SELECT id FROM orders", Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "bigint"}}},
+				// No definition: it resolves as a table of its columns.
+				{Name: "bare", Columns: []*metadata.ColumnMetadata{{Name: "x", Type: "integer"}}},
+			},
+			MaterializedViews: []*metadata.MaterializedViewMetadata{
+				{Name: "totals", Definition: "SELECT count(*) AS n FROM orders"},
+				{Name: "broken_mv", Definition: "SELEC nonsense"},
+				{Name: "stale_mv", Definition: "SELECT id FROM nowhere"},
+				{Name: "undefined_mv"},
+			},
+			Sequences: []*metadata.SequenceMetadata{{Name: "order_ids"}},
+			Functions: []*metadata.FunctionMetadata{{
+				Name:       "double_it",
+				Definition: "CREATE FUNCTION sales.double_it(integer) RETURNS integer STABLE AS $$ SELECT $1 * 2 $$ LANGUAGE sql;",
+			}},
+		}},
+	}
+}
+
+func TestLoadMetadataInstallsSnapshot(t *testing.T) {
+	c := New()
+	c.SetSearchPath([]string{"public"})
+	c.LoadMetadata(redshiftSnapshot())
+
+	for _, name := range []string{"orders", "empty", "clicks", "recent", "bare", "totals", "broken_mv", "stale_mv", "undefined_mv"} {
+		if c.GetRelation("sales", name) == nil {
+			t.Fatalf("relation sales.%s not installed", name)
+		}
+	}
+	var types []string
+	for _, col := range c.GetRelation("sales", "orders").Columns {
+		types = append(types, c.FormatType(col.TypeOID, col.TypeMod))
+	}
+	if want := []string{"bigint", "text", "text"}; !slices.Equal(types, want) {
+		t.Errorf("orders column types = %v, want the coarse %v", types, want)
+	}
+	if recent := c.GetRelation("sales", "recent"); recent.RelKind != 'v' || len(recent.Columns) != 1 || recent.Columns[0].Name != "id" {
+		t.Errorf("recent = kind %c, columns %v; want a view of id", recent.RelKind, recent.Columns)
+	}
+	// A definition that runs installs as written; one that does not falls back.
+	if totals := c.GetRelation("sales", "totals"); totals.RelKind != 'm' || len(totals.Columns) != 1 || totals.Columns[0].Name != "n" {
+		t.Errorf("totals = kind %c, columns %v; want the materialized view of n", totals.RelKind, totals.Columns)
+	}
+	for _, name := range []string{"broken_mv", "stale_mv", "undefined_mv"} {
+		if mv := c.GetRelation("sales", name); mv.RelKind != 'm' || len(mv.Columns) != 1 || mv.Columns[0].Name != metadataPlaceholderColumn {
+			t.Errorf("%s = kind %c, columns %v; want a materialized view stand-in", name, mv.RelKind, mv.Columns)
+		}
+	}
+	if c.GetSchema("sales").Sequences["order_ids"] == nil {
+		t.Error("sequence sales.order_ids not installed")
+	}
+	if !slices.Equal(c.searchPath, []string{"public"}) {
+		t.Errorf("search path = %v, want it restored to public", c.searchPath)
+	}
+}
+
+func TestUseMetadataResolvesRelationsWhenNamed(t *testing.T) {
+	c := New()
+	c.SetSearchPath([]string{"sales", "public"})
+	c.UseMetadata(redshiftSnapshot())
+	if c.GetRelation("sales", "orders") != nil {
+		t.Fatal("a relation must resolve only when a statement names it")
+	}
+	if _, err := c.Exec("CREATE VIEW public.report AS SELECT r.id, t.n FROM recent r, totals t;", nil); err != nil {
+		t.Fatalf("CREATE VIEW over resolved relations: %v", err)
+	}
+	for _, name := range []string{"recent", "totals", "orders"} {
+		if c.GetRelation("sales", name) == nil {
+			t.Errorf("sales.%s not resolved", name)
+		}
+	}
+	if procs := c.LookupProcByName("double_it"); len(procs) != 1 {
+		t.Errorf("double_it installed %d times, want once", len(procs))
+	}
+}
+
+func TestMetadataResolverResolvesSpecs(t *testing.T) {
+	r := newMetadataResolver(redshiftSnapshot())
+	resolve := func(schema, name string, searchPath ...string) *RelationSpec {
+		t.Helper()
+		spec, err := r.ResolveRelation(schema, name, searchPath)
+		if err != nil {
+			t.Fatalf("ResolveRelation(%q, %q): %v", schema, name, err)
+		}
+		return spec
+	}
+	columns := func(spec *RelationSpec) []RelationColumnSpec {
+		if spec == nil {
+			return nil
+		}
+		return spec.Columns
+	}
+
+	if spec := resolve("", "recent", "sales", "public"); spec == nil || spec.SchemaName != "sales" || spec.Kind != RelationKindView || spec.Definition != `SELECT id FROM "sales".orders` {
+		t.Errorf("recent = %+v, want a view with its relation qualified", spec)
+	}
+	if got, want := columns(resolve("sales", "orders")), []RelationColumnSpec{{"id", "bigint"}, {"note", "text"}, {"geo", "text"}}; !slices.Equal(got, want) {
+		t.Errorf("orders columns = %v, want %v", got, want)
+	}
+	if spec := resolve("", "bare", "sales"); spec == nil || spec.Kind != RelationKindTable || !slices.Equal(spec.Columns, []RelationColumnSpec{{"x", "integer"}}) {
+		t.Errorf("bare = %+v, want a table of its columns", spec)
+	}
+	if got := columns(resolve("", "order_ids", "sales")); len(got) != 3 || got[0].Name != "last_value" {
+		t.Errorf("order_ids columns = %v, want the sequence's", got)
+	}
+	if got := columns(resolve("", "clicks", "public", "sales")); !slices.Equal(got, []RelationColumnSpec{{"at", "timestamp"}}) {
+		t.Errorf("clicks columns = %v, want the external table's", got)
+	}
+	if got := columns(resolve("", "undefined_mv", "sales")); !slices.Equal(got, []RelationColumnSpec{{metadataPlaceholderColumn, "text"}}) {
+		t.Errorf("undefined_mv columns = %v, want the placeholder", got)
+	}
+	for _, tt := range []struct {
+		schema, name string
+		searchPath   []string
+	}{
+		{"", "orders", []string{"public"}},
+		{"sales", "Orders", nil},
+		{"missing", "orders", nil},
+	} {
+		if spec := resolve(tt.schema, tt.name, tt.searchPath...); spec != nil {
+			t.Errorf("ResolveRelation(%q, %q, %v) = %+v, want nil", tt.schema, tt.name, tt.searchPath, spec)
+		}
+	}
+}
+
+func TestMetadataResolverQualifiesViewDefinitions(t *testing.T) {
+	r := newMetadataResolver(redshiftSnapshot())
+	for definition, want := range map[string]string{
+		"SELECT id FROM orders": `SELECT id FROM "sales".orders`,
+		"SELECT id FROM orders WHERE id IN (SELECT id FROM recent)":                                       `SELECT id FROM "sales".orders WHERE id IN (SELECT id FROM "sales".recent)`,
+		"WITH orders AS (SELECT 1 AS id) SELECT id FROM orders":                                           "WITH orders AS (SELECT 1 AS id) SELECT id FROM orders",
+		"WITH o AS (SELECT id FROM orders) SELECT id FROM o":                                              `WITH o AS (SELECT id FROM "sales".orders) SELECT id FROM o`,
+		"WITH orders AS (SELECT id FROM orders) SELECT id FROM orders":                                    `WITH orders AS (SELECT id FROM "sales".orders) SELECT id FROM orders`,
+		"WITH orders AS (SELECT 1 AS id), later AS (SELECT id FROM orders) SELECT id FROM later":          "WITH orders AS (SELECT 1 AS id), later AS (SELECT id FROM orders) SELECT id FROM later",
+		"WITH RECURSIVE orders AS (SELECT 1 AS id UNION ALL SELECT id FROM orders) SELECT id FROM orders": "WITH RECURSIVE orders AS (SELECT 1 AS id UNION ALL SELECT id FROM orders) SELECT id FROM orders",
+		"CREATE MATERIALIZED VIEW sales.m AS SELECT id FROM orders":                                       `CREATE MATERIALIZED VIEW sales.m AS SELECT id FROM "sales".orders`,
+		"SELECT id FROM sales.orders":                                                                     "SELECT id FROM sales.orders",
+		"SELECT id FROM unknown":                                                                          "SELECT id FROM unknown",
+		"SELEC nonsense":                                                                                  "SELEC nonsense",
+	} {
+		if got := r.qualify(definition, "sales"); got != want {
+			t.Errorf("qualify(%q) = %q, want %q", definition, got, want)
+		}
+	}
+}
+
+func TestCoarseType(t *testing.T) {
+	for typ, want := range map[string]string{
+		"":                            "text",
+		"bigint":                      "bigint",
+		"smallint":                    "integer",
+		"boolean":                     "boolean",
+		"character varying(256)":      "text",
+		"numeric(10,2)":               "numeric",
+		"double precision":            "double precision",
+		"real":                        "real",
+		"date":                        "date",
+		"timestamp without time zone": "timestamp",
+		"super":                       "text",
+	} {
+		if got := coarseType(typ); got != want {
+			t.Errorf("coarseType(%q) = %q, want %q", typ, got, want)
+		}
+	}
+}

--- a/redshift/catalog/metadata_load_test.go
+++ b/redshift/catalog/metadata_load_test.go
@@ -87,6 +87,23 @@ func TestLoadMetadataInstallsSnapshot(t *testing.T) {
 	}
 }
 
+func TestLoadMetadataInstallsMaterializedViewsAfterWhatTheyName(t *testing.T) {
+	c := New()
+	c.LoadMetadata(&metadata.DatabaseSchemaMetadata{Schemas: []*metadata.SchemaMetadata{
+		{Name: "reports", MaterializedViews: []*metadata.MaterializedViewMetadata{
+			// a_totals names z_counts, which names a table of a later schema.
+			{Name: "a_totals", Definition: "SELECT n FROM reports.z_counts"},
+			{Name: "z_counts", Definition: "SELECT count(*) AS n FROM sales.orders"},
+		}},
+		{Name: "sales", Tables: []*metadata.TableMetadata{{Name: "orders", Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "bigint"}}}}},
+	}})
+	for _, name := range []string{"a_totals", "z_counts"} {
+		if mv := c.GetRelation("reports", name); mv == nil || len(mv.Columns) != 1 || mv.Columns[0].Name != "n" {
+			t.Errorf("%s did not install from its definition", name)
+		}
+	}
+}
+
 func TestUseMetadataResolvesRelationsWhenNamed(t *testing.T) {
 	c := New()
 	// $user expands to the session user.

--- a/redshift/catalog/metadata_load_test.go
+++ b/redshift/catalog/metadata_load_test.go
@@ -32,6 +32,8 @@ func redshiftSnapshot() *metadata.DatabaseSchemaMetadata {
 				{Name: "recent", Definition: "SELECT id FROM orders", Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "bigint"}}},
 				// No definition: it resolves as a table of its columns.
 				{Name: "bare", Columns: []*metadata.ColumnMetadata{{Name: "x", Type: "integer"}}},
+				// A definition that does not parse resolves the same way.
+				{Name: "odd", Definition: "SELEC nonsense", Columns: []*metadata.ColumnMetadata{{Name: "x", Type: "integer"}}},
 			},
 			MaterializedViews: []*metadata.MaterializedViewMetadata{
 				{Name: "totals", Definition: "SELECT count(*) AS n FROM orders"},
@@ -87,7 +89,9 @@ func TestLoadMetadataInstallsSnapshot(t *testing.T) {
 
 func TestUseMetadataResolvesRelationsWhenNamed(t *testing.T) {
 	c := New()
-	c.SetSearchPath([]string{"sales", "public"})
+	// $user expands to the session user.
+	c.SetSessionUser("sales")
+	c.SetSearchPath([]string{"$user", "public"})
 	c.UseMetadata(redshiftSnapshot())
 	if c.GetRelation("sales", "orders") != nil {
 		t.Fatal("a relation must resolve only when a statement names it")
@@ -128,8 +132,10 @@ func TestMetadataResolverResolvesSpecs(t *testing.T) {
 	if got, want := columns(resolve("sales", "orders")), []RelationColumnSpec{{"id", "bigint"}, {"note", "text"}, {"geo", "text"}, {"ttl", "interval"}}; !slices.Equal(got, want) {
 		t.Errorf("orders columns = %v, want %v", got, want)
 	}
-	if spec := resolve("", "bare", "sales"); spec == nil || spec.Kind != RelationKindTable || !slices.Equal(spec.Columns, []RelationColumnSpec{{"x", "integer"}}) {
-		t.Errorf("bare = %+v, want a table of its columns", spec)
+	for _, name := range []string{"bare", "odd"} {
+		if spec := resolve("", name, "sales"); spec == nil || spec.Kind != RelationKindTable || !slices.Equal(spec.Columns, []RelationColumnSpec{{"x", "integer"}}) {
+			t.Errorf("%s = %+v, want a table of its columns", name, spec)
+		}
 	}
 	if got := columns(resolve("", "order_ids", "sales")); len(got) != 3 || got[0].Name != "last_value" {
 		t.Errorf("order_ids columns = %v, want the sequence's", got)
@@ -168,11 +174,13 @@ func TestMetadataResolverQualifiesViewDefinitions(t *testing.T) {
 		"CREATE MATERIALIZED VIEW sales.m AS SELECT id FROM orders":                                       `CREATE MATERIALIZED VIEW sales.m AS SELECT id FROM "sales".orders`,
 		"SELECT id FROM sales.orders":                                                                     "SELECT id FROM sales.orders",
 		"SELECT id FROM unknown":                                                                          "SELECT id FROM unknown",
-		"SELEC nonsense":                                                                                  "SELEC nonsense",
 	} {
-		if got := r.qualify(definition, "sales"); got != want {
+		if got, _ := r.qualify(definition, "sales"); got != want {
 			t.Errorf("qualify(%q) = %q, want %q", definition, got, want)
 		}
+	}
+	if _, ok := r.qualify("SELEC nonsense", "sales"); ok {
+		t.Error("qualify accepted a definition that does not parse")
 	}
 }
 
@@ -188,6 +196,10 @@ func TestCoarseType(t *testing.T) {
 		"real":                        "real",
 		"date":                        "date",
 		"timestamp without time zone": "timestamp",
+		"timestamp with time zone":    "timestamp",
+		"time":                        "time",
+		"time without time zone":      "time",
+		"timetz":                      "time",
 		"super":                       "text",
 		"interval":                    "interval",
 		"interval year to month":      "interval",

--- a/redshift/catalog/metadata_load_test.go
+++ b/redshift/catalog/metadata_load_test.go
@@ -19,6 +19,7 @@ func redshiftSnapshot() *metadata.DatabaseSchemaMetadata {
 						{Name: "id", Type: "bigint"},
 						{Name: "note", Type: "character varying(256)"},
 						{Name: "geo", Type: "geometry"},
+						{Name: "ttl", Type: "interval"},
 					},
 				},
 				{Name: "empty"},
@@ -61,7 +62,7 @@ func TestLoadMetadataInstallsSnapshot(t *testing.T) {
 	for _, col := range c.GetRelation("sales", "orders").Columns {
 		types = append(types, c.FormatType(col.TypeOID, col.TypeMod))
 	}
-	if want := []string{"bigint", "text", "text"}; !slices.Equal(types, want) {
+	if want := []string{"bigint", "text", "text", "interval"}; !slices.Equal(types, want) {
 		t.Errorf("orders column types = %v, want the coarse %v", types, want)
 	}
 	if recent := c.GetRelation("sales", "recent"); recent.RelKind != 'v' || len(recent.Columns) != 1 || recent.Columns[0].Name != "id" {
@@ -124,7 +125,7 @@ func TestMetadataResolverResolvesSpecs(t *testing.T) {
 	if spec := resolve("", "recent", "sales", "public"); spec == nil || spec.SchemaName != "sales" || spec.Kind != RelationKindView || spec.Definition != `SELECT id FROM "sales".orders` {
 		t.Errorf("recent = %+v, want a view with its relation qualified", spec)
 	}
-	if got, want := columns(resolve("sales", "orders")), []RelationColumnSpec{{"id", "bigint"}, {"note", "text"}, {"geo", "text"}}; !slices.Equal(got, want) {
+	if got, want := columns(resolve("sales", "orders")), []RelationColumnSpec{{"id", "bigint"}, {"note", "text"}, {"geo", "text"}, {"ttl", "interval"}}; !slices.Equal(got, want) {
 		t.Errorf("orders columns = %v, want %v", got, want)
 	}
 	if spec := resolve("", "bare", "sales"); spec == nil || spec.Kind != RelationKindTable || !slices.Equal(spec.Columns, []RelationColumnSpec{{"x", "integer"}}) {
@@ -160,6 +161,7 @@ func TestMetadataResolverQualifiesViewDefinitions(t *testing.T) {
 		"SELECT id FROM orders WHERE id IN (SELECT id FROM recent)":                                       `SELECT id FROM "sales".orders WHERE id IN (SELECT id FROM "sales".recent)`,
 		"WITH orders AS (SELECT 1 AS id) SELECT id FROM orders":                                           "WITH orders AS (SELECT 1 AS id) SELECT id FROM orders",
 		"WITH o AS (SELECT id FROM orders) SELECT id FROM o":                                              `WITH o AS (SELECT id FROM "sales".orders) SELECT id FROM o`,
+		`WITH "Orders" AS (SELECT 1 AS id) SELECT id FROM orders`:                                         `WITH "Orders" AS (SELECT 1 AS id) SELECT id FROM "sales".orders`,
 		"WITH orders AS (SELECT id FROM orders) SELECT id FROM orders":                                    `WITH orders AS (SELECT id FROM "sales".orders) SELECT id FROM orders`,
 		"WITH orders AS (SELECT 1 AS id), later AS (SELECT id FROM orders) SELECT id FROM later":          "WITH orders AS (SELECT 1 AS id), later AS (SELECT id FROM orders) SELECT id FROM later",
 		"WITH RECURSIVE orders AS (SELECT 1 AS id UNION ALL SELECT id FROM orders) SELECT id FROM orders": "WITH RECURSIVE orders AS (SELECT 1 AS id UNION ALL SELECT id FROM orders) SELECT id FROM orders",
@@ -187,6 +189,8 @@ func TestCoarseType(t *testing.T) {
 		"date":                        "date",
 		"timestamp without time zone": "timestamp",
 		"super":                       "text",
+		"interval":                    "interval",
+		"interval year to month":      "interval",
 	} {
 		if got := coarseType(typ); got != want {
 			t.Errorf("coarseType(%q) = %q, want %q", typ, got, want)

--- a/redshift/catalog/metadata_load_test.go
+++ b/redshift/catalog/metadata_load_test.go
@@ -109,6 +109,25 @@ func TestUseMetadataResolvesRelationsWhenNamed(t *testing.T) {
 	}
 }
 
+func TestUseMetadataResolvesEarlierSchemasFirst(t *testing.T) {
+	c := New()
+	c.SetSearchPath([]string{"tenant", "public"})
+	c.UseMetadata(&metadata.DatabaseSchemaMetadata{Schemas: []*metadata.SchemaMetadata{
+		{Name: "tenant", Tables: []*metadata.TableMetadata{{Name: "accounts", Columns: []*metadata.ColumnMetadata{{Name: "tenant_id", Type: "integer"}}}}},
+		{Name: "public", Tables: []*metadata.TableMetadata{{Name: "accounts", Columns: []*metadata.ColumnMetadata{{Name: "legacy_id", Type: "integer"}}}}},
+	}})
+	// public.accounts is in the catalog before the unqualified name resolves.
+	if _, err := c.Exec("CREATE VIEW public.a AS SELECT legacy_id FROM public.accounts; CREATE VIEW public.b AS SELECT tenant_id FROM accounts;", nil); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if c.GetRelation("public", "a") == nil {
+		t.Fatal("public.a was not created")
+	}
+	if c.GetRelation("public", "b") == nil {
+		t.Error("accounts bound to public.accounts, not tenant.accounts earlier on the search path")
+	}
+}
+
 func TestMetadataResolverResolvesSpecs(t *testing.T) {
 	r := newMetadataResolver(redshiftSnapshot())
 	resolve := func(schema, name string, searchPath ...string) *RelationSpec {
@@ -201,6 +220,10 @@ func TestCoarseType(t *testing.T) {
 		"time without time zone":      "time",
 		"timetz":                      "time",
 		"super":                       "text",
+		"int8":                        "bigint",
+		"float8":                      "double precision",
+		"float":                       "double precision",
+		"float4":                      "real",
 		"interval":                    "interval",
 		"interval year to month":      "interval",
 	} {

--- a/redshift/catalog/relation.go
+++ b/redshift/catalog/relation.go
@@ -96,6 +96,22 @@ type Relation struct {
 
 // findRelation locates a relation by schema (or search path) and name.
 func (c *Catalog) findRelation(schemaName, relName string) (*Schema, *Relation, error) {
+	if schemaName == "" && c.relationResolver != nil {
+		// Resolve schema by schema along the search path, so a relation the
+		// catalog already has cannot hide one the resolver holds in an earlier
+		// schema.
+		for _, name := range c.resolverSearchPath() {
+			if schema, rel := c.lookupRelation(name, relName); rel != nil {
+				return schema, rel, nil
+			}
+			if err := c.resolveMissingRelation(name, relName); err != nil {
+				return nil, nil, err
+			}
+			if schema, rel := c.lookupRelation(name, relName); rel != nil {
+				return schema, rel, nil
+			}
+		}
+	}
 	if schema, rel := c.lookupRelation(schemaName, relName); rel != nil {
 		return schema, rel, nil
 	}

--- a/redshift/catalog/relation_resolver.go
+++ b/redshift/catalog/relation_resolver.go
@@ -14,7 +14,8 @@ const (
 	RelationKindMaterializedView byte = 'm'
 )
 
-// RelationResolver lazily supplies relation metadata for catalog misses.
+// RelationResolver lazily supplies relation metadata for catalog misses. It
+// gets the catalog's search path with $user expanded to the current user.
 type RelationResolver interface {
 	ResolveRelation(schemaName, relationName string, searchPath []string) (*RelationSpec, error)
 }
@@ -49,7 +50,15 @@ func (c *Catalog) resolveMissingRelation(schemaName, relName string) error {
 	c.relationResolutionStack[requestKey] = true
 	defer delete(c.relationResolutionStack, requestKey)
 
-	searchPath := append([]string(nil), c.searchPath...)
+	searchPath := make([]string, 0, len(c.searchPath))
+	for _, name := range c.searchPath {
+		if name == "$user" {
+			name = c.currentUser
+		}
+		if name != "" {
+			searchPath = append(searchPath, name)
+		}
+	}
 	spec, err := c.relationResolver.ResolveRelation(schemaName, relName, searchPath)
 	if err != nil {
 		return err

--- a/redshift/catalog/relation_resolver.go
+++ b/redshift/catalog/relation_resolver.go
@@ -50,16 +50,7 @@ func (c *Catalog) resolveMissingRelation(schemaName, relName string) error {
 	c.relationResolutionStack[requestKey] = true
 	defer delete(c.relationResolutionStack, requestKey)
 
-	searchPath := make([]string, 0, len(c.searchPath))
-	for _, name := range c.searchPath {
-		if name == "$user" {
-			name = c.currentUser
-		}
-		if name != "" {
-			searchPath = append(searchPath, name)
-		}
-	}
-	spec, err := c.relationResolver.ResolveRelation(schemaName, relName, searchPath)
+	spec, err := c.relationResolver.ResolveRelation(schemaName, relName, c.resolverSearchPath())
 	if err != nil {
 		return err
 	}
@@ -78,6 +69,21 @@ func (c *Catalog) resolveMissingRelation(schemaName, relName string) error {
 	}
 
 	return c.materializeRelationSpec(spec)
+}
+
+// resolverSearchPath returns the search path a resolver gets: the catalog's,
+// with $user expanded to the current user.
+func (c *Catalog) resolverSearchPath() []string {
+	searchPath := make([]string, 0, len(c.searchPath))
+	for _, name := range c.searchPath {
+		if name == "$user" {
+			name = c.currentUser
+		}
+		if name != "" {
+			searchPath = append(searchPath, name)
+		}
+	}
+	return searchPath
 }
 
 func normalizeRelationSpec(spec *RelationSpec, schemaName, relName string) *RelationSpec {


### PR DESCRIPTION
## Summary

Moves Bytebase's Redshift metadata→catalog code into omni, as #414 did for PostgreSQL and #416/#417 do for the other engines.

- `LoadMetadata` installs a snapshot for completion. It installs:
  - schemas;
  - tables and external tables, with coarse column types;
  - views, as `SELECT NULL` stand-ins under their column names;
  - materialized views from their definition, after everything else. A definition that fails is retried while a pass installs more, and falls back to a stand-in at the end;
  - sequences.
- `UseMetadata` sets a relation resolver, so a relation installs only when a statement first names it, which is how query span uses the catalog. It also installs the snapshot's functions.
  - A view resolves to its definition. Each unqualified relation in the definition is qualified by the schema it resolves to from the view's own schema. CTE names match exactly as parsed.
  - A view whose definition is empty or does not parse resolves as a table of its columns.
- Coarse column types keep these apart:
  - integers, big integers, booleans, and text;
  - numerics, reals, and doubles;
  - dates, times, timestamps, and intervals.

  Anything else becomes `text`, so no type the catalog lacks can fail an install.
- Two changes to how the catalog uses a relation resolver:
  - It resolves an unqualified name schema by schema along the search path, checking its own relations and then the resolver in each schema. So a relation already materialized in a later schema cannot hide one the resolver holds in an earlier schema.
  - It hands the resolver its search path with `$user` expanded to the current user, the same way it resolves names itself.

Fixes over the Bytebase code this replaces:
- `Exec` returns an error only for SQL that does not parse. A statement that fails reports its error in its `ExecResult`, and the old check missed that. So a materialized view whose definition parsed but did not analyze never fell back to its stand-in.
- A function in a schema the catalog did not have yet failed to install. `UseMetadata` now creates the schema first.
- Column types: `INT8` became a 32-bit integer, `FLOAT8` became `real`, intervals became integers, and times became timestamps.
- A quoted CTE name such as `"Orders"` hid the relation `orders`.
- A view whose definition did not parse made every query that named it fail.
- A materialized view that named a relation of a later schema, or a materialized view installed after it, fell back to a stand-in.
- An unqualified name bound to a relation already materialized in a later schema, even when the snapshot had a relation of that name in an earlier schema.

## Test plan

- `go test ./redshift/...`
- Mutation-checked the loader and the catalog's resolver hooks: each of 27 mutations fails a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
