### PR TITLE
catalog: load snapshots introspected from a live engine

### DIFF
--- a/mysql/catalog/container_metadata_load_test.go
+++ b/mysql/catalog/container_metadata_load_test.go
@@ -1,0 +1,223 @@
+package catalog
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/metadata"
+)
+
+// TestContainer_LoadMetadataIndexTypesMatchEngine loads a snapshot introspected
+// from real tables and checks every index against the type MySQL itself
+// resolved. Sync records INDEX_TYPE verbatim; the catalog then stores the
+// engine's default blank so SHOW CREATE TABLE renders no redundant USING, and
+// defaultIndexType fills it back in. Only a live engine can say whether it
+// fills in the right one — HASH on MEMORY, BTREE elsewhere — and whether a key
+// declared USING BTREE on a MEMORY table survives that round trip.
+func TestContainer_LoadMetadataIndexTypesMatchEngine(t *testing.T) {
+	ctr, cleanup := startContainer(t)
+	defer cleanup()
+
+	ddl := []string{
+		`CREATE TABLE idx_innodb (
+			id INT NOT NULL AUTO_INCREMENT,
+			email VARCHAR(255) NOT NULL,
+			body TEXT,
+			PRIMARY KEY (id),
+			UNIQUE KEY uq_email (email),
+			KEY k_email_prefix (email(32)),
+			FULLTEXT KEY ft_body (body)
+		) ENGINE=InnoDB`,
+		`CREATE TABLE idx_memory (
+			id INT NOT NULL,
+			label VARCHAR(64) NOT NULL,
+			PRIMARY KEY (id),
+			KEY k_label (label),
+			KEY k_label_btree (label) USING BTREE
+		) ENGINE=MEMORY`,
+	}
+	for _, stmt := range ddl {
+		if err := ctr.execSQL(stmt); err != nil {
+			t.Fatalf("container exec: %v", err)
+		}
+	}
+
+	meta := mysqlLiveSnapshot(t, ctr, "test")
+	c := New()
+	report, err := c.LoadMetadata(context.Background(), meta)
+	if err != nil {
+		t.Fatalf("LoadMetadata: %v", err)
+	}
+	if len(report.Degraded) != 0 || len(report.Missing) != 0 {
+		t.Fatalf("a snapshot taken from live tables must install whole; degraded=%v missing=%v", report.Degraded, report.Missing)
+	}
+
+	db := c.GetDatabase("test")
+	if db == nil {
+		t.Fatal("database test did not install")
+	}
+	for _, want := range mysqlLiveIndexTypes(t, ctr, "test") {
+		tbl := db.Tables[strings.ToLower(want.table)]
+		if tbl == nil {
+			t.Errorf("table %s did not install", want.table)
+			continue
+		}
+		found := false
+		for _, idx := range tbl.Indexes {
+			if !strings.EqualFold(idx.Name, want.index) {
+				continue
+			}
+			found = true
+			// An index whose type is the engine's default is stored blank, so
+			// that SHOW CREATE TABLE does not render a redundant USING. Resolve
+			// it the way a consumer must before comparing with the engine.
+			got := idx.IndexType
+			if got == "" {
+				got = defaultIndexType(tbl.Engine)
+			}
+			if !strings.EqualFold(got, want.indexType) {
+				t.Errorf("%s.%s index type = %q, want the engine's %q", want.table, want.index, got, want.indexType)
+			}
+		}
+		if !found {
+			t.Errorf("%s.%s did not install", want.table, want.index)
+		}
+	}
+}
+
+type liveIndexType struct {
+	table     string
+	index     string
+	indexType string
+}
+
+// mysqlLiveIndexTypes reports the index type MySQL resolved for every index,
+// which is what the loaded catalog has to agree with.
+func mysqlLiveIndexTypes(t *testing.T, ctr *mysqlContainer, database string) []liveIndexType {
+	t.Helper()
+	rows, err := ctr.db.QueryContext(ctr.ctx, `
+		SELECT TABLE_NAME, INDEX_NAME, INDEX_TYPE
+		FROM information_schema.STATISTICS
+		WHERE TABLE_SCHEMA = ? AND SEQ_IN_INDEX = 1
+		ORDER BY TABLE_NAME, INDEX_NAME`, database)
+	if err != nil {
+		t.Fatalf("introspect index types: %v", err)
+	}
+	defer rows.Close()
+	var out []liveIndexType
+	for rows.Next() {
+		var r liveIndexType
+		if err := rows.Scan(&r.table, &r.index, &r.indexType); err != nil {
+			t.Fatalf("scan index type: %v", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("introspect index types: %v", err)
+	}
+	return out
+}
+
+// mysqlLiveSnapshot introspects one database the way sync does: COLUMN_TYPE for
+// the column's full declared type, and INDEX_TYPE verbatim for every index.
+func mysqlLiveSnapshot(t *testing.T, ctr *mysqlContainer, database string) *metadata.DatabaseSchemaMetadata {
+	t.Helper()
+	sm := &metadata.SchemaMetadata{}
+	tables := map[string]*metadata.TableMetadata{}
+
+	rows, err := ctr.db.QueryContext(ctr.ctx, `
+		SELECT t.TABLE_NAME, t.ENGINE, t.TABLE_COLLATION,
+		       c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT,
+		       c.EXTRA, c.ORDINAL_POSITION, c.CHARACTER_SET_NAME, c.COLLATION_NAME
+		FROM information_schema.TABLES t
+		JOIN information_schema.COLUMNS c
+			ON c.TABLE_SCHEMA = t.TABLE_SCHEMA AND c.TABLE_NAME = t.TABLE_NAME
+		WHERE t.TABLE_SCHEMA = ? AND t.TABLE_TYPE = 'BASE TABLE'
+		ORDER BY t.TABLE_NAME, c.ORDINAL_POSITION`, database)
+	if err != nil {
+		t.Fatalf("introspect columns: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var table, columnName, columnType, nullable, extra string
+		var engine, tableCollation, def, charset, collation sql.NullString
+		var position int32
+		if err := rows.Scan(&table, &engine, &tableCollation, &columnName, &columnType,
+			&nullable, &def, &extra, &position, &charset, &collation); err != nil {
+			t.Fatalf("scan column: %v", err)
+		}
+		tbl, ok := tables[table]
+		if !ok {
+			tbl = &metadata.TableMetadata{Name: table, Engine: engine.String, Collation: tableCollation.String}
+			tables[table] = tbl
+			sm.Tables = append(sm.Tables, tbl)
+		}
+		col := &metadata.ColumnMetadata{
+			Name: columnName, Type: columnType, Nullable: nullable == "YES", Position: position,
+			CharacterSet: charset.String, Collation: collation.String,
+		}
+		switch {
+		case strings.Contains(strings.ToLower(extra), "auto_increment"):
+			col.Default = "AUTO_INCREMENT"
+		case def.Valid:
+			col.Default = def.String
+		}
+		tbl.Columns = append(tbl.Columns, col)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("introspect columns: %v", err)
+	}
+
+	for _, tbl := range sm.Tables {
+		tbl.Indexes = mysqlLiveIndexes(t, ctr, database, tbl.GetName())
+	}
+	return &metadata.DatabaseSchemaMetadata{Name: database, Schemas: []*metadata.SchemaMetadata{sm}}
+}
+
+func mysqlLiveIndexes(t *testing.T, ctr *mysqlContainer, database, table string) []*metadata.IndexMetadata {
+	t.Helper()
+	rows, err := ctr.db.QueryContext(ctr.ctx, `
+		SELECT INDEX_NAME, NON_UNIQUE, INDEX_TYPE, COLUMN_NAME, SUB_PART, SEQ_IN_INDEX
+		FROM information_schema.STATISTICS
+		WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
+		ORDER BY INDEX_NAME, SEQ_IN_INDEX`, database, table)
+	if err != nil {
+		t.Fatalf("introspect indexes: %v", err)
+	}
+	defer rows.Close()
+	byName := map[string]*metadata.IndexMetadata{}
+	var out []*metadata.IndexMetadata
+	for rows.Next() {
+		var name, indexType, column string
+		var nonUnique, seq int
+		var subPart sql.NullInt64
+		if err := rows.Scan(&name, &nonUnique, &indexType, &column, &subPart, &seq); err != nil {
+			t.Fatalf("scan index: %v", err)
+		}
+		idx, ok := byName[name]
+		if !ok {
+			idx = &metadata.IndexMetadata{
+				Name:    name,
+				Unique:  nonUnique == 0,
+				Primary: name == "PRIMARY",
+				Visible: true,
+			}
+			idx.Type = indexType
+			byName[name] = idx
+			out = append(out, idx)
+		}
+		expr := column
+		if subPart.Valid {
+			idx.KeyLength = append(idx.KeyLength, subPart.Int64)
+		} else {
+			idx.KeyLength = append(idx.KeyLength, -1)
+		}
+		idx.Expressions = append(idx.Expressions, expr)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("introspect indexes: %v", err)
+	}
+	return out
+}

--- a/pg/catalog/container_metadata_load_test.go
+++ b/pg/catalog/container_metadata_load_test.go
@@ -1,0 +1,291 @@
+package catalog
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/metadata"
+	pg "github.com/bytebase/omni/pg"
+	nodes "github.com/bytebase/omni/pg/ast"
+)
+
+// liveSchemaDDL exercises the shapes a real snapshot carries that a
+// hand-written fixture rarely does: a length-qualified varchar, a scaled
+// numeric, an array, a jsonb default that is a cast, an enum type used as a
+// column type, a nextval default naming a sequence, an identity column, a
+// stored generated column, and a view over it all.
+const liveSchemaDDL = `
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
+CREATE SEQUENCE ticket_seq INCREMENT 5 START 100;
+CREATE TABLE authors (
+	id        bigserial PRIMARY KEY,
+	handle    varchar(50) NOT NULL UNIQUE,
+	bio       text,
+	joined    timestamptz NOT NULL DEFAULT now(),
+	karma     numeric(10,2) NOT NULL DEFAULT 0.0,
+	tags      text[],
+	prefs     jsonb NOT NULL DEFAULT '{}'::jsonb,
+	ext       uuid,
+	state     mood NOT NULL DEFAULT 'ok',
+	ticket    bigint NOT NULL DEFAULT nextval('ticket_seq'),
+	is_active boolean NOT NULL DEFAULT true
+);
+CREATE TABLE posts (
+	id        int GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+	author_id bigint NOT NULL REFERENCES authors(id),
+	title     varchar(200) NOT NULL,
+	body      text,
+	words     int GENERATED ALWAYS AS (length(body)) STORED,
+	created   date NOT NULL DEFAULT CURRENT_DATE
+);
+CREATE INDEX posts_author_idx ON posts (author_id);
+CREATE VIEW active_authors AS SELECT id, handle, karma FROM authors WHERE is_active;
+`
+
+// TestContainerLoadMetadataFromLiveSchema loads a snapshot introspected from a
+// real PostgreSQL schema. Every other LoadMetadata test writes its own
+// snapshot, which only ever contains what the author expected the engine to
+// emit; this one makes the loader answer to what PostgreSQL actually reports —
+// its type vocabulary, its default expressions, its identity and generation
+// markers.
+func TestContainerLoadMetadataFromLiveSchema(t *testing.T) {
+	ctr := startPGContainer(t)
+	schema := ctr.freshSchema(t)
+	ctr.execInSchema(t, schema, liveSchemaDDL)
+
+	meta := liveSnapshot(t, ctr, schema)
+
+	c := New()
+	report, err := c.LoadMetadata(context.Background(), meta, LoadMetadataOptions{Full: true})
+	if err != nil {
+		t.Fatalf("LoadMetadata: %v", err)
+	}
+	if len(report.Degraded) != 0 || len(report.Missing) != 0 {
+		t.Fatalf("a snapshot taken from a live schema must install whole; degraded=%v missing=%v", report.Degraded, report.Missing)
+	}
+
+	// The engine's own type spelling must survive the round trip: whatever
+	// format_type reported going in, FormatType reports coming out. A type the
+	// loader cannot parse would otherwise install as a text stand-in and only
+	// surface later as wrong lineage.
+	for _, want := range meta.GetSchemas()[0].GetTables() {
+		rel := c.GetRelation(schema, want.GetName())
+		if rel == nil {
+			t.Errorf("table %s did not install", want.GetName())
+			continue
+		}
+		for _, wantCol := range want.GetColumns() {
+			col := relationColumn(rel, wantCol.GetName())
+			if col == nil {
+				t.Errorf("%s.%s did not install", want.GetName(), wantCol.GetName())
+				continue
+			}
+			if got := c.FormatType(col.TypeOID, col.TypeMod); got != wantCol.GetType() {
+				t.Errorf("%s.%s type = %q, want the engine's %q", want.GetName(), wantCol.GetName(), got, wantCol.GetType())
+			}
+			if col.NotNull == wantCol.GetNullable() {
+				t.Errorf("%s.%s nullable = %v, want %v", want.GetName(), wantCol.GetName(), !col.NotNull, wantCol.GetNullable())
+			}
+		}
+	}
+
+	// The loaded catalog must answer a real query, including through the view
+	// and across the foreign key.
+	stmts, err := pg.Parse(`
+		SELECT a.handle, a.karma, p.title, p.words
+		FROM posts p JOIN active_authors a ON a.id = p.author_id`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	stmt, ok := stmts[0].AST.(*nodes.SelectStmt)
+	if !ok {
+		t.Fatalf("expected a SelectStmt, got %T", stmts[0].AST)
+	}
+	c.SetSearchPath([]string{schema})
+	query, err := c.AnalyzeSelectStmt(stmt)
+	if err != nil {
+		t.Fatalf("analyzing a query against the loaded catalog: %v", err)
+	}
+	var names []string
+	for _, target := range query.TargetList {
+		names = append(names, target.ResName)
+	}
+	if strings.Join(names, ",") != "handle,karma,title,words" {
+		t.Errorf("query resolved to %v, want handle, karma, title, words", names)
+	}
+}
+
+func relationColumn(rel *Relation, name string) *Column {
+	for _, col := range rel.Columns {
+		if col.Name == name {
+			return col
+		}
+	}
+	return nil
+}
+
+// liveSnapshot introspects one schema into a Bytebase-shaped snapshot. It asks
+// for column types with format_type, as sync does, so the snapshot carries the
+// engine's own spelling ("character varying(50)") rather than the unqualified
+// name information_schema reports.
+func liveSnapshot(t *testing.T, ctr *pgContainer, schema string) *metadata.DatabaseSchemaMetadata {
+	t.Helper()
+	// Sync empties the search path for the duration of the read so that every
+	// type and default expression comes back schema-qualified. The loader
+	// relies on that: an unqualified name in a default has no schema to
+	// resolve against once the snapshot leaves the connection that produced it.
+	txn, err := ctr.db.BeginTx(ctr.ctx, nil)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer txn.Rollback()
+	if _, err := txn.ExecContext(ctr.ctx, `SELECT pg_catalog.set_config('search_path', '', true)`); err != nil {
+		t.Fatalf("clear the search path: %v", err)
+	}
+
+	sm := &metadata.SchemaMetadata{Name: schema}
+
+	tables := map[string]*metadata.TableMetadata{}
+	rows, err := txn.QueryContext(ctr.ctx, `
+		SELECT c.relname, a.attname,
+		       pg_catalog.format_type(a.atttypid, a.atttypmod), a.attnotnull, pg_get_expr(d.adbin, d.adrelid), a.attnum,
+		       a.attidentity::text, a.attgenerated::text
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		JOIN pg_attribute a ON a.attrelid = c.oid
+		LEFT JOIN pg_attrdef d ON d.adrelid = c.oid AND d.adnum = a.attnum
+		WHERE n.nspname = $1 AND c.relkind = 'r' AND a.attnum > 0 AND NOT a.attisdropped
+		ORDER BY c.relname, a.attnum`, schema)
+	if err != nil {
+		t.Fatalf("introspect columns: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var table, name, typ, identity, generated string
+		var notNull bool
+		var def sql.NullString
+		var attnum int32
+		if err := rows.Scan(&table, &name, &typ, &notNull, &def, &attnum, &identity, &generated); err != nil {
+			t.Fatalf("scan column: %v", err)
+		}
+		tbl, ok := tables[table]
+		if !ok {
+			tbl = &metadata.TableMetadata{Name: table}
+			tables[table] = tbl
+			sm.Tables = append(sm.Tables, tbl)
+		}
+		col := &metadata.ColumnMetadata{Name: name, Type: typ, Nullable: !notNull, Position: attnum}
+		switch {
+		case identity == "a":
+			col.IsIdentity, col.IdentityGeneration = true, metadata.ColumnMetadata_ALWAYS
+		case identity == "d":
+			col.IsIdentity, col.IdentityGeneration = true, metadata.ColumnMetadata_BY_DEFAULT
+		case generated == "s" && def.Valid:
+			col.Generation = &metadata.GenerationMetadata{Type: metadata.GenerationMetadata_TYPE_STORED, Expression: def.String}
+		case def.Valid:
+			col.Default = def.String
+		}
+		tbl.Columns = append(tbl.Columns, col)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("introspect columns: %v", err)
+	}
+
+	for _, tbl := range sm.Tables {
+		tbl.Indexes = liveIndexes(t, ctr, txn, schema, tbl.GetName())
+	}
+	for _, e := range ctr.queryEnumTypes(t, schema) {
+		sm.EnumTypes = append(sm.EnumTypes, &metadata.EnumTypeMetadata{Name: e.name, Values: strings.Split(e.values, ",")})
+	}
+	sm.Sequences = liveSequences(t, ctr, txn, schema)
+	for _, v := range ctr.queryViews(t, schema) {
+		sm.Views = append(sm.Views, &metadata.ViewMetadata{Name: v.name, Definition: v.definition})
+	}
+	return &metadata.DatabaseSchemaMetadata{Name: "omni_test", Schemas: []*metadata.SchemaMetadata{sm}}
+}
+
+func liveIndexes(t *testing.T, ctr *pgContainer, txn *sql.Tx, schema, table string) []*metadata.IndexMetadata {
+	t.Helper()
+	rows, err := txn.QueryContext(ctr.ctx, `
+		SELECT i.relname, ix.indisunique, ix.indisprimary,
+		       array_to_string(array_agg(a.attname ORDER BY k.ord), ',')
+		FROM pg_class t
+		JOIN pg_namespace n ON n.oid = t.relnamespace
+		JOIN pg_index ix ON ix.indrelid = t.oid
+		JOIN pg_class i ON i.oid = ix.indexrelid
+		JOIN LATERAL unnest(ix.indkey) WITH ORDINALITY AS k(attnum, ord) ON true
+		JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
+		WHERE n.nspname = $1 AND t.relname = $2
+		GROUP BY i.relname, ix.indisunique, ix.indisprimary
+		ORDER BY i.relname`, schema, table)
+	if err != nil {
+		t.Fatalf("introspect indexes: %v", err)
+	}
+	defer rows.Close()
+	var out []*metadata.IndexMetadata
+	for rows.Next() {
+		var name, columns string
+		var unique, primary bool
+		if err := rows.Scan(&name, &unique, &primary, &columns); err != nil {
+			t.Fatalf("scan index: %v", err)
+		}
+		out = append(out, &metadata.IndexMetadata{
+			Name: name, Unique: unique, Primary: primary, Type: "btree",
+			Expressions: strings.Split(columns, ","),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("introspect indexes: %v", err)
+	}
+	return out
+}
+
+// liveSequences introspects sequences with their ownership. Sync records the
+// owning table and column, and the loader needs them: a sequence that backs a
+// serial or identity column is installed with that column, not on its own.
+func liveSequences(t *testing.T, ctr *pgContainer, txn *sql.Tx, schema string) []*metadata.SequenceMetadata {
+	t.Helper()
+	rows, err := txn.QueryContext(ctr.ctx, `
+		SELECT s.relname, pg_catalog.format_type(sq.seqtypid, NULL),
+		       sq.seqstart, sq.seqmin, sq.seqmax, sq.seqincrement, sq.seqcycle,
+		       COALESCE(dc.relname, ''), COALESCE(da.attname, '')
+		FROM pg_class s
+		JOIN pg_namespace sn ON sn.oid = s.relnamespace
+		JOIN pg_sequence sq ON sq.seqrelid = s.oid
+		LEFT JOIN pg_depend dep ON dep.objid = s.oid
+			AND dep.classid = 'pg_class'::regclass AND dep.deptype IN ('a', 'i')
+		LEFT JOIN pg_class dc ON dc.oid = dep.refobjid
+		LEFT JOIN pg_attribute da ON da.attrelid = dc.oid AND da.attnum = dep.refobjsubid
+		WHERE sn.nspname = $1 AND s.relkind = 'S'
+		ORDER BY s.relname`, schema)
+	if err != nil {
+		t.Fatalf("introspect sequences: %v", err)
+	}
+	defer rows.Close()
+	var out []*metadata.SequenceMetadata
+	for rows.Next() {
+		var name, dataType, ownerTable, ownerColumn string
+		var start, minValue, maxValue, increment int64
+		var cycle bool
+		if err := rows.Scan(&name, &dataType, &start, &minValue, &maxValue, &increment, &cycle, &ownerTable, &ownerColumn); err != nil {
+			t.Fatalf("scan sequence: %v", err)
+		}
+		out = append(out, &metadata.SequenceMetadata{
+			Name: name, DataType: dataType,
+			Start:       fmt.Sprintf("%d", start),
+			MinValue:    fmt.Sprintf("%d", minValue),
+			MaxValue:    fmt.Sprintf("%d", maxValue),
+			Increment:   fmt.Sprintf("%d", increment),
+			Cycle:       cycle,
+			OwnerTable:  ownerTable,
+			OwnerColumn: ownerColumn,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("introspect sequences: %v", err)
+	}
+	return out
+}

--- a/scripts/test-mysql.sh
+++ b/scripts/test-mysql.sh
@@ -25,7 +25,7 @@ declare -a SHARD_NAMES=(
 shard_regex() {
     case "$1" in
         smoke-and-misc)
-            printf '%s\n' '^(TestDDLWorkflow_Container|TestShowCreateTable_ContainerComparison|TestContainerSmoke|TestContainer_ReservedKeywordAcceptance|TestSpotCheck_CatalogVerification|TestMySQL_DeparseRules)$'
+            printf '%s\n' '^(TestDDLWorkflow_Container|TestShowCreateTable_ContainerComparison|TestContainerSmoke|TestContainer_ReservedKeywordAcceptance|TestSpotCheck_CatalogVerification|TestMySQL_DeparseRules|TestContainer_LoadMetadataIndexTypesMatchEngine)$'
             ;;
         section-1-core)
             printf '%s\n' '^TestContainer_Section_1_([1-9]|10|11|12)_'


### PR DESCRIPTION
Every `LoadMetadata` test so far writes its own snapshot, so the loader only ever meets the shapes the test author expected the engine to emit. These two introspect a real schema and load that.

## The tests

- **`pg/catalog`** — builds the snapshot by reading a live schema the way sync does, with the search path emptied for the read so types and default expressions come back schema-qualified. It then checks that the engine's own type spelling survives the round trip (`character varying(50)`, `numeric(10,2)`, `test_1.mood`) and that the loaded catalog analyzes a query across a view and a foreign key.
- **`mysql/catalog`** — checks every index against the type MySQL resolved, on an InnoDB and a MEMORY table. The case worth having: a key declared `USING BTREE` on a MEMORY table, where the stored type is blank and `defaultIndexType` must not overwrite it with `HASH`.

## What writing them turned up

Both failed at first, each time because the snapshot I built was not the one sync produces. That is the finding: the loader depends on parts of the snapshot contract that nothing states, and violating them degrades objects silently rather than failing.

- An **unqualified user type in a default expression** (`'ok'::mood`) leaves the table standing in — `userTypeRef` needs `schema.name` to order the enum first, and the catalog has no search path to resolve the bare name against. Sync avoids it by setting `search_path = ''` for the column read, and by storing user-defined column types as `udtSchema.udtName`.
- A **sequence without `OwnerTable`/`OwnerColumn`** collides with the identity column that already created it (`sequence "posts_id_seq" already exists`). The loader installs an owned sequence with its column; it can only tell which are owned from those fields.
- MySQL records `INDEX_TYPE` **verbatim for every index**. Recording it only for the non-default kinds is what made `USING BTREE` on a MEMORY table come back as `HASH`.

Each of these is a real constraint on any producer of a snapshot, and none was covered before.

## Testing

Neither test skips on `-short`, so the container jobs and the fast jobs both run them. The MySQL one is wired into the `smoke-and-misc` shard. Both pass against real PostgreSQL 16 and MySQL containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)