### PR TITLE
mysql/catalog: name view columns after the body resolves

### DIFF
--- a/mysql/catalog/metadata_load.go
+++ b/mysql/catalog/metadata_load.go
@@ -171,12 +171,17 @@ func (c *Catalog) reanalyzeViews(ctx context.Context, views []*metadataObject) e
 }
 
 func (c *Catalog) viewAnalyzed(name string) bool {
+	v := c.installedView(name)
+	return v != nil && v.AnalyzedQuery != nil
+}
+
+// installedView returns the view of that name in the database being loaded.
+func (c *Catalog) installedView(name string) *View {
 	db := c.GetDatabase(c.CurrentDatabase())
 	if db == nil {
-		return false
+		return nil
 	}
-	v := db.Views[toLower(name)]
-	return v != nil && v.AnalyzedQuery != nil
+	return db.Views[toLower(name)]
 }
 
 // --- Objects ---
@@ -290,7 +295,11 @@ func (c *Catalog) installMetadataObject(o *metadataObject) error {
 		if err != nil {
 			return err
 		}
-		return c.DefineView(stmt)
+		if err := c.DefineView(stmt); err != nil {
+			return err
+		}
+		nameViewColumns(c.installedView(o.name), metadataViewColumnNames(o.view))
+		return nil
 	case metadataFunction:
 		stmt, err := parseRoutine(o.function.GetDefinition(), false)
 		if err != nil {
@@ -588,47 +597,44 @@ func referenceAction(action string) nodes.ReferenceAction {
 
 // metadataViewStmt keeps the view's text as it is along with its parsed body.
 // DefineView installs a view whose body does not analyze, so a view may name
-// one that installs after it; reanalyzeViews retries it then.
+// one that installs after it; reanalyzeViews retries it then. nameViewColumns
+// names the columns once the body resolves.
 func metadataViewStmt(v *metadata.ViewMetadata) (*nodes.CreateViewStmt, error) {
 	sel, err := parseFirstStatement[*nodes.SelectStmt](v.GetDefinition())
 	if err != nil {
 		return nil, err
 	}
-	stmt := &nodes.CreateViewStmt{OrReplace: true, Name: &nodes.TableRef{Name: v.GetName()}, Select: sel, SelectText: v.GetDefinition()}
-	// A stored definition drops the column list of CREATE VIEW v (a, b), so the
-	// snapshot's columns become one only where they differ from the body's.
+	return &nodes.CreateViewStmt{OrReplace: true, Name: &nodes.TableRef{Name: v.GetName()}, Select: sel, SelectText: v.GetDefinition()}, nil
+}
+
+// metadataViewColumnNames lists the column names the snapshot records for a
+// view.
+func metadataViewColumnNames(v *metadata.ViewMetadata) []string {
 	var names []string
 	for _, col := range v.GetColumns() {
 		if col.GetName() != "" {
 			names = append(names, col.GetName())
 		}
 	}
-	// A * names its columns only once the catalog resolves it, so the body
-	// gives no names to compare.
-	if len(names) > 0 && !selectsStar(sel) && !slices.EqualFunc(names, extractViewColumns(sel), strings.EqualFold) {
-		stmt.Columns = names
-	}
-	return stmt, nil
+	return names
 }
 
-// selectsStar reports whether a view body's output list has a *, as in SELECT *
-// or SELECT t.*.
-func selectsStar(sel *nodes.SelectStmt) bool {
-	for _, target := range nodes.LeftmostQueryLeaf(sel).TargetList {
-		expr := target
-		if rt, ok := target.(*nodes.ResTarget); ok {
-			expr = rt.Val
-		}
-		switch t := expr.(type) {
-		case *nodes.StarExpr:
-			return true
-		case *nodes.ColumnRef:
-			if t.Star {
-				return true
-			}
-		}
+// nameViewColumns names a view's columns from the snapshot: the ones its
+// resolved body left unnamed, and, where the body named as many by other names,
+// the snapshot's as a column list. A stored definition drops the column list of
+// CREATE VIEW v (a, b), and only a view created with one has names its body
+// does not give.
+func nameViewColumns(v *View, names []string) {
+	if v == nil || len(names) == 0 {
+		return
 	}
-	return false
+	if len(v.Columns) < len(names) {
+		v.Columns = names
+		return
+	}
+	if len(v.Columns) == len(names) && !slices.EqualFunc(v.Columns, names, strings.EqualFold) {
+		v.Columns, v.ExplicitColumns = names, true
+	}
 }
 
 // metadataTriggerStmt builds a trigger from its parts. Sync stores the body

--- a/mysql/catalog/metadata_load.go
+++ b/mysql/catalog/metadata_load.go
@@ -641,17 +641,20 @@ func nameViewColumns(v *View, names []string) {
 	default:
 		return
 	}
-	nameViewColumnMetadata(v)
+	nameViewColumnMetadata(v, names)
 }
 
 // nameViewColumnMetadata carries the view's column names into the metadata
-// DefineView inferred alongside them, which is indexed the same way. A column
-// the body never resolved has no inferred metadata of its own.
-func nameViewColumnMetadata(v *View) {
-	for len(v.ColumnMetadata) < len(v.Columns) {
-		v.ColumnMetadata = append(v.ColumnMetadata, ViewColumn{})
+// DefineView inferred alongside them. A body with a column for each of the
+// snapshot's kept them in that order, so only the names change. One with fewer
+// expanded a star the catalog could not resolve, which shifts every column
+// after it: what the body inferred belongs to no column the snapshot names,
+// and the names stand on their own.
+func nameViewColumnMetadata(v *View, names []string) {
+	if len(v.ColumnMetadata) != len(names) {
+		v.ColumnMetadata = make([]ViewColumn, len(names))
 	}
-	for i, name := range v.Columns {
+	for i, name := range names {
 		v.ColumnMetadata[i].Name = name
 	}
 }

--- a/mysql/catalog/metadata_load.go
+++ b/mysql/catalog/metadata_load.go
@@ -625,15 +625,34 @@ func metadataViewColumnNames(v *metadata.ViewMetadata) []string {
 // CREATE VIEW v (a, b), and only a view created with one has names its body
 // does not give.
 func nameViewColumns(v *View, names []string) {
-	if v == nil || len(names) == 0 {
+	if v == nil || len(names) == 0 || len(v.Columns) > len(names) {
 		return
 	}
-	if len(v.Columns) < len(names) {
+	// Only a body that named every column of its own can disagree with the
+	// snapshot over a name. One that left a column unnamed did not resolve: a
+	// star over a missing relation expands to fewer columns, or to a single
+	// unnamed one, and names them all from the snapshot instead.
+	bodyNamedAll := len(v.Columns) == len(names) && !slices.Contains(v.Columns, "")
+	switch {
+	case !bodyNamedAll:
 		v.Columns = names
+	case !slices.EqualFunc(v.Columns, names, strings.EqualFold):
+		v.Columns, v.ExplicitColumns = names, true
+	default:
 		return
 	}
-	if len(v.Columns) == len(names) && !slices.EqualFunc(v.Columns, names, strings.EqualFold) {
-		v.Columns, v.ExplicitColumns = names, true
+	nameViewColumnMetadata(v)
+}
+
+// nameViewColumnMetadata carries the view's column names into the metadata
+// DefineView inferred alongside them, which is indexed the same way. A column
+// the body never resolved has no inferred metadata of its own.
+func nameViewColumnMetadata(v *View) {
+	for len(v.ColumnMetadata) < len(v.Columns) {
+		v.ColumnMetadata = append(v.ColumnMetadata, ViewColumn{})
+	}
+	for i, name := range v.Columns {
+		v.ColumnMetadata[i].Name = name
 	}
 }
 

--- a/mysql/catalog/metadata_load_test.go
+++ b/mysql/catalog/metadata_load_test.go
@@ -406,15 +406,23 @@ func TestLoadMetadataKeepsViewColumnListsOnlyWhereNeeded(t *testing.T) {
 			{Name: "same", Definition: "SELECT id FROM users", Columns: []*metadata.ColumnMetadata{{Name: "ID"}}},
 			{Name: "star", Definition: "SELECT * FROM users", Columns: []*metadata.ColumnMetadata{{Name: "id"}}},
 			{Name: "star_qualified", Definition: "SELECT u.* FROM users u", Columns: []*metadata.ColumnMetadata{{Name: "id"}}},
+			// Created as CREATE VIEW star_renamed (user_id) AS SELECT * FROM users.
+			{Name: "star_renamed", Definition: "SELECT * FROM users", Columns: []*metadata.ColumnMetadata{{Name: "user_id"}}},
+			// A body that does not resolve names nothing of its own.
+			{Name: "unresolved", Definition: "SELECT * FROM missing", Columns: []*metadata.ColumnMetadata{{Name: "a"}, {Name: "b"}}},
 		},
 	}))
 	requireReport(t, report, nil, nil)
-	if v := requireView(t, c, "renamed"); !v.ExplicitColumns || !slices.Equal(v.Columns, []string{"user_id"}) {
-		t.Errorf("renamed = explicit %v, columns %v; want the snapshot's user_id", v.ExplicitColumns, v.Columns)
+	for _, name := range []string{"renamed", "star_renamed"} {
+		if v := requireView(t, c, name); !v.ExplicitColumns || !slices.Equal(v.Columns, []string{"user_id"}) {
+			t.Errorf("%s = explicit %v, columns %v; want the snapshot's user_id", name, v.ExplicitColumns, v.Columns)
+		}
 	}
-	for _, name := range []string{"same", "star", "star_qualified"} {
-		if v := requireView(t, c, name); v.ExplicitColumns {
-			t.Errorf("%s = explicit columns %v, want the body's", name, v.Columns)
+	// A body naming its own columns keeps them; one that does not resolve takes
+	// the snapshot's, inferred.
+	for name, want := range map[string][]string{"same": {"id"}, "star": {"id"}, "star_qualified": {"id"}, "unresolved": {"a", "b"}} {
+		if v := requireView(t, c, name); v.ExplicitColumns || !slices.Equal(v.Columns, want) {
+			t.Errorf("%s = explicit %v, columns %v; want %v inferred", name, v.ExplicitColumns, v.Columns, want)
 		}
 	}
 }

--- a/mysql/catalog/metadata_load_test.go
+++ b/mysql/catalog/metadata_load_test.go
@@ -441,6 +441,28 @@ func TestLoadMetadataKeepsViewColumnListsOnlyWhereNeeded(t *testing.T) {
 	}
 }
 
+func TestLoadMetadataDropsViewColumnMetadataAnUnresolvedStarShifts(t *testing.T) {
+	c, report := loadMySQLSnapshot(t, snapshot(&metadata.SchemaMetadata{
+		Tables: []*metadata.TableMetadata{{Name: "users", Columns: []*metadata.ColumnMetadata{{Name: "name", Type: "varchar(8)", Nullable: true}}}},
+		Views: []*metadata.ViewMetadata{
+			{Name: "shifted", Definition: "SELECT m.*, u.name FROM missing m, users u", Columns: []*metadata.ColumnMetadata{{Name: "a"}, {Name: "b"}, {Name: "name"}}},
+			{Name: "aligned", Definition: "SELECT u.name FROM users u", Columns: []*metadata.ColumnMetadata{{Name: "label"}}},
+		},
+	}))
+	requireReport(t, report, nil, nil)
+	// A star the catalog cannot expand shifts every column after it, so what the
+	// body inferred belongs to none of the names the snapshot gives.
+	for i, col := range requireView(t, c, "shifted").ColumnMetadata {
+		if col.Collation != "" || col.Nullable {
+			t.Errorf("shifted column %d (%s) = nullable %v, collation %q; want nothing carried over", i, col.Name, col.Nullable, col.Collation)
+		}
+	}
+	// A body with a column for each of the snapshot's keeps what it inferred.
+	if col := requireView(t, c, "aligned").ColumnMetadata[0]; col.Name != "label" || !col.Nullable || col.Collation == "" {
+		t.Errorf("aligned column = %+v; want users.name's inferred nullability and collation under label", col)
+	}
+}
+
 func TestLoadMetadataInstallsTriggers(t *testing.T) {
 	account := func(triggers ...*metadata.TriggerMetadata) *metadata.TableMetadata {
 		return &metadata.TableMetadata{

--- a/mysql/catalog/metadata_load_test.go
+++ b/mysql/catalog/metadata_load_test.go
@@ -408,8 +408,10 @@ func TestLoadMetadataKeepsViewColumnListsOnlyWhereNeeded(t *testing.T) {
 			{Name: "star_qualified", Definition: "SELECT u.* FROM users u", Columns: []*metadata.ColumnMetadata{{Name: "id"}}},
 			// Created as CREATE VIEW star_renamed (user_id) AS SELECT * FROM users.
 			{Name: "star_renamed", Definition: "SELECT * FROM users", Columns: []*metadata.ColumnMetadata{{Name: "user_id"}}},
-			// A body that does not resolve names nothing of its own.
+			// A body that does not resolve names nothing of its own. A qualified
+			// star leaves one unnamed column behind rather than none.
 			{Name: "unresolved", Definition: "SELECT * FROM missing", Columns: []*metadata.ColumnMetadata{{Name: "a"}, {Name: "b"}}},
+			{Name: "unresolved_qualified", Definition: "SELECT m.* FROM missing m", Columns: []*metadata.ColumnMetadata{{Name: "a"}}},
 		},
 	}))
 	requireReport(t, report, nil, nil)
@@ -420,9 +422,21 @@ func TestLoadMetadataKeepsViewColumnListsOnlyWhereNeeded(t *testing.T) {
 	}
 	// A body naming its own columns keeps them; one that does not resolve takes
 	// the snapshot's, inferred.
-	for name, want := range map[string][]string{"same": {"id"}, "star": {"id"}, "star_qualified": {"id"}, "unresolved": {"a", "b"}} {
+	for name, want := range map[string][]string{"same": {"id"}, "star": {"id"}, "star_qualified": {"id"}, "unresolved": {"a", "b"}, "unresolved_qualified": {"a"}} {
 		if v := requireView(t, c, name); v.ExplicitColumns || !slices.Equal(v.Columns, want) {
 			t.Errorf("%s = explicit %v, columns %v; want %v inferred", name, v.ExplicitColumns, v.Columns, want)
+		}
+	}
+	// Whatever a view ends up advertising, its inferred column metadata answers
+	// to the same names.
+	for _, name := range []string{"renamed", "same", "star", "star_qualified", "star_renamed", "unresolved", "unresolved_qualified"} {
+		v := requireView(t, c, name)
+		var inferred []string
+		for _, col := range v.ColumnMetadata {
+			inferred = append(inferred, col.Name)
+		}
+		if !slices.Equal(inferred, v.Columns) {
+			t.Errorf("%s = columns %v, column metadata %v; want them named alike", name, v.Columns, inferred)
 		}
 	}
 }


### PR DESCRIPTION
Follows #416, which merged before this landed.

`LoadMetadata` decides a view's columns once `DefineView` resolves the body: the snapshot names the columns the body left unnamed, and becomes a column list where the body names as many by other names, which only a view created with one can do. So a view stored as `CREATE VIEW v (user_id) AS SELECT * FROM users` keeps `user_id`, which the guard before the install could not see, and `selectsStar` is gone.

Codex raised this on the TiDB loader in #417; this gives the MySQL loader the same shape.

## Test plan

- `go test -short ./mysql/...`
- Mutation-checked: each mutation of the loader fails a test, the new ones included — leaving the columns unnamed, overwriting the names the body gives, and dropping the column list for a renamed view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
