### PR TITLE
redshift/catalog: install functions eagerly, degrade a definition that fails

### DIFF
--- a/redshift/catalog/metadata_load.go
+++ b/redshift/catalog/metadata_load.go
@@ -17,11 +17,13 @@ import (
 // sequences of a Bytebase schema snapshot into c, as completion needs them.
 // Columns take a coarse type and a view selects NULL under its column names,
 // so no object depends on another. A materialized view installs from its
-// definition once the relations it names are in, and like a view otherwise. An
-// object that still fails to install is left out.
+// definition once the relations and functions it names are in, and like a view
+// otherwise. An object that still fails to install is left out.
 func (c *Catalog) LoadMetadata(meta *metadata.DatabaseSchemaMetadata) {
 	defer c.SetSearchPath(slices.Clone(c.searchPath))
-	c.installMetadataMatViews(c.installMetadataRelations(meta))
+	matViews := c.installMetadataRelations(meta)
+	c.installMetadataFunctions(meta)
+	c.installMetadataMatViews(matViews)
 }
 
 // metadataMatView is a materialized view waiting for what its definition names.
@@ -58,7 +60,8 @@ func (c *Catalog) installMetadataRelations(meta *metadata.DatabaseSchemaMetadata
 
 // installMetadataMatViews installs each definition, retrying the failed ones
 // while a pass installs more, since a definition may name another materialized
-// view. Once a pass installs none, the rest install like views.
+// view. Once a pass installs none, the first failure installs like a view and
+// the rest retry against it.
 func (c *Catalog) installMetadataMatViews(matViews []metadataMatView) {
 	for len(matViews) > 0 {
 		var failed []metadataMatView
@@ -69,13 +72,15 @@ func (c *Catalog) installMetadataMatViews(matViews []metadataMatView) {
 				failed = append(failed, m)
 			}
 		}
-		if len(failed) == len(matViews) {
-			for _, m := range failed {
-				c.execMetadataDDL(metadataViewDDL("MATERIALIZED VIEW", m.schema, m.mv.GetName(), nil))
-			}
-			return
+		if len(failed) < len(matViews) {
+			matViews = failed
+			continue
 		}
-		matViews = failed
+		// No definition installed this pass, so the first one installs like a
+		// view and the rest retry against it: one blocked only by that
+		// definition still installs from its own.
+		c.execMetadataDDL(metadataViewDDL("MATERIALIZED VIEW", failed[0].schema, failed[0].mv.GetName(), nil))
+		matViews = failed[1:]
 	}
 }
 
@@ -86,6 +91,12 @@ func (c *Catalog) installMetadataMatViews(matViews []metadataMatView) {
 // view's own schema, so the definition reads the same under c's search path.
 func (c *Catalog) UseMetadata(meta *metadata.DatabaseSchemaMetadata) {
 	c.SetRelationResolver(newMetadataResolver(meta))
+	c.installMetadataFunctions(meta)
+}
+
+// installMetadataFunctions installs the snapshot's functions, so a definition
+// that calls one installs too.
+func (c *Catalog) installMetadataFunctions(meta *metadata.DatabaseSchemaMetadata) {
 	for _, s := range meta.GetSchemas() {
 		if len(s.GetFunctions()) == 0 {
 			continue
@@ -251,7 +262,8 @@ func (r *metadataResolver) ResolveRelation(schemaName, relationName string, sear
 	case rel.sequence:
 		spec.Columns = []RelationColumnSpec{{Name: "last_value", Type: "bigint"}, {Name: "log_cnt", Type: "bigint"}, {Name: "is_called", Type: "boolean"}}
 	case parsed:
-		spec.Definition = definition
+		// The columns stand in where the definition does not install.
+		spec.Definition, spec.Columns = definition, metadataColumnSpecs(rel.columns)
 	default:
 		// A view whose definition is empty or does not parse resolves as a
 		// table of its columns.

--- a/redshift/catalog/metadata_load_test.go
+++ b/redshift/catalog/metadata_load_test.go
@@ -34,6 +34,8 @@ func redshiftSnapshot() *metadata.DatabaseSchemaMetadata {
 				{Name: "bare", Columns: []*metadata.ColumnMetadata{{Name: "x", Type: "integer"}}},
 				// A definition that does not parse resolves the same way.
 				{Name: "odd", Definition: "SELEC nonsense", Columns: []*metadata.ColumnMetadata{{Name: "x", Type: "integer"}}},
+				// A definition that parses but does not install falls back too.
+				{Name: "unanalyzable", Definition: "SELECT no_such_fn(id) AS x FROM orders", Columns: []*metadata.ColumnMetadata{{Name: "x", Type: "integer"}}},
 			},
 			MaterializedViews: []*metadata.MaterializedViewMetadata{
 				{Name: "totals", Definition: "SELECT count(*) AS n FROM orders"},
@@ -94,13 +96,37 @@ func TestLoadMetadataInstallsMaterializedViewsAfterWhatTheyName(t *testing.T) {
 			// a_totals names z_counts, which names a table of a later schema.
 			{Name: "a_totals", Definition: "SELECT n FROM reports.z_counts"},
 			{Name: "z_counts", Definition: "SELECT count(*) AS n FROM sales.orders"},
+			// Calls a function of a later schema.
+			{Name: "doubled", Definition: "SELECT sales.double_it(id) AS n FROM sales.orders"},
+			// needs_broken names one that can never install.
+			{Name: "broken_mv", Definition: "SELEC nonsense"},
+			{Name: "needs_broken", Definition: "SELECT count(*) AS n FROM reports.broken_mv"},
 		}},
-		{Name: "sales", Tables: []*metadata.TableMetadata{{Name: "orders", Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "bigint"}}}}},
+		{
+			Name:      "sales",
+			Tables:    []*metadata.TableMetadata{{Name: "orders", Columns: []*metadata.ColumnMetadata{{Name: "id", Type: "bigint"}}}},
+			Functions: []*metadata.FunctionMetadata{{Name: "double_it", Definition: "CREATE FUNCTION sales.double_it(bigint) RETURNS bigint STABLE AS $$ SELECT $1 * 2 $$ LANGUAGE sql;"}},
+		},
 	}})
-	for _, name := range []string{"a_totals", "z_counts"} {
+	for _, name := range []string{"a_totals", "z_counts", "doubled", "needs_broken"} {
 		if mv := c.GetRelation("reports", name); mv == nil || len(mv.Columns) != 1 || mv.Columns[0].Name != "n" {
 			t.Errorf("%s did not install from its definition", name)
 		}
+	}
+	if mv := c.GetRelation("reports", "broken_mv"); mv == nil || len(mv.Columns) != 1 || mv.Columns[0].Name != metadataPlaceholderColumn {
+		t.Errorf("broken_mv = %+v, want the stand-in", mv)
+	}
+}
+
+func TestUseMetadataDegradesAViewThatDoesNotInstall(t *testing.T) {
+	c := New()
+	c.SetSearchPath([]string{"sales", "public"})
+	c.UseMetadata(redshiftSnapshot())
+	if _, err := c.Exec("CREATE VIEW public.u AS SELECT x FROM unanalyzable;", nil); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if c.GetRelation("public", "u") == nil {
+		t.Error("a view whose definition does not install did not fall back to its columns")
 	}
 }
 

--- a/redshift/catalog/relation_resolver.go
+++ b/redshift/catalog/relation_resolver.go
@@ -124,22 +124,32 @@ func (c *Catalog) materializeRelationSpec(spec *RelationSpec) error {
 		return c.materializeResolvedTable(spec)
 	case RelationKindView:
 		stmt, err := parseRelationDefinitionView(spec)
-		if err != nil {
-			return err
+		if err == nil {
+			err = c.DefineView(stmt)
 		}
-		return c.DefineView(stmt)
+		return c.orResolvedTable(spec, err)
 	case RelationKindMaterializedView:
 		stmt, err := parseRelationDefinitionMaterializedView(spec)
-		if err != nil {
-			return err
+		if err == nil {
+			err = c.ExecCreateTableAs(stmt)
 		}
-		return c.ExecCreateTableAs(stmt)
+		return c.orResolvedTable(spec, err)
 	default:
 		return &Error{
 			Code:    CodeFeatureNotSupported,
 			Message: fmt.Sprintf("relation resolver returned unsupported relation kind %q", spec.Kind),
 		}
 	}
+}
+
+// orResolvedTable falls back to a table of the spec's columns where a view's
+// definition does not install: it may name what the catalog does not have, and
+// a relation of the right columns still resolves the statement.
+func (c *Catalog) orResolvedTable(spec *RelationSpec, err error) error {
+	if err == nil || len(spec.Columns) == 0 {
+		return err
+	}
+	return c.materializeResolvedTable(spec)
 }
 
 func (c *Catalog) ensureResolverSchema(schemaName string) error {


### PR DESCRIPTION
Follows #418, which merged before this landed. Codex reviewed the merged commit and raised three points; this fixes all three.

- `LoadMetadata` installs the snapshot's functions after the relations and before the materialized views, through the same helper `UseMetadata` uses. A materialized view calling a snapshot function now installs from its definition instead of falling back to the one-column stand-in.
- A pass that installs no definition stands in for the first failure and retries the rest, so a definition blocked only by that one still installs and keeps its columns. Each such pass takes one definition out, so the retrying ends.
- A view whose definition does not install falls back to a table of the columns the snapshot records. That covers a definition the catalog cannot analyze, such as one calling a function `UseMetadata` skipped, not only one that does not parse.

## Test plan

- `go test -short ./redshift/...`
- Mutation-checked: each mutation of the loader and the catalog's resolver hooks fails a test, the four new ones included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
